### PR TITLE
Split base.fixture.ts: extract diagnosis.util.ts and api.fixture.ts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,15 +64,13 @@ All commands must be run from `playwright/typescript/`.
   - `common.ts` — Shared heading string constants (`NEWS`, `NEW_BROWSERS`, `NEW_OSES`) used by multiple page classes
   - `public/` — Public page classes: `HomePage`, `AboutSystemPage`, `ServiceStatisticsPage`, `ContactPage`, `RegisterPage`, `PasswordResetPage`, `PreviouslyAddedPage`; exported via `index.ts` as `PUBLIC_PAGE_CLASSES` (except `PreviouslyAddedPage`)
   - `authenticated/` — Authenticated page classes: `InformationPage`, `StatsPage`, `HitsPage`, `ScriptsPage`, `AdminPage`; exported via `index.ts` as `AUTHENTICATED_PAGE_CLASSES`
-- `fixtures/base.fixture.ts` — Custom Playwright fixture extending `test` with:
-  - `authenticatedRequest` — logs in via POST `/zone/` before each test
-  - Captures browser console logs and XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure; when `ANTHROPIC_API_KEY` and `CLAUDE_DIAGNOSIS=true` are both set, also attaches an `AI diagnosis` generated via `claude-haiku-4-5`
-  - Re-exports `expect`, `request`, `Page`, `Locator`, `BrowserContext` from `@playwright/test`
-  - Re-exports `pixelmatch` and `PNG` (used for pixel-diff screenshot comparison)
+- `fixtures/base.fixture.ts` — Custom Playwright fixture extending `test` with a `page` override that captures browser console logs and an XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure, then calls `attachAiDiagnosis()`; re-exports `expect`, `request`, `Page`, `Locator`, `BrowserContext` from `@playwright/test`; re-exports `pixelmatch` and `PNG` (used for pixel-diff screenshot comparison)
+- `fixtures/api.fixture.ts` — Extends `base.fixture.ts` with HTTP request fixtures: `unauthenticatedRequest` (plain context) and `authenticatedRequest` (logs in via POST `/zone/`); import from here in tests that use either fixture
 - `utils/accessibility.util.ts` — `expectNoAccessibilityViolations()` using `@axe-core/playwright` (WCAG2AAA)
 - `utils/string.util.ts` — `expectHeadings()` helper: asserts visibility of multiple headings on a page
 - `utils/env.util.ts` — `loadEnv(importMetaUrl, levelsUp)` loads `.env` relative to the calling file; `requireCredentials()` validates and returns `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD`, throwing a descriptive error if either is missing
 - `utils/validation.util.ts` — `expectValidXhtml(request, xhtml)` POSTs raw markup to the classic W3C Markup Validation Service (`validator.w3.org/check`) and asserts no errors (correct for XHTML 1.0 Strict; Nu is HTML5-only and gives false positives); `expectValidCss(request, cssUrl)` queries W3C CSS validator by URI and asserts zero errors
+- `utils/diagnosis.util.ts` — `attachAiDiagnosis(testInfo, logs, domContent)`: calls the Anthropic API (`claude-haiku-4-5`) to produce a diagnosis attachment on test failure; no-ops when `ANTHROPIC_API_KEY` or `CLAUDE_DIAGNOSIS=true` are absent; errors are caught and warned so diagnosis never fails a test
 - `types/` — Shared TypeScript interfaces; exported via path alias `@types-local/*`
   - `svg-analysis.ts` — `SvgAnalysis` interface: shape of the object returned by `page.evaluate()` in `statistics.spec.ts`
   - `statistics-row.ts` — `StatisticsRow` interface: shape of each data row returned by the bulk `page.evaluate()` in `statistics.spec.ts`
@@ -111,7 +109,7 @@ All commands must be run from `playwright/typescript/`.
 Before committing changes to `playwright/typescript`, review against these criteria:
 
 - **Playwright test correctness** — selectors use `getByRole()` / `getByText()` with `exact: true`; no CSS class selectors; no `waitForTimeout()`; count asserted before `.nth()`; no `.first()` silencing missing elements; assertions are specific and meaningful (not just `toBeTruthy()`)
-- **Fixture usage** — custom fixtures from `base.fixture.ts` used where appropriate; `authenticatedRequest` used for authenticated API tests; no manual login logic duplicated outside `auth.setup.ts`; imports come from `@fixtures/base.fixture` (not directly from `@playwright/test`)
+- **Fixture usage** — custom fixtures from `base.fixture.ts` used where appropriate; tests using `authenticatedRequest` or `unauthenticatedRequest` import from `@fixtures/api.fixture` (not `@fixtures/base.fixture`); no manual login logic duplicated outside `auth.setup.ts`; imports never come directly from `@playwright/test`
 - **Page Object Model conventions** — page classes extend `AbstractPage`; `heading` getter uses `getByRole('heading', { name: ..., exact: true })`; static `url`, `title`, `accessKey` defined; no page-specific logic leaking into test files
 - **TypeScript quality** — no `!` non-null assertions on env vars; `page.evaluate()` calls have explicit generic type; no implicit `any`; no unused imports; path aliases used instead of relative imports (`@fixtures/*`, `@pages/*`, `@utils/*`, `@test-data/*`, `@types-local/*`); `tsc --noEmit` passes
 - **Potential bugs** — async/await not missing on Playwright calls; no unhandled promise rejections; locators not reused across navigations; any file reading `process.env` credentials calls `loadEnv(import.meta.url, N)` at module top level (missing this passes on CI but fails locally)

--- a/README.md
+++ b/README.md
@@ -116,15 +116,13 @@ npm run format:check
   - `common.ts` — Shared heading string constants (`NEWS`, `NEW_BROWSERS`, `NEW_OSES`) used by multiple page classes
   - `public/` — Public page classes: `HomePage`, `AboutSystemPage`, `ServiceStatisticsPage`, `ContactPage`, `RegisterPage`, `PasswordResetPage`, `PreviouslyAddedPage`; exported via `index.ts` as `PUBLIC_PAGE_CLASSES` (except `PreviouslyAddedPage`)
   - `authenticated/` — Authenticated page classes: `InformationPage`, `StatsPage`, `HitsPage`, `ScriptsPage`, `AdminPage`; exported via `index.ts` as `AUTHENTICATED_PAGE_CLASSES`
-- `fixtures/base.fixture.ts` — Custom Playwright fixture extending `test` with:
-  - `authenticatedRequest` — logs in via POST `/zone/` before each test
-  - Captures browser console logs and XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure; when `ANTHROPIC_API_KEY` and `CLAUDE_DIAGNOSIS=true` are both set, also attaches an `AI diagnosis` generated via `claude-haiku-4-5`
-  - Re-exports `expect`, `request`, `Page`, `Locator`, `BrowserContext` from `@playwright/test`
-  - Re-exports `pixelmatch` and `PNG` (used for pixel-diff screenshot comparison)
+- `fixtures/base.fixture.ts` — Custom Playwright fixture extending `test` with a `page` override that captures browser console logs and an XHTML DOM snapshot (`dom.xhtml` with XML declaration and `<?xml-stylesheet?>` PIs) as attachments on test failure, then calls `attachAiDiagnosis()`; re-exports `expect`, `request`, `Page`, `Locator`, `BrowserContext` from `@playwright/test`; re-exports `pixelmatch` and `PNG` (used for pixel-diff screenshot comparison)
+- `fixtures/api.fixture.ts` — Extends `base.fixture.ts` with HTTP request fixtures: `unauthenticatedRequest` (plain context) and `authenticatedRequest` (logs in via POST `/zone/`); import from here in tests that use either fixture
 - `utils/accessibility.util.ts` — `expectNoAccessibilityViolations()` using `@axe-core/playwright` (WCAG2AAA)
 - `utils/string.util.ts` — `expectHeadings()` helper: asserts visibility of multiple headings on a page
 - `utils/validation.util.ts` — `expectValidXhtml(request, xhtml)` POSTs raw markup to the classic W3C Markup Validation Service (`validator.w3.org/check`) and asserts no errors (correct for XHTML 1.0 Strict; Nu is HTML5-only and gives false positives); `expectValidCss(request, cssUrl)` queries W3C CSS validator by URI and asserts zero errors
 - `utils/env.util.ts` — `loadEnv(importMetaUrl, levelsUp)` loads `.env` relative to the calling file; `requireCredentials()` validates and returns `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD`
+- `utils/diagnosis.util.ts` — `attachAiDiagnosis(testInfo, logs, domContent)`: calls the Anthropic API (`claude-haiku-4-5`) to produce a diagnosis attachment on test failure; no-ops when `ANTHROPIC_API_KEY` or `CLAUDE_DIAGNOSIS=true` are absent
 - `types/` — Shared TypeScript interfaces; exported via path alias `@types-local/*`
   - `svg-analysis.ts` — `SvgAnalysis` interface: shape of the object returned by `page.evaluate()` in `statistics.spec.ts`
   - `statistics-row.ts` — `StatisticsRow` interface: shape of each data row returned by the bulk `page.evaluate()` in `statistics.spec.ts`

--- a/playwright/typescript/fixtures/api.fixture.ts
+++ b/playwright/typescript/fixtures/api.fixture.ts
@@ -1,0 +1,30 @@
+import { expect, type APIRequestContext } from '@playwright/test';
+import { test as base } from '@fixtures/base.fixture';
+import { requireCredentials } from '@utils/env.util';
+
+type ApiFixtures = {
+  authenticatedRequest: APIRequestContext;
+  unauthenticatedRequest: APIRequestContext;
+};
+
+export const test = base.extend<ApiFixtures>({
+  unauthenticatedRequest: async ({ playwright, baseURL }, use) => {
+    const ctx = await playwright.request.newContext({ baseURL });
+    await use(ctx);
+    await ctx.dispose();
+  },
+
+  authenticatedRequest: async ({ request }, use) => {
+    const { user, password } = requireCredentials();
+    const response = await request.post('/zone/', {
+      form: {
+        username: user,
+        password: password,
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+    await use(request);
+  },
+});
+
+export { expect, type APIRequestContext } from '@playwright/test';

--- a/playwright/typescript/fixtures/api.fixture.ts
+++ b/playwright/typescript/fixtures/api.fixture.ts
@@ -22,9 +22,9 @@ export const test = base.extend<ApiFixtures>({
         password: password,
       },
     });
-    expect(response.ok()).toBeTruthy();
+    expect(response.status()).toBe(200);
     await use(request);
   },
 });
 
-export { expect, type APIRequestContext } from '@playwright/test';
+export { expect, type APIRequestContext } from '@fixtures/base.fixture';

--- a/playwright/typescript/fixtures/base.fixture.ts
+++ b/playwright/typescript/fixtures/base.fixture.ts
@@ -1,18 +1,35 @@
-import { test as base, expect, type APIRequestContext } from '@playwright/test';
+import { test as base, type Page, type TestInfo } from '@playwright/test';
 import { writeFileSync } from 'fs';
-import Anthropic from '@anthropic-ai/sdk';
-import { loadEnv, requireCredentials } from '@utils/env.util';
+import { loadEnv } from '@utils/env.util';
+import { attachAiDiagnosis } from '@utils/diagnosis.util';
 
 loadEnv(import.meta.url, 3);
 
-const DOM_TRUNCATE_CHARS = 30_000;
+async function attachConsoleLogs(testInfo: TestInfo, logs: string[]): Promise<void> {
+  if (logs.length === 0) return;
+  const logPath = testInfo.outputPath('console.log');
+  writeFileSync(logPath, logs.join('\n'));
+  await testInfo.attach('console logs', { path: logPath, contentType: 'text/plain' });
+}
 
-type OrwellStatFixtures = {
-  authenticatedRequest: APIRequestContext;
-  unauthenticatedRequest: APIRequestContext;
-};
+async function attachDomSnapshot(page: Page, testInfo: TestInfo): Promise<string> {
+  const styleLinks = await page.evaluate<string[]>(() =>
+    Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'))
+      .map((l) => l.getAttribute('href'))
+      .filter((href): href is string => href !== null)
+  );
+  const xmlProlog = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    ...styleLinks.map((href) => `<?xml-stylesheet type="text/css" href="${href}"?>`),
+  ].join('\n');
+  const domContent = xmlProlog + '\n' + (await page.content());
+  const domPath = testInfo.outputPath('dom.xhtml');
+  writeFileSync(domPath, domContent);
+  await testInfo.attach('DOM', { path: domPath, contentType: 'text/html' });
+  return domContent;
+}
 
-export const test = base.extend<OrwellStatFixtures>({
+export const test = base.extend({
   page: async ({ page }, use, testInfo) => {
     const logs: string[] = [];
     page.on('console', (msg) => logs.push(`[${msg.type()}] ${msg.text()}`));
@@ -21,102 +38,10 @@ export const test = base.extend<OrwellStatFixtures>({
     await use(page);
 
     if (testInfo.status !== testInfo.expectedStatus) {
-      if (logs.length > 0) {
-        const logPath = testInfo.outputPath('console.log');
-        writeFileSync(logPath, logs.join('\n'));
-        await testInfo.attach('console logs', {
-          path: logPath,
-          contentType: 'text/plain',
-        });
-      }
-
-      const styleLinks = await page.evaluate<string[]>(() =>
-        Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'))
-          .map((l) => l.getAttribute('href'))
-          .filter((href): href is string => href !== null)
-      );
-      const xmlProlog = [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        ...styleLinks.map((href) => `<?xml-stylesheet type="text/css" href="${href}"?>`),
-      ].join('\n');
-      const domContent = xmlProlog + '\n' + (await page.content());
-      const domPath = testInfo.outputPath('dom.xhtml');
-      writeFileSync(domPath, domContent);
-      await testInfo.attach('DOM', {
-        path: domPath,
-        contentType: 'text/html',
-      });
-
-      const apiKey = process.env.ANTHROPIC_API_KEY;
-      const diagnosisEnabled = process.env.CLAUDE_DIAGNOSIS === 'true';
-      if (apiKey && diagnosisEnabled) {
-        try {
-          const anthropic = new Anthropic({ apiKey });
-          const domSnippet =
-            domContent.length > DOM_TRUNCATE_CHARS
-              ? domContent.slice(0, DOM_TRUNCATE_CHARS) + '\n...[truncated]'
-              : domContent;
-          const errorMessages = testInfo.errors
-            .map((e) => e.message ?? '')
-            .filter(Boolean)
-            .join('\n');
-          const response = await anthropic.messages.create({
-            model: 'claude-haiku-4-5',
-            max_tokens: 1024,
-            system:
-              'You are a test-failure analyst for a Playwright E2E suite. Given failed test metadata, browser console logs, and a DOM snapshot, produce a concise diagnosis: (1) most likely root cause, (2) what assertion probably failed and why, (3) one suggested fix.',
-            messages: [
-              {
-                role: 'user',
-                content: [
-                  `Test: ${testInfo.title}`,
-                  `Project: ${testInfo.project.name}`,
-                  `Status: ${testInfo.status} (expected: ${testInfo.expectedStatus})`,
-                  `Errors:\n${errorMessages || '(none)'}`,
-                  '',
-                  '--- Console logs ---',
-                  logs.length > 0 ? logs.join('\n') : '(none)',
-                  '',
-                  '--- DOM snapshot (may be truncated) ---',
-                  domSnippet,
-                ].join('\n'),
-              },
-            ],
-          });
-          const firstBlock = response.content[0];
-          const diagnosis = firstBlock?.type === 'text' ? firstBlock.text : '';
-          if (diagnosis) {
-            const diagPath = testInfo.outputPath('diagnosis.md');
-            writeFileSync(diagPath, diagnosis);
-            await testInfo.attach('AI diagnosis', {
-              path: diagPath,
-              contentType: 'text/plain',
-            });
-          }
-        } catch (err) {
-          // Diagnosis is best-effort; never fail a test because of it
-          console.warn('[AI diagnosis] skipped:', err);
-        }
-      }
+      await attachConsoleLogs(testInfo, logs);
+      const domContent = await attachDomSnapshot(page, testInfo);
+      await attachAiDiagnosis(testInfo, logs, domContent);
     }
-  },
-
-  unauthenticatedRequest: async ({ playwright, baseURL }, use) => {
-    const ctx = await playwright.request.newContext({ baseURL });
-    await use(ctx);
-    await ctx.dispose();
-  },
-
-  authenticatedRequest: async ({ request }, use) => {
-    const { user, password } = requireCredentials();
-    const response = await request.post('/zone/', {
-      form: {
-        username: user,
-        password: password,
-      },
-    });
-    expect(response.ok()).toBeTruthy();
-    await use(request);
   },
 });
 

--- a/playwright/typescript/tests/api.spec.ts
+++ b/playwright/typescript/tests/api.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@fixtures/base.fixture';
+import { test, expect } from '@fixtures/api.fixture';
 import { PUBLIC_PAGE_CLASSES } from '@pages/public/index';
 import { AUTHENTICATED_PAGE_CLASSES } from '@pages/authenticated/index';
 

--- a/playwright/typescript/tests/validation.spec.ts
+++ b/playwright/typescript/tests/validation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@fixtures/base.fixture';
+import { test, expect } from '@fixtures/api.fixture';
 import { expectValidXhtml, expectValidCss } from '@utils/validation.util';
 import { PUBLIC_PAGE_CLASSES } from '@pages/public/index';
 import { AUTHENTICATED_PAGE_CLASSES } from '@pages/authenticated/index';

--- a/playwright/typescript/utils/diagnosis.util.ts
+++ b/playwright/typescript/utils/diagnosis.util.ts
@@ -1,0 +1,63 @@
+import { writeFileSync } from 'fs';
+import Anthropic from '@anthropic-ai/sdk';
+import type { TestInfo } from '@playwright/test';
+
+const DOM_TRUNCATE_CHARS = 30_000;
+
+export async function attachAiDiagnosis(
+  testInfo: TestInfo,
+  logs: string[],
+  domContent: string
+): Promise<void> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const diagnosisEnabled = process.env.CLAUDE_DIAGNOSIS === 'true';
+  if (!apiKey || !diagnosisEnabled) return;
+
+  try {
+    const anthropic = new Anthropic({ apiKey });
+    const domSnippet =
+      domContent.length > DOM_TRUNCATE_CHARS
+        ? domContent.slice(0, DOM_TRUNCATE_CHARS) + '\n...[truncated]'
+        : domContent;
+    const errorMessages = testInfo.errors
+      .map((e) => e.message ?? '')
+      .filter(Boolean)
+      .join('\n');
+    const response = await anthropic.messages.create({
+      model: 'claude-haiku-4-5',
+      max_tokens: 1024,
+      system:
+        'You are a test-failure analyst for a Playwright E2E suite. Given failed test metadata, browser console logs, and a DOM snapshot, produce a concise diagnosis: (1) most likely root cause, (2) what assertion probably failed and why, (3) one suggested fix.',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            `Test: ${testInfo.title}`,
+            `Project: ${testInfo.project.name}`,
+            `Status: ${testInfo.status} (expected: ${testInfo.expectedStatus})`,
+            `Errors:\n${errorMessages || '(none)'}`,
+            '',
+            '--- Console logs ---',
+            logs.length > 0 ? logs.join('\n') : '(none)',
+            '',
+            '--- DOM snapshot (may be truncated) ---',
+            domSnippet,
+          ].join('\n'),
+        },
+      ],
+    });
+    const firstBlock = response.content[0];
+    const diagnosis = firstBlock?.type === 'text' ? firstBlock.text : '';
+    if (diagnosis) {
+      const diagPath = testInfo.outputPath('diagnosis.md');
+      writeFileSync(diagPath, diagnosis);
+      await testInfo.attach('AI diagnosis', {
+        path: diagPath,
+        contentType: 'text/plain',
+      });
+    }
+  } catch (err) {
+    // Diagnosis is best-effort; never fail a test because of it
+    console.warn('[AI diagnosis] skipped:', err);
+  }
+}


### PR DESCRIPTION
## Summary

- Extracted AI diagnosis logic into `utils/diagnosis.util.ts` (`attachAiDiagnosis`)
- Moved HTTP request fixtures (`unauthenticatedRequest`, `authenticatedRequest`) into `fixtures/api.fixture.ts`, which extends `base.fixture.ts`
- Refactored `base.fixture.ts` `page` override into three focused helper calls: `attachConsoleLogs`, `attachDomSnapshot`, `attachAiDiagnosis`
- Updated `api.spec.ts` and `validation.spec.ts` to import from `@fixtures/api.fixture`

## Test plan

- [x] `tsc --noEmit` passes
- [x] `npm run format` — no changes
- [x] `navigation.spec.ts` and `api.spec.ts` pass on Chromium

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)