### PR TITLE
54 Add AI-powered test failure diagnosis using Claude Messages API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ ENV=
 # will silently send an empty password and all requests will return 401.
 BASIC_AUTH_USER=
 BASIC_AUTH_PASSWORD=
+# Optional: AI-powered test failure diagnosis.
+# Both vars must be set to enable. When either is absent the fixture behaves
+# exactly as without them — no extra attachments, no errors.
+# Set CLAUDE_DIAGNOSIS to exactly "true" (without quotes) to opt in.
+ANTHROPIC_API_KEY=
+CLAUDE_DIAGNOSIS=

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -49,7 +49,7 @@ jobs:
           ORWELLSTAT_USER: ${{ secrets.ORWELLSTAT_USER }}
           ORWELLSTAT_PASSWORD: ${{ secrets.ORWELLSTAT_PASSWORD }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_DIAGNOSIS: ${{ secrets.CLAUDE_DIAGNOSIS }}
+          CLAUDE_DIAGNOSIS: ${{ vars.CLAUDE_DIAGNOSIS }}
       - name: Upload updated baselines
         if: ${{ github.event.inputs.update_visual_baselines == 'true' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -48,6 +48,8 @@ jobs:
         env:
           ORWELLSTAT_USER: ${{ secrets.ORWELLSTAT_USER }}
           ORWELLSTAT_PASSWORD: ${{ secrets.ORWELLSTAT_PASSWORD }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_DIAGNOSIS: ${{ secrets.CLAUDE_DIAGNOSIS }}
       - name: Upload updated baselines
         if: ${{ github.event.inputs.update_visual_baselines == 'true' }}
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ For a full project overview, setup instructions, and commands see [README.md](RE
 
 ```
 .env                        # credentials (git-ignored); see .env.example
-.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD
+.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, CLAUDE_DIAGNOSIS
 .github/workflows/          # CI workflows (one per sub-project)
 SECURITY.md                 # security policy and vulnerability reporting
 playwright/
@@ -31,9 +31,11 @@ ORWELLSTAT_PASSWORD=<password>
 ENV=<production|staging>
 BASIC_AUTH_USER=<staging basic auth user>
 BASIC_AUTH_PASSWORD=<staging basic auth password>
+ANTHROPIC_API_KEY=<Anthropic API key>
+CLAUDE_DIAGNOSIS=true
 ```
 
-`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `ENV` selects the target environment for Playwright — accepted values are `production` (default) and `staging`; omitting it defaults to `production`. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed for staging — Playwright passes them as HTTP Basic Auth credentials when set. In CI all vars are injected as GitHub Actions secrets. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env`).
+`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed for staging — Playwright passes them as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` and `CLAUDE_DIAGNOSIS=true` are both optional — when both are present, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. In CI all vars are injected as GitHub Actions secrets. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env`).
 
 ---
 
@@ -64,7 +66,7 @@ All commands must be run from `playwright/typescript/`.
   - `authenticated/` — Authenticated page classes: `InformationPage`, `StatsPage`, `HitsPage`, `ScriptsPage`, `AdminPage`; exported via `index.ts` as `AUTHENTICATED_PAGE_CLASSES`
 - `fixtures/base.fixture.ts` — Custom Playwright fixture extending `test` with:
   - `authenticatedRequest` — logs in via POST `/zone/` before each test
-  - Captures browser console logs and XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure
+  - Captures browser console logs and XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure; when `ANTHROPIC_API_KEY` and `CLAUDE_DIAGNOSIS=true` are both set, also attaches an `AI diagnosis` generated via `claude-haiku-4-5`
   - Re-exports `expect`, `request`, `Page`, `Locator`, `BrowserContext` from `@playwright/test`
   - Re-exports `pixelmatch` and `PNG` (used for pixel-diff screenshot comparison)
 - `utils/accessibility.util.ts` — `expectNoAccessibilityViolations()` using `@axe-core/playwright` (WCAG2AAA)

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ ORWELLSTAT_PASSWORD=<password>
 ENV=<production|staging>
 BASIC_AUTH_USER=<staging basic auth user>
 BASIC_AUTH_PASSWORD=<staging basic auth password>
+ANTHROPIC_API_KEY=<Anthropic API key>
+CLAUDE_DIAGNOSIS=true
 ```
 
-`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `ENV` selects the target environment for Playwright — `production` (default) or `staging`; omitting it defaults to `production`. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. In CI, all vars are injected as GitHub Actions secrets.
+`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` and `CLAUDE_DIAGNOSIS=true` are both optional — when both are present, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. In CI, all vars are injected as GitHub Actions secrets.
 
 ---
 
@@ -116,7 +118,7 @@ npm run format:check
   - `authenticated/` — Authenticated page classes: `InformationPage`, `StatsPage`, `HitsPage`, `ScriptsPage`, `AdminPage`; exported via `index.ts` as `AUTHENTICATED_PAGE_CLASSES`
 - `fixtures/base.fixture.ts` — Custom Playwright fixture extending `test` with:
   - `authenticatedRequest` — logs in via POST `/zone/` before each test
-  - Captures browser console logs and XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure
+  - Captures browser console logs and XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure; when `ANTHROPIC_API_KEY` and `CLAUDE_DIAGNOSIS=true` are both set, also attaches an `AI diagnosis` generated via `claude-haiku-4-5`
   - Re-exports `expect`, `request`, `Page`, `Locator`, `BrowserContext` from `@playwright/test`
   - Re-exports `pixelmatch` and `PNG` (used for pixel-diff screenshot comparison)
 - `utils/accessibility.util.ts` — `expectNoAccessibilityViolations()` using `@axe-core/playwright` (WCAG2AAA)

--- a/playwright/typescript/fixtures/base.fixture.ts
+++ b/playwright/typescript/fixtures/base.fixture.ts
@@ -1,8 +1,11 @@
 import { test as base, expect, type APIRequestContext } from '@playwright/test';
 import { writeFileSync } from 'fs';
+import Anthropic from '@anthropic-ai/sdk';
 import { loadEnv, requireCredentials } from '@utils/env.util';
 
 loadEnv(import.meta.url, 3);
+
+const DOM_TRUNCATE_CHARS = 30_000;
 
 type OrwellStatFixtures = {
   authenticatedRequest: APIRequestContext;
@@ -36,12 +39,63 @@ export const test = base.extend<OrwellStatFixtures>({
         '<?xml version="1.0" encoding="UTF-8"?>',
         ...styleLinks.map((href) => `<?xml-stylesheet type="text/css" href="${href}"?>`),
       ].join('\n');
+      const domContent = xmlProlog + '\n' + (await page.content());
       const domPath = testInfo.outputPath('dom.xhtml');
-      writeFileSync(domPath, xmlProlog + '\n' + (await page.content()));
+      writeFileSync(domPath, domContent);
       await testInfo.attach('DOM', {
         path: domPath,
         contentType: 'text/html',
       });
+
+      const apiKey = process.env.ANTHROPIC_API_KEY;
+      const diagnosisEnabled = process.env.CLAUDE_DIAGNOSIS === 'true';
+      if (apiKey && diagnosisEnabled) {
+        try {
+          const anthropic = new Anthropic({ apiKey });
+          const domSnippet =
+            domContent.length > DOM_TRUNCATE_CHARS
+              ? domContent.slice(0, DOM_TRUNCATE_CHARS) + '\n...[truncated]'
+              : domContent;
+          const errorMessages = testInfo.errors
+            .map((e) => e.message ?? '')
+            .filter(Boolean)
+            .join('\n');
+          const response = await anthropic.messages.create({
+            model: 'claude-haiku-4-5',
+            max_tokens: 1024,
+            system:
+              'You are a test-failure analyst for a Playwright E2E suite. Given failed test metadata, browser console logs, and a DOM snapshot, produce a concise diagnosis: (1) most likely root cause, (2) what assertion probably failed and why, (3) one suggested fix.',
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  `Test: ${testInfo.title}`,
+                  `Project: ${testInfo.project.name}`,
+                  `Status: ${testInfo.status} (expected: ${testInfo.expectedStatus})`,
+                  `Errors:\n${errorMessages || '(none)'}`,
+                  '',
+                  '--- Console logs ---',
+                  logs.length > 0 ? logs.join('\n') : '(none)',
+                  '',
+                  '--- DOM snapshot (may be truncated) ---',
+                  domSnippet,
+                ].join('\n'),
+              },
+            ],
+          });
+          const diagnosis = response.content[0].type === 'text' ? response.content[0].text : '';
+          if (diagnosis) {
+            const diagPath = testInfo.outputPath('diagnosis.md');
+            writeFileSync(diagPath, diagnosis);
+            await testInfo.attach('AI diagnosis', {
+              path: diagPath,
+              contentType: 'text/plain',
+            });
+          }
+        } catch {
+          // Diagnosis is best-effort; never fail a test because of it
+        }
+      }
     }
   },
 

--- a/playwright/typescript/fixtures/base.fixture.ts
+++ b/playwright/typescript/fixtures/base.fixture.ts
@@ -83,7 +83,8 @@ export const test = base.extend<OrwellStatFixtures>({
               },
             ],
           });
-          const diagnosis = response.content[0].type === 'text' ? response.content[0].text : '';
+          const firstBlock = response.content[0];
+          const diagnosis = firstBlock?.type === 'text' ? firstBlock.text : '';
           if (diagnosis) {
             const diagPath = testInfo.outputPath('diagnosis.md');
             writeFileSync(diagPath, diagnosis);
@@ -92,8 +93,9 @@ export const test = base.extend<OrwellStatFixtures>({
               contentType: 'text/plain',
             });
           }
-        } catch {
+        } catch (err) {
           // Diagnosis is best-effort; never fail a test because of it
+          console.warn('[AI diagnosis] skipped:', err);
         }
       }
     }

--- a/playwright/typescript/package-lock.json
+++ b/playwright/typescript/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.58.2",
         "@types/node": "^25.5.0",
@@ -14,6 +15,27 @@
         "pngjs": "^7.0.0",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@axe-core/playwright": {
@@ -27,6 +49,16 @@
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -103,6 +135,20 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/pixelmatch": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
@@ -173,6 +219,13 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/playwright/typescript/package.json
+++ b/playwright/typescript/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
     "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary

- Adds `@anthropic-ai/sdk` as a dev dependency
- On test failure, calls `claude-haiku-4-5` with test metadata, console logs, and DOM snapshot; attaches the response as an `AI diagnosis` artifact in the Playwright report
- Feature is opt-in: both `ANTHROPIC_API_KEY` and `CLAUDE_DIAGNOSIS=true` must be set; API errors are swallowed so test results are never affected

## Test plan

- [x] `tsc --noEmit` passes
- [x] `npm run format:check` passes
- [x] Ran Chromium tests locally with `CLAUDE_DIAGNOSIS=true` — failing test produced an `AI diagnosis` attachment with accurate root cause, assertion analysis, and suggested fix
- [x] Passing tests produce no diagnosis attachment

Closes #54