### PR TITLE
34 Support running playwright-typescript workflow locally with act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+--secret-file .env

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -25,8 +25,12 @@ jobs:
         env:
           ORWELLSTAT_USER: ${{ secrets.ORWELLSTAT_USER }}
           ORWELLSTAT_PASSWORD: ${{ secrets.ORWELLSTAT_PASSWORD }}
-      - uses: actions/upload-artifact@v4
+      - name: Detect local act runner
+        id: detect-act
         if: ${{ !cancelled() }}
+        run: '[ "${ACT}" = "true" ] && echo "running=true" >> $GITHUB_OUTPUT || true'
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && steps.detect-act.outputs.running != 'true' }}
         with:
           name: playwright-report
           path: playwright/typescript/playwright-report/

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Detect local act runner
         id: detect-act
         if: ${{ !cancelled() }}
-        run: '[ "${ACT}" = "true" ] && echo "running=true" >> $GITHUB_OUTPUT || true'
+        run: |
+          if [ "${ACT}" = "true" ]; then
+            echo "running=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && steps.detect-act.outputs.running != 'true' }}
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ When fixing a GitHub issue, follow these steps in order:
 3. Review against the [code review checklist](#code-review-checklist)
 4. Run the affected test(s) — must pass
 5. Create a branch from remote `main` named `feature/<issue-number>` or `bugfix/<issue-number>` (e.g. `feature/19`)
-6. Commit with a **short, single-line message** in the format `<issue-number> <short description>` (e.g. `19 Add explicit SvgAnalysis type to page.evaluate()`)
+6. Commit with a **short, single-line message** in the format `<issue-number> <short description>` (e.g. `19 Add explicit SvgAnalysis type to page.evaluate()`). No body, no `Co-Authored-By` trailer — single line only.
 7. Push and create a PR
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ All commands must be run from `playwright/typescript/`.
 - `trace: 'on-first-retry'`
 - Commented-out staging `baseURL` (`http://stage.orwellstat.hubertgajewski.com`) can be enabled for staging
 
-**CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uploads `playwright/typescript/playwright-report/` as an artifact (retained 30 days).
+**CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uploads `playwright/typescript/playwright-report/` as an artifact (retained 30 days); upload is skipped when running locally with `act`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -190,3 +190,5 @@ act push -W .github/workflows/playwright-typescript.yml --container-architecture
 On first run, `act` will ask for a Docker image size — choose **Medium** (~500MB). The workflow itself installs Playwright browsers via `npx playwright install --with-deps`.
 
 > **Note:** The `--container-architecture linux/amd64` flag is required on Apple Silicon (M-series) Macs to avoid compatibility issues.
+
+> **Credentials:** The repo root contains `.actrc` which automatically passes `--secret-file .env` to every `act` invocation. `ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` from `.env` are loaded as secrets with no extra flags needed.


### PR DESCRIPTION
## Summary
- Add `.actrc` to auto-load credentials from `.env` as secrets when using `act`
- Add `Detect local act runner` step that safely writes a step output (never the raw env var)
- Skip `actions/upload-artifact@v4` when running locally — it requires GitHub's artifact backend

## Test plan
- [x] Run `act push -W .github/workflows/playwright-typescript.yml --container-architecture linux/amd64` — job should succeed and artifact upload step should be skipped
- [x] Verify workflow still passes on GitHub Actions with artifact upload running normally

Closes #34