### PR TITLE
50 Set workers to 100% on CI to use all available vCPUs

### DIFF
--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: undefined,
+  workers: process.env.CI ? '100%' : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? '100%' : undefined,
+  workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? '100%' : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
Closes #50

PR #37 removed `--workers=1` from the CLI but left `workers: undefined` in the config. Playwright defaults to 1 worker on CI environments when `workers` is `undefined`, so nothing changed.

This sets `workers: process.env.CI ? '100%' : undefined`, which:
- Uses all vCPUs on whatever GitHub Actions runner is provisioned (4 on `ubuntu-latest`)
- Scales automatically if the runner type changes
- Leaves local behaviour unchanged (Playwright default: half CPU cores)