### PR TITLE
58 Add workflow_dispatch to CI for regenerating visual baselines

### DIFF
--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -4,15 +4,30 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      update_visual_baselines:
+        description: 'Regenerate Linux visual baselines (--update-snapshots) and commit them back'
+        type: boolean
+        default: false
+      ref:
+        description: 'Branch to run on (defaults to main)'
+        required: false
+        default: ''
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
@@ -23,11 +38,28 @@ jobs:
         run: npx playwright install --with-deps
         working-directory: playwright/typescript
       - name: Run Playwright tests
-        run: npx playwright test
+        run: |
+          if [ "${{ github.event.inputs.update_visual_baselines }}" = "true" ]; then
+            npx playwright test tests/visual.spec.ts --update-snapshots
+          else
+            npx playwright test
+          fi
         working-directory: playwright/typescript
         env:
           ORWELLSTAT_USER: ${{ secrets.ORWELLSTAT_USER }}
           ORWELLSTAT_PASSWORD: ${{ secrets.ORWELLSTAT_PASSWORD }}
+      - name: Commit updated visual baselines
+        if: ${{ github.event.inputs.update_visual_baselines == 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add playwright/typescript/tests/visual.spec.ts-snapshots/
+          if git diff --cached --quiet; then
+            echo "No baseline changes to commit"
+          else
+            git commit -m "Update Linux visual baselines [skip ci]"
+            git push
+          fi
       - name: Detect local act runner
         id: detect-act
         if: ${{ !cancelled() }}

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       update_visual_baselines:
-        description: 'Regenerate Linux visual baselines (--update-snapshots) and commit them back'
+        description: 'Regenerate Linux visual baselines for all 5 browser projects (--update-snapshots) and commit them back to the branch'
         type: boolean
         default: false
       ref:
@@ -21,13 +21,10 @@ jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
@@ -48,18 +45,12 @@ jobs:
         env:
           ORWELLSTAT_USER: ${{ secrets.ORWELLSTAT_USER }}
           ORWELLSTAT_PASSWORD: ${{ secrets.ORWELLSTAT_PASSWORD }}
-      - name: Commit updated visual baselines
+      - name: Upload updated baselines
         if: ${{ github.event.inputs.update_visual_baselines == 'true' }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add playwright/typescript/tests/visual.spec.ts-snapshots/
-          if git diff --cached --quiet; then
-            echo "No baseline changes to commit"
-          else
-            git commit -m "Update Linux visual baselines [skip ci]"
-            git push
-          fi
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-baselines-linux
+          path: playwright/typescript/tests/visual.spec.ts-snapshots/
       - name: Detect local act runner
         id: detect-act
         if: ${{ !cancelled() }}
@@ -73,3 +64,31 @@ jobs:
           name: playwright-report
           path: playwright/typescript/playwright-report/
           retention-days: 30
+
+  commit-baselines:
+    needs: test
+    if: ${{ github.event.inputs.update_visual_baselines == 'true' }}
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: visual-baselines-linux
+          path: playwright/typescript/tests/visual.spec.ts-snapshots/
+      - name: Commit updated visual baselines
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add playwright/typescript/tests/visual.spec.ts-snapshots/
+          if git diff --cached --quiet; then
+            echo "No baseline changes to commit"
+          else
+            git commit -m "Update Linux visual baselines [skip ci]"
+            git push origin HEAD:${{ github.event.inputs.ref }}
+          fi

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -11,7 +11,7 @@ on:
         type: boolean
         default: false
       ref:
-        description: 'Branch to run on (defaults to main)'
+        description: 'Branch to run on (defaults to triggering branch)'
         required: false
         default: ''
 env:
@@ -90,5 +90,5 @@ jobs:
             echo "No baseline changes to commit"
           else
             git commit -m "Update Linux visual baselines [skip ci]"
-            git push origin HEAD:${{ github.event.inputs.ref }}
+            git push origin HEAD:${{ github.event.inputs.ref || github.ref_name }}
           fi


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the Playwright CI workflow so Linux visual baselines can be regenerated on demand
- Reduces `timeout-minutes` from 60 to 30
- When triggered with `update_visual_baselines: true` and a `ref` input, checks out that branch, runs `--update-snapshots` for `visual.spec.ts`, and commits the `-linux` baseline PNGs back

## Usage
Actions → "Playwright Typescript Tests" → "Run workflow" → enter branch name in `ref`, check `update_visual_baselines` → Run

## Test plan
- [ ] Merge this PR
- [ ] Trigger workflow with `ref: feature/56`, `update_visual_baselines: true`
- [ ] Verify `-linux` baseline PNGs are committed to `feature/56`
- [ ] Verify CI passes on PR #74

Closes #58 