### PR TITLE
52 Replace row-by-row loop with single page.evaluate() to prevent timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ All commands must be run from `playwright/typescript/`.
 - `utils/validation.util.ts` — `expectValidXhtml(request, xhtml)` POSTs raw markup to the classic W3C Markup Validation Service (`validator.w3.org/check`) and asserts no errors (correct for XHTML 1.0 Strict; Nu is HTML5-only and gives false positives); `expectValidCss(request, cssUrl)` queries W3C CSS validator by URI and asserts zero errors
 - `types/` — Shared TypeScript interfaces; exported via path alias `@types-local/*`
   - `svg-analysis.ts` — `SvgAnalysis` interface: shape of the object returned by `page.evaluate()` in `statistics.spec.ts`
+  - `statistics-row.ts` — `StatisticsRow` interface: shape of each data row returned by the bulk `page.evaluate()` in `statistics.spec.ts`
 - `test-data/` — Reserved for static test data (currently empty)
 
 **Page Object Model pattern:** Each page class extends `AbstractPage` and defines static `url`, `title` (and optionally `accessKey`) properties used in data-driven loops. The constructor calls `super(page, url, title, accessKey)`. Only the `heading` getter and page-specific static string constants need to be defined per class.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ Before committing changes to `playwright/typescript`, review against these crite
 - **Potential bugs** — async/await not missing on Playwright calls; no unhandled promise rejections; locators not reused across navigations; any file reading `process.env` credentials calls `loadEnv(import.meta.url, N)` at module top level (missing this passes on CI but fails locally)
 - **Flakiness** — no fixed timeouts; animation waits use `requestAnimationFrame`; auth setup asserts login actually succeeded; no assumptions about element order without explicit count assertion
 - **Security** — no credentials hardcoded anywhere; `.env` and `bruno/environments/.env` remain gitignored; Bruno secrets use `vars:secret` (not plaintext in `.bru` files); no sensitive data in committed config files (`.actrc`, `playwright.config.ts`, etc.); `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD` sourced only from `.env` (local) or GitHub Actions secrets (CI)
+- **Formatting** — code is formatted with Prettier (`npm run format` from `playwright/typescript/`); never commit files that would fail `npm run format:check`
 - **Consistency with existing patterns** — new utils and test files documented in **both** `CLAUDE.md` and `README.md` (both files have mirrored architecture sections); new page files exported via the appropriate `index.ts`; code style matches surrounding files; JSON/config files are valid (no stray braces, no syntax errors)
 
 ---
@@ -135,11 +136,13 @@ When fixing a GitHub issue, follow these steps in order:
 
 1. Make the code change
 2. Run `tsc --noEmit` — must pass with no errors
-3. Review against the [code review checklist](#code-review-checklist)
-4. Run the affected test(s) — must pass
-5. Create a branch from remote `main` named `feature/<issue-number>` or `bugfix/<issue-number>` (e.g. `feature/19`)
-6. Commit with a **short, single-line message** in the format `<issue-number> <short description>` (e.g. `19 Add explicit SvgAnalysis type to page.evaluate()`). No body, no `Co-Authored-By` trailer — single line only.
-7. Push and create a PR
+3. Run `npm run format` — auto-formats all files; no manual style fixes needed
+4. Review against the [code review checklist](#code-review-checklist)
+5. Run the affected test(s) — must pass
+6. Create a branch from remote `main` named `feature/<issue-number>` or `bugfix/<issue-number>` (e.g. `feature/19`)
+7. Commit with a **short, single-line message** in the format `<issue-number> <short description>` (e.g. `19 Add explicit SvgAnalysis type to page.evaluate()`). No body, no `Co-Authored-By` trailer — single line only.
+8. **Review the diff as a fresh reviewer** — run `git diff HEAD~1` and read the diff as someone who was not part of the discussion and has no context beyond what is visible in the code. For every non-obvious change ask: *"Would I understand why this was done just from the diff?"* If the answer is no, either add a comment in the code or adjust the implementation before pushing.
+9. Push and create a PR
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ npx playwright show-report
 
 # Interactive UI mode
 npx playwright test --ui
+
+# Format with Prettier
+npm run format
+
+# Check formatting without writing
+npm run format:check
 ```
 
 ### Architecture

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ npx playwright test --ui
 - `utils/env.util.ts` — `loadEnv(importMetaUrl, levelsUp)` loads `.env` relative to the calling file; `requireCredentials()` validates and returns `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD`
 - `types/` — Shared TypeScript interfaces; exported via path alias `@types-local/*`
   - `svg-analysis.ts` — `SvgAnalysis` interface: shape of the object returned by `page.evaluate()` in `statistics.spec.ts`
+  - `statistics-row.ts` — `StatisticsRow` interface: shape of each data row returned by the bulk `page.evaluate()` in `statistics.spec.ts`
 - `test-data/` — Reserved for static test data (currently empty)
 
 **Page Object Model pattern:** Each page class extends `AbstractPage` and defines static `url`, `title` (and optionally `accessKey`) properties used in data-driven loops. The constructor calls `super(page, url, title, accessKey)`. Only the `heading` getter and page-specific static string constants need to be defined per class.

--- a/playwright/typescript/tests/statistics.spec.ts
+++ b/playwright/typescript/tests/statistics.spec.ts
@@ -111,8 +111,6 @@ test('system statistics', async ({ page }) => {
             lp: row.cells[0]?.textContent?.trim() ?? '',
             count: row.cells[2]?.textContent?.trim() ?? '',
             percent: row.cells[3]?.textContent?.trim() ?? '',
-            count:   row.cells[2]?.textContent?.trim() ?? '',
-            percent: row.cells[3]?.textContent?.trim() ?? '',
           }))
       : [];
   });

--- a/playwright/typescript/tests/statistics.spec.ts
+++ b/playwright/typescript/tests/statistics.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, pixelmatch, PNG } from '@fixtures/base.fixture';
 import { ServiceStatisticsPage } from '@pages/public/service-statistics.page';
 import { expectHeadings } from '@utils/string.util';
 import { SvgAnalysis } from '@types-local/svg-analysis';
+import { StatisticsRow } from '@types-local/statistics-row';
 
 test('SVG chart is rendered on stats page', async ({ page }) => {
   const [svgResponse] = await Promise.all([
@@ -100,10 +101,24 @@ test('system statistics', async ({ page }) => {
   const rowCount = await rows.count();
   expect(rowCount).toBeGreaterThan(0);
 
-  for (let i = 1; i <= rowCount - 4; i++) {
-    await expect(page.getByRole('cell', { name: String(i) }).first()).toBeVisible();
-    await expect(rows.nth(i).getByRole('cell').nth(2)).toHaveText(/^\d+$/);
-    await expect(rows.nth(i).getByRole('cell').nth(3)).toHaveText(/^\d+\.\d{2}%$/);
+  // Read all data rows in one browser round-trip to avoid 246+ sequential awaits timing out
+  const dataRows = await page.evaluate<StatisticsRow[]>(() => {
+    const table = document.querySelector('table');
+    return table
+      ? Array.from(table.rows)
+          .slice(1, -3)
+          .map((row) => ({
+            lp:      row.cells[0]?.textContent?.trim() ?? '',
+            count:   row.cells[2]?.textContent?.trim() ?? '',
+            percent: row.cells[3]?.textContent?.trim() ?? '',
+          }))
+      : [];
+  });
+  expect(dataRows).toHaveLength(rowCount - 4);
+  for (let i = 0; i < dataRows.length; i++) {
+    expect(dataRows[i].lp,      `row ${i + 1}: lp`).toBe(String(i + 1));
+    expect(dataRows[i].count,   `row ${i + 1}: count`).toMatch(/^\d+$/);
+    expect(dataRows[i].percent, `row ${i + 1}: percent`).toMatch(/^\d+\.\d{2}%$/);
   }
 
   // Structural check: the table ends with exactly these 3 footer rows in order

--- a/playwright/typescript/tests/statistics.spec.ts
+++ b/playwright/typescript/tests/statistics.spec.ts
@@ -108,13 +108,15 @@ test('system statistics', async ({ page }) => {
       ? Array.from(table.rows)
           .slice(1, -3)
           .map((row) => ({
-            lp:      row.cells[0]?.textContent?.trim() ?? '',
+            lp: row.cells[0]?.textContent?.trim() ?? '',
+            count: row.cells[2]?.textContent?.trim() ?? '',
+            percent: row.cells[3]?.textContent?.trim() ?? '',
             count:   row.cells[2]?.textContent?.trim() ?? '',
             percent: row.cells[3]?.textContent?.trim() ?? '',
           }))
       : [];
   });
-  expect(dataRows).toHaveLength(rowCount - 4);
+  expect(dataRows).toHaveLength(rowCount - 4); // 1 header row + 3 footer rows
   for (let i = 0; i < dataRows.length; i++) {
     expect(dataRows[i].lp,      `row ${i + 1}: lp`).toBe(String(i + 1));
     expect(dataRows[i].count,   `row ${i + 1}: count`).toMatch(/^\d+$/);

--- a/playwright/typescript/types/statistics-row.ts
+++ b/playwright/typescript/types/statistics-row.ts
@@ -1,0 +1,5 @@
+export interface StatisticsRow {
+  lp: string;
+  count: string;
+  percent: string;
+}


### PR DESCRIPTION
Closes #52

The `system statistics` test looped through 82+ data rows making 3 `await expect()` calls per row — up to 246 sequential async round-trips. With 4 workers competing for 2 vCPUs on CI, the test hit the 30s timeout around row 76. The DOM snapshot confirmed the cell had valid content; Playwright simply ran out of time mid-assertion.

**Fix:** a single `page.evaluate()` reads all data rows in one browser round-trip, then the loop asserts synchronously in Node.js — reducing 246+ async calls to 1.

Added `StatisticsRow` interface in `types/statistics-row.ts` (same pattern as `SvgAnalysis`). Updated `CLAUDE.md` and `README.md`.