### PR TITLE
45 Add httpCredentials for staging Basic Auth in playwright.config.ts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 ORWELLSTAT_USER=
 ORWELLSTAT_PASSWORD=
+# Required only for staging (https://stage.orwellstat.hubertgajewski.com).
+# If BASIC_AUTH_USER is set but BASIC_AUTH_PASSWORD is omitted, Playwright
+# will silently send an empty password and all requests will return 401.
 BASIC_AUTH_USER=
 BASIC_AUTH_PASSWORD=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ All commands must be run from `playwright/typescript/`.
 - All projects use `storageState: '.auth/user.json'` (written by `auth.setup.ts`)
 - On failure: screenshots, video, and console/DOM log attachments are saved
 - `trace: 'on-first-retry'`
-- Commented-out staging `baseURL` (`http://stage.orwellstat.hubertgajewski.com`) can be enabled for staging; when enabled, `httpCredentials` are injected automatically if `BASIC_AUTH_USER` is set
+- Commented-out staging `baseURL` (`https://stage.orwellstat.hubertgajewski.com`) can be enabled for staging; when enabled, `httpCredentials` are injected automatically if `BASIC_AUTH_USER` is set
 
 **CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uploads `playwright/typescript/playwright-report/` as an artifact (retained 30 days); upload is skipped when running locally with `act`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ For a full project overview, setup instructions, and commands see [README.md](RE
 
 ```
 .env                        # credentials (git-ignored); see .env.example
-.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD
+.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD
 .github/workflows/          # CI workflows (one per sub-project)
 playwright/
   typescript/               # Playwright tests in TypeScript
@@ -27,9 +27,11 @@ Credentials are stored in `.env` at the **repo root** and shared across all sub-
 ```
 ORWELLSTAT_USER=<username>
 ORWELLSTAT_PASSWORD=<password>
+BASIC_AUTH_USER=<staging basic auth user>
+BASIC_AUTH_PASSWORD=<staging basic auth password>
 ```
 
-In CI these are injected as GitHub Actions secrets. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env`).
+`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed for staging — Playwright passes them as HTTP Basic Auth credentials when set. In CI all four are injected as GitHub Actions secrets. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env`).
 
 ---
 
@@ -86,7 +88,7 @@ All commands must be run from `playwright/typescript/`.
 - All projects use `storageState: '.auth/user.json'` (written by `auth.setup.ts`)
 - On failure: screenshots, video, and console/DOM log attachments are saved
 - `trace: 'on-first-retry'`
-- Commented-out staging `baseURL` (`http://stage.orwellstat.hubertgajewski.com`) can be enabled for staging
+- Commented-out staging `baseURL` (`http://stage.orwellstat.hubertgajewski.com`) can be enabled for staging; when enabled, `httpCredentials` are injected automatically if `BASIC_AUTH_USER` is set
 
 **CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uploads `playwright/typescript/playwright-report/` as an artifact (retained 30 days); upload is skipped when running locally with `act`.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ npx playwright test --ui
 - All projects use `storageState: '.auth/user.json'` (written by `auth.setup.ts`)
 - On failure: screenshots, video, and console/DOM log attachments are saved
 - `trace: 'on-first-retry'`
-- Commented-out staging `baseURL` (`http://stage.orwellstat.hubertgajewski.com`) can be enabled for staging; when enabled, `httpCredentials` are injected automatically if `BASIC_AUTH_USER` is set
+- Commented-out staging `baseURL` (`https://stage.orwellstat.hubertgajewski.com`) can be enabled for staging; when enabled, `httpCredentials` are injected automatically if `BASIC_AUTH_USER` is set
 
 **CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uploads `playwright/typescript/playwright-report/` as an artifact (retained 30 days); upload is skipped when running locally with `act`.
 
@@ -153,7 +153,7 @@ Open the `bruno/` directory in the Bruno standalone app or use the Bruno VSCode 
 | Environment | Base URL |
 |---|---|
 | production | `https://orwellstat.hubertgajewski.com` |
-| staging | `http://stage.orwellstat.hubertgajewski.com` |
+| staging | `https://stage.orwellstat.hubertgajewski.com` |
 
 Environment secrets (passwords, Basic auth credentials) are stored in `bruno/environments/.env` (git-ignored). Create this file locally:
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ Copy `.env.example` to `.env` at the repo root and fill in your credentials:
 ```
 ORWELLSTAT_USER=<username>
 ORWELLSTAT_PASSWORD=<password>
+BASIC_AUTH_USER=<staging basic auth user>
+BASIC_AUTH_PASSWORD=<staging basic auth password>
 ```
 
-This file is shared across all sub-projects. In CI, credentials are injected as GitHub Actions secrets.
+`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. In CI, all four are injected as GitHub Actions secrets.
 
 ---
 
@@ -132,7 +134,7 @@ npx playwright test --ui
 - All projects use `storageState: '.auth/user.json'` (written by `auth.setup.ts`)
 - On failure: screenshots, video, and console/DOM log attachments are saved
 - `trace: 'on-first-retry'`
-- Commented-out staging `baseURL` (`http://stage.orwellstat.hubertgajewski.com`) can be enabled for staging
+- Commented-out staging `baseURL` (`http://stage.orwellstat.hubertgajewski.com`) can be enabled for staging; when enabled, `httpCredentials` are injected automatically if `BASIC_AUTH_USER` is set
 
 **CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uploads `playwright/typescript/playwright-report/` as an artifact (retained 30 days); upload is skipped when running locally with `act`.
 

--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -18,8 +18,8 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 
   use: {
-    // baseURL: 'https://orwellstat.hubertgajewski.com',
-    baseURL: 'http://stage.orwellstat.hubertgajewski.com',
+    baseURL: 'https://orwellstat.hubertgajewski.com',
+//     baseURL: 'https://stage.orwellstat.hubertgajewski.com',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -18,14 +18,22 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 
   use: {
-    baseURL: 'https://orwellstat.hubertgajewski.com',
-    // baseURL: 'http://stage.orwellstat.hubertgajewski.com',
+    // baseURL: 'https://orwellstat.hubertgajewski.com',
+    baseURL: 'http://stage.orwellstat.hubertgajewski.com',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
     extraHTTPHeaders: {
       Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
     },
+    ...(process.env.BASIC_AUTH_USER
+      ? {
+          httpCredentials: {
+            username: process.env.BASIC_AUTH_USER,
+            password: process.env.BASIC_AUTH_PASSWORD ?? '',
+          },
+        }
+      : {}),
   },
 
   projects: [
@@ -36,27 +44,42 @@ export default defineConfig({
     },
     {
       name: 'Chromium',
-      use: { ...devices['Desktop Chrome'], storageState: new URL('.auth/user.json', import.meta.url).pathname },
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: new URL('.auth/user.json', import.meta.url).pathname,
+      },
       dependencies: ['setup'],
     },
     {
       name: 'Firefox',
-      use: { ...devices['Desktop Firefox'], storageState: new URL('.auth/user.json', import.meta.url).pathname },
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: new URL('.auth/user.json', import.meta.url).pathname,
+      },
       dependencies: ['setup'],
     },
     {
       name: 'Webkit',
-      use: { ...devices['Desktop Safari'], storageState: new URL('.auth/user.json', import.meta.url).pathname },
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: new URL('.auth/user.json', import.meta.url).pathname,
+      },
       dependencies: ['setup'],
     },
     {
       name: 'Mobile Chrome',
-      use: { ...devices['Galaxy S24'], storageState: new URL('.auth/user.json', import.meta.url).pathname },
+      use: {
+        ...devices['Galaxy S24'],
+        storageState: new URL('.auth/user.json', import.meta.url).pathname,
+      },
       dependencies: ['setup'],
     },
     {
       name: 'Mobile Safari',
-      use: { ...devices['iPhone 15'], storageState: new URL('.auth/user.json', import.meta.url).pathname },
+      use: {
+        ...devices['iPhone 15'],
+        storageState: new URL('.auth/user.json', import.meta.url).pathname,
+      },
       dependencies: ['setup'],
     },
 


### PR DESCRIPTION
Closes #45

## Summary

- `playwright.config.ts` now spreads `httpCredentials` when `BASIC_AUTH_USER` is set, enabling Playwright to pass HTTP Basic Auth automatically for staging
- `README.md` and `CLAUDE.md` updated to document `BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD` in the Playwright context

## Test plan

- [ ] Set `BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD` in `.env` and run `npx playwright test` against staging — `auth.setup.ts` should pass
- [ ] Unset `BASIC_AUTH_USER` and run against production — no `httpCredentials` passed, behaviour unchanged
- [ ] `tsc --noEmit` passes