### PR TITLE
20 Remove .first() from statsbar assertions, use exact text match

### DIFF
--- a/playwright/typescript/tests/about-system.spec.ts
+++ b/playwright/typescript/tests/about-system.spec.ts
@@ -51,14 +51,14 @@ test('about system page - headings and statsbar content', async ({ page }) => {
   // Sample browser names in the list
   for (const browser of AboutSystemPage.sampleBrowsers) {
     await expect(
-      statsbar.getByRole('listitem').filter({ hasText: browser }).first()
+      statsbar.getByRole('listitem').getByText(browser, { exact: true })
     ).toBeVisible();
   }
 
   // Sample OS names in the list
   for (const os of AboutSystemPage.sampleOSes) {
     await expect(
-      statsbar.getByRole('listitem').filter({ hasText: os }).first()
+      statsbar.getByRole('listitem').getByText(os, { exact: true })
     ).toBeVisible();
   }
 


### PR DESCRIPTION
## Summary
- Removes `.first()` from browser and OS statsbar assertions in `about-system.spec.ts`
- Replaces `filter({ hasText: browser })` with `getByText(browser, { exact: true })` to avoid strict mode violations caused by partial text matches (e.g. `Firefox` matching `Firefox`, `Firefox for iOS`, `Firefox OS`)

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] `about-system.spec.ts` passes on Chromium

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)