### PR TITLE
22 Replace footer row index arithmetic with content-based selectors

### DIFF
--- a/playwright/typescript/tests/statistics.spec.ts
+++ b/playwright/typescript/tests/statistics.spec.ts
@@ -113,15 +113,18 @@ test('system statistics', async ({ page }) => {
 
   // Verify footer row values (count and percent) – located by content, not by index
   const totalRecognized = rows.filter({ hasText: ServiceStatisticsPage.totalRecognized });
+  await expect(totalRecognized).toHaveCount(1);
   await expect(totalRecognized.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
   await expect(totalRecognized.getByRole('cell').nth(3)).toHaveText('100%');
 
   const unrecognized = rows.filter({ hasText: ServiceStatisticsPage.unrecognized });
+  await expect(unrecognized).toHaveCount(1);
   await expect(unrecognized.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
   await expect(unrecognized.getByRole('cell').nth(3)).toHaveText('-');
 
   // 'Łącznie' is a substring of 'Łącznie rozpoznane'; use exact cell name to avoid matching both
   const total = rows.filter({ has: page.getByRole('cell', { name: ServiceStatisticsPage.total, exact: true }) });
+  await expect(total).toHaveCount(1);
   await expect(total.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
   await expect(total.getByRole('cell').nth(3)).toHaveText('-');
 });

--- a/playwright/typescript/tests/statistics.spec.ts
+++ b/playwright/typescript/tests/statistics.spec.ts
@@ -106,23 +106,22 @@ test('system statistics', async ({ page }) => {
     await expect(rows.nth(i).getByRole('cell').nth(3)).toHaveText(/^\d+\.\d{2}%$/);
   }
 
-  // Footer rows – totals (last 3 rows: recognized, unrecognized, total)
-  const totalRecognized = rows.nth(rowCount - 3);
-  await expect(totalRecognized.getByRole('cell').nth(1)).toHaveText(
-    ServiceStatisticsPage.totalRecognized
-  );
+  // Structural check: the table ends with exactly these 3 footer rows in order
+  await expect(rows.nth(rowCount - 3)).toContainText(ServiceStatisticsPage.totalRecognized);
+  await expect(rows.nth(rowCount - 2)).toContainText(ServiceStatisticsPage.unrecognized);
+  await expect(rows.last()).toContainText(ServiceStatisticsPage.total);
+
+  // Verify footer row values (count and percent) – located by content, not by index
+  const totalRecognized = rows.filter({ hasText: ServiceStatisticsPage.totalRecognized });
   await expect(totalRecognized.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
   await expect(totalRecognized.getByRole('cell').nth(3)).toHaveText('100%');
 
-  const unrecognized = rows.nth(rowCount - 2);
-  await expect(unrecognized.getByRole('cell').nth(1)).toHaveText(
-    ServiceStatisticsPage.unrecognized
-  );
+  const unrecognized = rows.filter({ hasText: ServiceStatisticsPage.unrecognized });
   await expect(unrecognized.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
   await expect(unrecognized.getByRole('cell').nth(3)).toHaveText('-');
 
-  const total = rows.nth(rowCount - 1);
-  await expect(total.getByRole('cell').nth(1)).toHaveText(ServiceStatisticsPage.total);
+  // 'Łącznie' is a substring of 'Łącznie rozpoznane'; use exact cell name to avoid matching both
+  const total = rows.filter({ has: page.getByRole('cell', { name: ServiceStatisticsPage.total, exact: true }) });
   await expect(total.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
   await expect(total.getByRole('cell').nth(3)).toHaveText('-');
 });


### PR DESCRIPTION
## Summary
Two-phase approach for the 3 statistics table footer rows:

1. **Structural check** — `rows.nth(rowCount - N)` with `toContainText` verifies that the table still ends with these 3 labels in the expected order
2. **Value check** — `rows.filter({ hasText: ... })` locates each footer row by content to assert count and percent columns, so these assertions survive if rows are added in the middle

Note: `'Łącznie'` is a substring of `'Łącznie rozpoznane'`, so the total row uses `filter({ has: page.getByRole('cell', { name: ..., exact: true }) })` instead of `hasText` to avoid matching both rows.

## Test plan
- [ ] `tsc --noEmit` passes with no errors
- [ ] `statistics.spec.ts` passes on Chromium

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)