### PR TITLE
Add runtime validation for missing credentials

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ All commands must be run from `playwright/typescript/`.
   - Re-exports `pixelmatch` and `PNG` (used for pixel-diff screenshot comparison)
 - `utils/accessibility.util.ts` — `expectNoAccessibilityViolations()` using `@axe-core/playwright` (WCAG2AAA)
 - `utils/string.util.ts` — `expectHeadings()` helper: asserts visibility of multiple headings on a page
+- `utils/env.util.ts` — `loadEnv(importMetaUrl, levelsUp)` loads `.env` relative to the calling file; `requireCredentials()` validates and returns `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD`, throwing a descriptive error if either is missing
 - `types/` — Reserved for shared TypeScript interfaces (currently empty)
 - `test-data/` — Reserved for static test data (currently empty)
 
@@ -85,6 +86,36 @@ All commands must be run from `playwright/typescript/`.
 - Commented-out staging `baseURL` (`http://stage.orwellstat.hubertgajewski.com`) can be enabled for staging
 
 **CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uploads `playwright/typescript/playwright-report/` as an artifact (retained 30 days).
+
+---
+
+## Code review checklist
+
+Before committing changes to `playwright/typescript`, review against these criteria:
+
+- **Playwright test correctness** — selectors use `getByRole()` / `getByText()` with `exact: true`; no CSS class selectors; no `waitForTimeout()`; count asserted before `.nth()`; no `.first()` silencing missing elements
+- **Page Object Model conventions** — page classes extend `AbstractPage`; `heading` getter uses `getByRole('heading', { name: ..., exact: true })`; static `url`, `title`, `accessKey` defined
+- **TypeScript quality** — no `!` non-null assertions on env vars; `page.evaluate()` calls have explicit generic type; no implicit `any`; `tsc --noEmit` passes
+- **Flakiness** — no fixed timeouts; animation waits use `requestAnimationFrame`; auth setup asserts login actually succeeded
+- **Consistency** — new utils documented in `CLAUDE.md`; new page files exported via the appropriate `index.ts`; path aliases used (`@fixtures/*`, `@pages/*`, `@utils/*`)
+
+---
+
+## GitHub issue format
+
+When creating GitHub issues for requirements, bugs, or code review findings, use this structure:
+
+**Title:** `[label] Short imperative description`
+
+**Body sections (in order):**
+
+1. **User Story** — "As a tester, I want ... so that ..."
+2. **Context** — explanation of the current problem with exact file references
+3. **Acceptance Criteria** — Given/When/Then scenarios covering the happy path and the failure case
+4. **Implementation Hint** — concrete code snippet showing the fix
+5. **Definition of Done** — checklist of observable, verifiable outcomes
+
+**Labels:** apply semantic labels such as `test-quality`, `flakiness`, `type-safety`, `pom`.
 
 ---
 

--- a/playwright/typescript/auth.setup.ts
+++ b/playwright/typescript/auth.setup.ts
@@ -1,22 +1,15 @@
 import { test as setup } from '@playwright/test';
-import dotenv from 'dotenv';
+import { loadEnv, requireCredentials } from '@utils/env.util';
 
-dotenv.config({ path: new URL('../../.env', import.meta.url).pathname });
-
-const { ORWELLSTAT_USER, ORWELLSTAT_PASSWORD } = process.env;
-if (!ORWELLSTAT_USER || !ORWELLSTAT_PASSWORD) {
-  throw new Error(
-    'Missing ORWELLSTAT_USER or ORWELLSTAT_PASSWORD. ' +
-      'Set them in .env (local) or as repository secrets (CI).'
-  );
-}
+loadEnv(import.meta.url, 2);
+const { user, password } = requireCredentials();
 
 setup('authenticate', async ({ page }) => {
   await page.goto('/');
-  await page.locator('[name="username"]').fill(ORWELLSTAT_USER);
+  await page.locator('[name="username"]').fill(user);
   await page
     .locator('[name="password"]')
-    .fill(ORWELLSTAT_PASSWORD);
+    .fill(password);
   await page.locator('form[action="/zone/"]').getByRole('button').click();
   await page.waitForURL('**/zone/');
   await page.context().storageState({ path: new URL('.auth/user.json', import.meta.url).pathname });

--- a/playwright/typescript/auth.setup.ts
+++ b/playwright/typescript/auth.setup.ts
@@ -3,12 +3,20 @@ import dotenv from 'dotenv';
 
 dotenv.config({ path: new URL('../../.env', import.meta.url).pathname });
 
+const { ORWELLSTAT_USER, ORWELLSTAT_PASSWORD } = process.env;
+if (!ORWELLSTAT_USER || !ORWELLSTAT_PASSWORD) {
+  throw new Error(
+    'Missing ORWELLSTAT_USER or ORWELLSTAT_PASSWORD. ' +
+      'Set them in .env (local) or as repository secrets (CI).'
+  );
+}
+
 setup('authenticate', async ({ page }) => {
   await page.goto('/');
-  await page.locator('[name="username"]').fill(process.env.ORWELLSTAT_USER!);
+  await page.locator('[name="username"]').fill(ORWELLSTAT_USER);
   await page
     .locator('[name="password"]')
-    .fill(process.env.ORWELLSTAT_PASSWORD!);
+    .fill(ORWELLSTAT_PASSWORD);
   await page.locator('form[action="/zone/"]').getByRole('button').click();
   await page.waitForURL('**/zone/');
   await page.context().storageState({ path: new URL('.auth/user.json', import.meta.url).pathname });

--- a/playwright/typescript/fixtures/base.fixture.ts
+++ b/playwright/typescript/fixtures/base.fixture.ts
@@ -41,10 +41,17 @@ export const test = base.extend<OrwellStatFixtures>({
   },
 
   authenticatedRequest: async ({ request }, use) => {
+    const { ORWELLSTAT_USER, ORWELLSTAT_PASSWORD } = process.env;
+    if (!ORWELLSTAT_USER || !ORWELLSTAT_PASSWORD) {
+      throw new Error(
+        'Missing ORWELLSTAT_USER or ORWELLSTAT_PASSWORD. ' +
+          'Set them in .env (local) or as repository secrets (CI).'
+      );
+    }
     const response = await request.post('/zone/', {
       form: {
-        username: process.env.ORWELLSTAT_USER!,
-        password: process.env.ORWELLSTAT_PASSWORD!,
+        username: ORWELLSTAT_USER,
+        password: ORWELLSTAT_PASSWORD,
       },
     });
     expect(response.ok()).toBeTruthy();

--- a/playwright/typescript/fixtures/base.fixture.ts
+++ b/playwright/typescript/fixtures/base.fixture.ts
@@ -1,6 +1,8 @@
 import { test as base, expect, type APIRequestContext } from '@playwright/test';
-
 import { writeFileSync } from 'fs';
+import { loadEnv, requireCredentials } from '@utils/env.util';
+
+loadEnv(import.meta.url, 3);
 
 type OrwellStatFixtures = {
   authenticatedRequest: APIRequestContext;
@@ -41,17 +43,11 @@ export const test = base.extend<OrwellStatFixtures>({
   },
 
   authenticatedRequest: async ({ request }, use) => {
-    const { ORWELLSTAT_USER, ORWELLSTAT_PASSWORD } = process.env;
-    if (!ORWELLSTAT_USER || !ORWELLSTAT_PASSWORD) {
-      throw new Error(
-        'Missing ORWELLSTAT_USER or ORWELLSTAT_PASSWORD. ' +
-          'Set them in .env (local) or as repository secrets (CI).'
-      );
-    }
+    const { user, password } = requireCredentials();
     const response = await request.post('/zone/', {
       form: {
-        username: ORWELLSTAT_USER,
-        password: ORWELLSTAT_PASSWORD,
+        username: user,
+        password: password,
       },
     });
     expect(response.ok()).toBeTruthy();

--- a/playwright/typescript/utils/env.util.ts
+++ b/playwright/typescript/utils/env.util.ts
@@ -1,0 +1,20 @@
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { resolve, dirname } from 'path';
+
+export function loadEnv(importMetaUrl: string, levelsUp: number): void {
+  const dir = dirname(fileURLToPath(importMetaUrl));
+  const parts = Array(levelsUp).fill('..');
+  dotenv.config({ path: resolve(dir, ...parts, '.env') });
+}
+
+export function requireCredentials(): { user: string; password: string } {
+  const { ORWELLSTAT_USER, ORWELLSTAT_PASSWORD } = process.env;
+  if (!ORWELLSTAT_USER || !ORWELLSTAT_PASSWORD) {
+    throw new Error(
+      'Missing ORWELLSTAT_USER or ORWELLSTAT_PASSWORD. ' +
+        'Set them in .env (local) or as repository secrets (CI).'
+    );
+  }
+  return { user: ORWELLSTAT_USER, password: ORWELLSTAT_PASSWORD };
+}


### PR DESCRIPTION
## Summary

- Replaces `!` non-null assertions on `process.env` credentials with explicit guards in `auth.setup.ts` and `base.fixture.ts`
- Throws a descriptive error mentioning both `.env` (local) and repository secrets (CI) when `ORWELLSTAT_USER` or `ORWELLSTAT_PASSWORD` are absent

Closes #15

## Test plan

- [x] Running with missing `.env` locally produces the descriptive error before any browser launches
- [x] CI run with secrets configured passes normally
- [x] `tsc --noEmit` exits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)