### PR TITLE
42 Add XHTML and CSS validation tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ All commands must be run from `playwright/typescript/`.
   - `about-system.spec.ts` — About System page headings and statsbar content tests
   - `contact.spec.ts` — Contact page headings and statsbar content tests
   - `statistics.spec.ts` — Service statistics page: SVG chart rendering and statistics table tests
+  - `validation.spec.ts` — W3C XHTML and CSS validation tests across all pages (classic W3C Markup Validator + CSS validator APIs); Chromium-only
 - `auth.setup.ts` — Playwright auth setup: logs in via UI and saves storage state to `.auth/user.json`
 - `pages/` — Page Object Model classes
   - `base.page.ts` — `BasePage` interface (`url`, `title`, `goto()`, `heading`, optional `accessKey`)
@@ -64,6 +65,7 @@ All commands must be run from `playwright/typescript/`.
 - `utils/accessibility.util.ts` — `expectNoAccessibilityViolations()` using `@axe-core/playwright` (WCAG2AAA)
 - `utils/string.util.ts` — `expectHeadings()` helper: asserts visibility of multiple headings on a page
 - `utils/env.util.ts` — `loadEnv(importMetaUrl, levelsUp)` loads `.env` relative to the calling file; `requireCredentials()` validates and returns `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD`, throwing a descriptive error if either is missing
+- `utils/validation.util.ts` — `expectValidXhtml(request, xhtml)` POSTs raw markup to the classic W3C Markup Validation Service (`validator.w3.org/check`) and asserts no errors (correct for XHTML 1.0 Strict; Nu is HTML5-only and gives false positives); `expectValidCss(request, cssUrl)` queries W3C CSS validator by URI and asserts zero errors
 - `types/` — Shared TypeScript interfaces; exported via path alias `@types-local/*`
   - `svg-analysis.ts` — `SvgAnalysis` interface: shape of the object returned by `page.evaluate()` in `statistics.spec.ts`
 - `test-data/` — Reserved for static test data (currently empty)
@@ -101,7 +103,7 @@ Before committing changes to `playwright/typescript`, review against these crite
 - **Potential bugs** — async/await not missing on Playwright calls; no unhandled promise rejections; locators not reused across navigations; any file reading `process.env` credentials calls `loadEnv(import.meta.url, N)` at module top level (missing this passes on CI but fails locally)
 - **Flakiness** — no fixed timeouts; animation waits use `requestAnimationFrame`; auth setup asserts login actually succeeded; no assumptions about element order without explicit count assertion
 - **Security** — no credentials hardcoded anywhere; `.env` and `bruno/environments/.env` remain gitignored; Bruno secrets use `vars:secret` (not plaintext in `.bru` files); no sensitive data in committed config files (`.actrc`, `playwright.config.ts`, etc.); `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD` sourced only from `.env` (local) or GitHub Actions secrets (CI)
-- **Consistency with existing patterns** — new utils documented in `CLAUDE.md`; new page files exported via the appropriate `index.ts`; code style matches surrounding files; JSON/config files are valid (no stray braces, no syntax errors)
+- **Consistency with existing patterns** — new utils and test files documented in **both** `CLAUDE.md` and `README.md` (both files have mirrored architecture sections); new page files exported via the appropriate `index.ts`; code style matches surrounding files; JSON/config files are valid (no stray braces, no syntax errors)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ npx playwright test tests/home.spec.ts
 npx playwright test tests/about-system.spec.ts
 npx playwright test tests/contact.spec.ts
 npx playwright test tests/statistics.spec.ts
+npx playwright test tests/validation.spec.ts
 
 # Specific browser
 npx playwright test --project=chromium
@@ -94,6 +95,7 @@ npx playwright test --ui
   - `about-system.spec.ts` — About System page headings and statsbar content tests
   - `contact.spec.ts` — Contact page headings and statsbar content tests
   - `statistics.spec.ts` — Service statistics page: SVG chart rendering and statistics table tests
+  - `validation.spec.ts` — W3C XHTML and CSS validation tests across all pages (classic W3C Markup Validator + CSS validator APIs); Chromium-only
 - `auth.setup.ts` — Playwright auth setup: logs in via UI and saves storage state to `.auth/user.json`
 - `pages/` — Page Object Model classes
   - `base.page.ts` — `BasePage` interface (`url`, `title`, `goto()`, `heading`, optional `accessKey`)
@@ -103,12 +105,15 @@ npx playwright test --ui
   - `authenticated/` — Authenticated page classes: `InformationPage`, `StatsPage`, `HitsPage`, `ScriptsPage`, `AdminPage`; exported via `index.ts` as `AUTHENTICATED_PAGE_CLASSES`
 - `fixtures/base.fixture.ts` — Custom Playwright fixture extending `test` with:
   - `authenticatedRequest` — logs in via POST `/zone/` before each test
-  - Captures browser console logs and DOM snapshot as attachments on test failure
+  - Captures browser console logs and XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure
   - Re-exports `expect`, `request`, `Page`, `Locator`, `BrowserContext` from `@playwright/test`
   - Re-exports `pixelmatch` and `PNG` (used for pixel-diff screenshot comparison)
 - `utils/accessibility.util.ts` — `expectNoAccessibilityViolations()` using `@axe-core/playwright` (WCAG2AAA)
 - `utils/string.util.ts` — `expectHeadings()` helper: asserts visibility of multiple headings on a page
-- `types/` — Reserved for shared TypeScript interfaces (currently empty)
+- `utils/validation.util.ts` — `expectValidXhtml(request, xhtml)` POSTs raw markup to the classic W3C Markup Validation Service (`validator.w3.org/check`) and asserts no errors (correct for XHTML 1.0 Strict; Nu is HTML5-only and gives false positives); `expectValidCss(request, cssUrl)` queries W3C CSS validator by URI and asserts zero errors
+- `utils/env.util.ts` — `loadEnv(importMetaUrl, levelsUp)` loads `.env` relative to the calling file; `requireCredentials()` validates and returns `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD`
+- `types/` — Shared TypeScript interfaces; exported via path alias `@types-local/*`
+  - `svg-analysis.ts` — `SvgAnalysis` interface: shape of the object returned by `page.evaluate()` in `statistics.spec.ts`
 - `test-data/` — Reserved for static test data (currently empty)
 
 **Page Object Model pattern:** Each page class extends `AbstractPage` and defines static `url`, `title` (and optionally `accessKey`) properties used in data-driven loops. The constructor calls `super(page, url, title, accessKey)`. Only the `heading` getter and page-specific static string constants need to be defined per class.
@@ -129,7 +134,7 @@ npx playwright test --ui
 - `trace: 'on-first-retry'`
 - Commented-out staging `baseURL` (`http://stage.orwellstat.hubertgajewski.com`) can be enabled for staging
 
-**CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uploads `playwright/typescript/playwright-report/` as an artifact (retained 30 days).
+**CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uploads `playwright/typescript/playwright-report/` as an artifact (retained 30 days); upload is skipped when running locally with `act`.
 
 ---
 

--- a/playwright/typescript/fixtures/base.fixture.ts
+++ b/playwright/typescript/fixtures/base.fixture.ts
@@ -70,6 +70,7 @@ export {
   type Page,
   type Locator,
   type BrowserContext,
+  type APIRequestContext,
 } from '@playwright/test';
 
 export { default as pixelmatch } from 'pixelmatch';

--- a/playwright/typescript/tests/validation.spec.ts
+++ b/playwright/typescript/tests/validation.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@fixtures/base.fixture';
+import { expectValidXhtml, expectValidCss } from '@utils/validation.util';
+import { PUBLIC_PAGE_CLASSES } from '@pages/public/index';
+import { AUTHENTICATED_PAGE_CLASSES } from '@pages/authenticated/index';
+import { HomePage } from '@pages/public/home.page';
+
+test.describe('markup and CSS validation', () => {
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Validation tests run on Chromium only'
+  );
+
+  const xhtmlHeaders = { Accept: 'application/xhtml+xml' };
+
+  for (const PageClass of PUBLIC_PAGE_CLASSES) {
+    test(`${PageClass.url} - XHTML valid`, async ({ unauthenticatedRequest }) => {
+      const response = await unauthenticatedRequest.get(PageClass.url, { headers: xhtmlHeaders });
+      await expectValidXhtml(unauthenticatedRequest, await response.text());
+    });
+  }
+
+  for (const PageClass of AUTHENTICATED_PAGE_CLASSES) {
+    test(`${PageClass.url} - XHTML valid`, async ({ authenticatedRequest }) => {
+      const response = await authenticatedRequest.get(PageClass.url, { headers: xhtmlHeaders });
+      await expectValidXhtml(authenticatedRequest, await response.text());
+    });
+  }
+
+  test('stylesheets - CSS valid', async ({ unauthenticatedRequest }) => {
+    const response = await unauthenticatedRequest.get(HomePage.url, { headers: xhtmlHeaders });
+    const text = await response.text();
+    const baseUrl = new URL(response.url()).origin;
+    const styleUrls = [...text.matchAll(/<\?xml-stylesheet\s+href="([^"]+)"/g)].map(
+      (m) => new URL(m[1], baseUrl).href
+    );
+    expect(styleUrls.length, 'Expected at least one xml-stylesheet PI on the page').toBeGreaterThan(
+      0
+    );
+    for (const url of styleUrls) {
+      await expectValidCss(unauthenticatedRequest, url);
+    }
+  });
+});

--- a/playwright/typescript/utils/validation.util.ts
+++ b/playwright/typescript/utils/validation.util.ts
@@ -1,0 +1,52 @@
+import { expect, type APIRequestContext } from '@fixtures/base.fixture';
+
+const W3C_MARKUP_VALIDATOR = 'https://validator.w3.org/check';
+const CSS_VALIDATOR = 'https://jigsaw.w3.org/css-validator/validator';
+
+interface W3cMessage {
+  type: 'error' | 'info' | 'non-document-error';
+  message: string;
+  lastLine?: number;
+}
+
+interface W3cResponse {
+  messages: W3cMessage[];
+}
+
+interface CssValidationResponse {
+  cssvalidation: {
+    result: { errorcount: number };
+    errors?: Array<{ message: string; line: number }>;
+  };
+}
+
+export async function expectValidXhtml(request: APIRequestContext, xhtml: string): Promise<void> {
+  const response = await request.fetch(W3C_MARKUP_VALIDATOR, {
+    method: 'POST',
+    multipart: {
+      uploaded_file: { name: 'page.xhtml', mimeType: 'application/xhtml+xml', buffer: Buffer.from(xhtml) },
+      output: 'json',
+    },
+  });
+  expect(response.ok(), `W3C markup validator request failed: ${response.status()}`).toBeTruthy();
+  const { messages } = (await response.json()) as W3cResponse;
+  const errors = messages.filter(
+    (m: W3cMessage) => m.type === 'error' || m.type === 'non-document-error'
+  );
+  expect(
+    errors,
+    `XHTML validation errors:\n${errors.map((e: W3cMessage) => `  Line ${e.lastLine ?? '?'}: ${e.message}`).join('\n')}`
+  ).toHaveLength(0);
+}
+
+export async function expectValidCss(request: APIRequestContext, cssUrl: string): Promise<void> {
+  const response = await request.get(
+    `${CSS_VALIDATOR}?output=json&uri=${encodeURIComponent(cssUrl)}`
+  );
+  expect(response.ok(), `CSS validator request failed: ${response.status()}`).toBeTruthy();
+  const { cssvalidation } = (await response.json()) as CssValidationResponse;
+  expect(
+    cssvalidation.result.errorcount,
+    `CSS errors in ${cssUrl}:\n${(cssvalidation.errors ?? []).map((e: { message: string; line: number }) => `  Line ${e.line}: ${e.message}`).join('\n')}`
+  ).toBe(0);
+}


### PR DESCRIPTION
## Summary

- Adds `utils/validation.util.ts` with `expectValidXhtml()` (W3C Nu validator API) and `expectValidCss()` (W3C CSS Validator API)
- Adds `tests/validation.spec.ts` with Chromium-only XHTML validation for all public and authenticated pages, plus CSS validation for all stylesheets
- Updates `CLAUDE.md` and `README.md` with new files; expands Consistency checklist item to explicitly require updating both docs

## Test plan

- [x] `tsc --noEmit` passes
- [x] Validation tests run on Chromium and pass against production
- [x] Tests are skipped on Firefox, WebKit, Mobile Chrome, Mobile Safari

Closes #42