### PR TITLE
40 Save DOM snapshot as XHTML with XML prolog on test failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ All commands must be run from `playwright/typescript/`.
   - `authenticated/` — Authenticated page classes: `InformationPage`, `StatsPage`, `HitsPage`, `ScriptsPage`, `AdminPage`; exported via `index.ts` as `AUTHENTICATED_PAGE_CLASSES`
 - `fixtures/base.fixture.ts` — Custom Playwright fixture extending `test` with:
   - `authenticatedRequest` — logs in via POST `/zone/` before each test
-  - Captures browser console logs and DOM snapshot as attachments on test failure
+  - Captures browser console logs and XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure
   - Re-exports `expect`, `request`, `Page`, `Locator`, `BrowserContext` from `@playwright/test`
   - Re-exports `pixelmatch` and `PNG` (used for pixel-diff screenshot comparison)
 - `utils/accessibility.util.ts` — `expectNoAccessibilityViolations()` using `@axe-core/playwright` (WCAG2AAA)

--- a/playwright/typescript/fixtures/base.fixture.ts
+++ b/playwright/typescript/fixtures/base.fixture.ts
@@ -27,8 +27,17 @@ export const test = base.extend<OrwellStatFixtures>({
         });
       }
 
-      const domPath = testInfo.outputPath('dom.html');
-      writeFileSync(domPath, await page.content());
+      const styleLinks = await page.evaluate(() =>
+        Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'))
+          .map((l) => l.getAttribute('href'))
+          .filter((href): href is string => href !== null)
+      );
+      const xmlProlog = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        ...styleLinks.map((href) => `<?xml-stylesheet type="text/css" href="${href}"?>`),
+      ].join('\n');
+      const domPath = testInfo.outputPath('dom.xhtml');
+      writeFileSync(domPath, xmlProlog + '\n' + (await page.content()));
       await testInfo.attach('DOM', {
         path: domPath,
         contentType: 'text/html',

--- a/playwright/typescript/fixtures/base.fixture.ts
+++ b/playwright/typescript/fixtures/base.fixture.ts
@@ -27,7 +27,7 @@ export const test = base.extend<OrwellStatFixtures>({
         });
       }
 
-      const styleLinks = await page.evaluate(() =>
+      const styleLinks = await page.evaluate<string[]>(() =>
         Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'))
           .map((l) => l.getAttribute('href'))
           .filter((href): href is string => href !== null)


### PR DESCRIPTION
## Summary
- Rename DOM snapshot attachment from `dom.html` to `dom.xhtml`
- Prepend `<?xml version="1.0" encoding="UTF-8"?>` and one `<?xml-stylesheet type="text/css" href="..."?>` per page stylesheet before the serialized DOM
- Keep `contentType: 'text/html'` so Safari opens the attachment inline instead of downloading it
- Update CLAUDE.md fixture description

## Test plan
- [x] Trigger a test failure and verify the attachment is named `dom.xhtml`
- [x] Verify the file starts with the XML declaration followed by stylesheet PIs
- [x] Verify clicking the DOM link in Playwright's HTML report opens inline in Safari
- [x] `tsc --noEmit` passes

Closes #40