### PR TITLE
Verify login success in auth setup

### DIFF
--- a/playwright/typescript/auth.setup.ts
+++ b/playwright/typescript/auth.setup.ts
@@ -1,5 +1,6 @@
-import { test as setup } from '@playwright/test';
+import { test as setup, expect } from '@playwright/test';
 import { loadEnv, requireCredentials } from '@utils/env.util';
+import { AbstractPage } from '@pages/abstract.page';
 
 loadEnv(import.meta.url, 2);
 const { user, password } = requireCredentials();
@@ -12,5 +13,6 @@ setup('authenticate', async ({ page }) => {
     .fill(password);
   await page.locator('form[action="/zone/"]').getByRole('button').click();
   await page.waitForURL('**/zone/');
+  await expect(page.getByText(AbstractPage.loggedInAs)).toBeVisible();
   await page.context().storageState({ path: new URL('.auth/user.json', import.meta.url).pathname });
 });


### PR DESCRIPTION
## Summary

- Adds `await expect(page.getByText(AbstractPage.loggedInAs)).toBeVisible()` after `waitForURL` in `auth.setup.ts`
- Prevents a failed login from silently saving a broken session to `.auth/user.json`

**Root cause investigated via live page:** on wrong credentials the app redirects to `/zone/` (same URL as success) and renders the login form again with error text 'Podane dane sa nieprawidlowe' — so `waitForURL` alone cannot distinguish success from failure. Asserting `loggedInAs` is the reliable discriminator.

**On exact: true:** the partial match is intentional and correct — the page renders 'Jestem zalogowany jako [username]' as a single text node, so `loggedInAs` is a prefix rather than the full string. CLAUDE.md's `exact: true` convention applies when the full text is known; skipping it here is the right call.

Closes #17

## Test plan

- [x] Auth setup passes with valid credentials (all 36 Chromium tests pass)
- [x] Auth setup fails immediately with wrong credentials before saving storage state (manual verification)

Generated with [Claude Code](https://claude.com/claude-code)