### PR TITLE
Fix PreviouslyAddedPage heading selector

### DIFF
--- a/playwright/typescript/pages/public/previously-added.page.ts
+++ b/playwright/typescript/pages/public/previously-added.page.ts
@@ -26,8 +26,6 @@ export class PreviouslyAddedPage extends AbstractPage {
   }
 
   get heading() {
-    return this.page.getByText(
-      'Poprzednio dodane przeglądarki i inne aplikacje WWW:'
-    );
+    return this.page.getByText(PreviouslyAddedPage.previousBrowsersSection);
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `getByText('Poprzednio dodane przeglądarki i inne aplikacje WWW:')` in `PreviouslyAddedPage.heading` with `getByText(PreviouslyAddedPage.previousBrowsersSection)`, reusing the existing static constant and dropping the trailing colon
- `getByRole('heading')` was attempted first but the text is not in a heading element — it is plain content inside a `<div class="text">` with a nested `<abbr>` tag, so `getByText` with partial match is correct here

Closes #16

## Test plan

- [x] `home.spec.ts` passes on all browser projects
- [x] No string duplication: selector uses the static constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)