### PR TITLE
36 Remove artificial 1-worker limit on CI

### DIFF
--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
## Summary
- Remove `workers: process.env.CI ? 1 : undefined` — a leftover from the Playwright scaffold template for local dev server projects
- Tests hit an external live site, so there is no resource contention; the default (half available CPU cores) is appropriate on both local and CI

## Test plan
- [x] `tsc --noEmit` passes
- [ ] CI run shows more than 1 worker active in the Playwright output

Closes #36