### PR TITLE
30 Force GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   review:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -4,6 +4,9 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Adds FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true to playwright-typescript.yml and claude-code-review.yml. Opts in ahead of GitHub forced migration on June 2, 2026.

Closes #30

Generated with Claude Code