### PR TITLE
21 Replace .menu CSS class selector with #menubar ID selector

### DIFF
--- a/playwright/typescript/tests/navigation.spec.ts
+++ b/playwright/typescript/tests/navigation.spec.ts
@@ -30,7 +30,7 @@ test.describe('navigation', () => {
 
   test('home page', async ({ page }) => {
     await page
-      .locator('.menu')
+      .locator('#menubar')
       .getByRole('link', { name: 'Strona główna', exact: true })
       .click();
 
@@ -44,7 +44,7 @@ test.describe('navigation', () => {
 
   test('about system', async ({ page }) => {
     await page
-      .locator('.menu')
+      .locator('#menubar')
       .getByRole('link', { name: 'O systemie', exact: true })
       .click();
 
@@ -62,7 +62,7 @@ test.describe('navigation', () => {
 
   test('statistics', async ({ page }) => {
     await page
-      .locator('.menu')
+      .locator('#menubar')
       .getByRole('link', { name: 'Statystyki serwisu', exact: true })
       .click();
 
@@ -74,7 +74,7 @@ test.describe('navigation', () => {
 
   test('contact', async ({ page }) => {
     await page
-      .locator('.menu')
+      .locator('#menubar')
       .getByRole('link', { name: 'Kontakt', exact: true })
       .click();
 


### PR DESCRIPTION
## Summary
- Replaces `.locator('.menu')` CSS class selector with `.locator('#menubar')` in all four navigation tests
- `#menubar` is the stable ID of the `<div>` that wraps the navigation `<ul>`

## Note on implementation
The issue hints at `getByRole('navigation')`, but the application uses `<div id="menubar">` — there is no `<nav>` element or `role="navigation"` attribute in the DOM. `#menubar` is an ID selector (not a class), so it does not depend on styling decisions and satisfies the intent of the issue.

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] All 16 navigation tests pass on Chromium (12 title + 4 nav click tests)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)