### PR TITLE
Add test.step() to statistics and about-system specs

### DIFF
--- a/playwright/typescript/tests/about-system.spec.ts
+++ b/playwright/typescript/tests/about-system.spec.ts
@@ -3,71 +3,80 @@ import { AboutSystemPage } from '@pages/public/about-system.page';
 import { expectHeadings } from '@utils/string.util';
 
 test('about system page - headings and statsbar content', async ({ page }) => {
-  await page.goto(AboutSystemPage.url);
+  await test.step('navigate to page', async () => {
+    await page.goto(AboutSystemPage.url);
+  });
 
   const statsbar = page.locator('#statsbar');
 
-  await expectHeadings(page, [
-    AboutSystemPage.signIn,
-    AboutSystemPage.whatIsOrwellStat,
-    AboutSystemPage.whatDataIsCollected,
-    AboutSystemPage.browsersAndApps,
-    AboutSystemPage.operatingSystems,
-    AboutSystemPage.requirements,
-    AboutSystemPage.minimalRequirements,
-    AboutSystemPage.recommended,
-  ]);
+  await test.step('verify headings', async () => {
+    await expectHeadings(page, [
+      AboutSystemPage.signIn,
+      AboutSystemPage.whatIsOrwellStat,
+      AboutSystemPage.whatDataIsCollected,
+      AboutSystemPage.browsersAndApps,
+      AboutSystemPage.operatingSystems,
+      AboutSystemPage.requirements,
+      AboutSystemPage.minimalRequirements,
+      AboutSystemPage.recommended,
+    ]);
+  });
 
-  // Login section – authenticated state shows logout button
-  await expect(statsbar.getByText(AboutSystemPage.loggedInAs, { exact: false })).toBeVisible();
-  await expect(
-    statsbar.getByRole('button', { name: AboutSystemPage.logoutButton, exact: true })
-  ).toBeVisible();
+  await test.step('verify statsbar login section', async () => {
+    await expect(statsbar.getByText(AboutSystemPage.loggedInAs, { exact: false })).toBeVisible();
+    await expect(
+      statsbar.getByRole('button', { name: AboutSystemPage.logoutButton, exact: true })
+    ).toBeVisible();
+  });
 
-  // "Co to jest Orwell Stat?" – text and external links
-  await expect(statsbar.getByText(AboutSystemPage.orwellStatIntro, { exact: false })).toBeVisible();
-  await expect(
-    statsbar.getByRole('link', { name: AboutSystemPage.wsbNlu.name, exact: true })
-  ).toHaveAttribute('href', AboutSystemPage.wsbNlu.href);
-  await expect(
-    statsbar.getByRole('link', { name: AboutSystemPage.hubertGajewski.name, exact: true })
-  ).toHaveAttribute('href', AboutSystemPage.hubertGajewski.href);
-  await expect(
-    statsbar.getByRole('link', { name: AboutSystemPage.tomaszGorazd.name, exact: true })
-  ).toHaveAttribute('href', AboutSystemPage.tomaszGorazd.href);
+  await test.step('verify intro and external links', async () => {
+    await expect(
+      statsbar.getByText(AboutSystemPage.orwellStatIntro, { exact: false })
+    ).toBeVisible();
+    await expect(
+      statsbar.getByRole('link', { name: AboutSystemPage.wsbNlu.name, exact: true })
+    ).toHaveAttribute('href', AboutSystemPage.wsbNlu.href);
+    await expect(
+      statsbar.getByRole('link', { name: AboutSystemPage.hubertGajewski.name, exact: true })
+    ).toHaveAttribute('href', AboutSystemPage.hubertGajewski.href);
+    await expect(
+      statsbar.getByRole('link', { name: AboutSystemPage.tomaszGorazd.name, exact: true })
+    ).toHaveAttribute('href', AboutSystemPage.tomaszGorazd.href);
+  });
 
-  // "Jakie dane rejestruje system?" – browser/OS counts
-  await expect(statsbar.getByText(AboutSystemPage.browserCount, { exact: false })).toBeVisible();
-  await expect(statsbar.getByText(AboutSystemPage.osCount, { exact: false })).toBeVisible();
+  await test.step('verify browser and OS counts and lists', async () => {
+    await expect(statsbar.getByText(AboutSystemPage.browserCount, { exact: false })).toBeVisible();
+    await expect(statsbar.getByText(AboutSystemPage.osCount, { exact: false })).toBeVisible();
 
-  // Sample browser names in the list
-  for (const browser of AboutSystemPage.sampleBrowsers) {
-    await expect(statsbar.getByRole('listitem').getByText(browser, { exact: true })).toBeVisible();
-  }
+    for (const browser of AboutSystemPage.sampleBrowsers) {
+      await expect(
+        statsbar.getByRole('listitem').getByText(browser, { exact: true })
+      ).toBeVisible();
+    }
 
-  // Sample OS names in the list
-  for (const os of AboutSystemPage.sampleOSes) {
-    await expect(statsbar.getByRole('listitem').getByText(os, { exact: true })).toBeVisible();
-  }
+    for (const os of AboutSystemPage.sampleOSes) {
+      await expect(statsbar.getByRole('listitem').getByText(os, { exact: true })).toBeVisible();
+    }
+  });
 
-  // "Wymagania" – images with alt text
-  for (const screenshot of Object.values(AboutSystemPage.screenshots)) {
-    await expect(statsbar.locator(`img[src="${screenshot.src}"]`)).toHaveAttribute(
-      'alt',
-      screenshot.alt
-    );
-  }
+  await test.step('verify requirements screenshots', async () => {
+    for (const screenshot of Object.values(AboutSystemPage.screenshots)) {
+      await expect(statsbar.locator(`img[src="${screenshot.src}"]`)).toHaveAttribute(
+        'alt',
+        screenshot.alt
+      );
+    }
+  });
 
-  // "Zalecane" section – Adobe SVG Viewer link
-  await expect(
-    statsbar.getByRole('link', { name: AboutSystemPage.adobeSvgViewer.name, exact: true })
-  ).toHaveAttribute('href', AboutSystemPage.adobeSvgViewer.href);
-
-  // Minimum requirements – key text fragments
-  await expect(
-    statsbar.getByText(AboutSystemPage.vgaRequirementText, { exact: false })
-  ).toBeVisible();
-  await expect(
-    statsbar.getByText(AboutSystemPage.hdRequirementText, { exact: false })
-  ).toBeVisible();
+  await test.step('verify requirements text', async () => {
+    await expect(
+      statsbar.getByRole('link', { name: AboutSystemPage.adobeSvgViewer.name, exact: true })
+    ).toHaveAttribute('href', AboutSystemPage.adobeSvgViewer.href);
+    await expect(
+      statsbar.getByText(AboutSystemPage.vgaRequirementText, { exact: false })
+    ).toBeVisible();
+    await expect(
+      statsbar.getByText(AboutSystemPage.hdRequirementText, { exact: false })
+    ).toBeVisible();
+  });
 });

--- a/playwright/typescript/tests/statistics.spec.ts
+++ b/playwright/typescript/tests/statistics.spec.ts
@@ -5,150 +5,172 @@ import { SvgAnalysis } from '@types-local/svg-analysis';
 import { StatisticsRow } from '@types-local/statistics-row';
 
 test('SVG chart is rendered on stats page', async ({ page }) => {
-  // Firefox does not cache Basic Auth credentials for <object> sub-resources on staging.
-  // Pre-navigate to chart_all.php so Firefox caches the credentials before the <object> loads it.
-  if (process.env.BASIC_AUTH_USER) {
-    const preAuthResponse = await page.goto(ServiceStatisticsPage.svgChartPreAuthUrl);
-    expect(preAuthResponse?.status()).toBe(200);
-  }
+  const svgResponse = await test.step('navigate and wait for chart', async () => {
+    // Firefox does not cache Basic Auth credentials for <object> sub-resources on staging.
+    // Pre-navigate to chart_all.php so Firefox caches the credentials before the <object> loads it.
+    if (process.env.BASIC_AUTH_USER) {
+      const preAuthResponse = await page.goto(ServiceStatisticsPage.svgChartPreAuthUrl);
+      expect(preAuthResponse?.status()).toBe(200);
+    }
 
-  const [svgResponse] = await Promise.all([
-    page.waitForResponse((response) => response.url().includes(ServiceStatisticsPage.svgChartUrl)),
-    page.goto(ServiceStatisticsPage.url),
-  ]);
-  expect(svgResponse.status()).toBe(200);
-  expect(svgResponse.headers()['content-type']).toContain('svg');
+    const [response] = await Promise.all([
+      page.waitForResponse((response) =>
+        response.url().includes(ServiceStatisticsPage.svgChartUrl)
+      ),
+      page.goto(ServiceStatisticsPage.url),
+    ]);
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('svg');
 
-  await expect(page.locator('object[type="image/svg+xml"]')).toBeVisible();
+    await expect(page.locator('object[type="image/svg+xml"]')).toBeVisible();
 
-  // Verify SVG animation is running by diffing two consecutive frames
-  const frame1 = await page.locator('object[type="image/svg+xml"]').screenshot();
-  await page.evaluate(
-    () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
-  );
-  const frame2 = await page.locator('object[type="image/svg+xml"]').screenshot();
-  expect(frame1).not.toEqual(frame2);
-
-  const img1 = PNG.sync.read(frame1);
-  const img2 = PNG.sync.read(frame2);
-  const { width, height } = img1;
-  const diff = new Uint8Array(width * height * 4);
-  const diffPixels = pixelmatch(img1.data, img2.data, diff, width, height, {
-    threshold: 0.1,
+    return response;
   });
 
-  expect(diffPixels).toBeGreaterThan(100);
+  await test.step('verify chart animation', async () => {
+    const frame1 = await page.locator('object[type="image/svg+xml"]').screenshot();
+    await page.evaluate(
+      () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    );
+    const frame2 = await page.locator('object[type="image/svg+xml"]').screenshot();
+    expect(frame1).not.toEqual(frame2);
 
-  // Parse SVG DOM in-browser to verify animation structure
-  const svgContent = await svgResponse.text();
+    const img1 = PNG.sync.read(frame1);
+    const img2 = PNG.sync.read(frame2);
+    const { width, height } = img1;
+    const diff = new Uint8Array(width * height * 4);
+    const diffPixels = pixelmatch(img1.data, img2.data, diff, width, height, {
+      threshold: 0.1,
+    });
 
-  const svgDom = await page.evaluate<SvgAnalysis, string>((svg) => {
-    const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
-    return {
-      animateInRectCount: doc.querySelectorAll('rect > animate').length,
-      animateInTextCount: doc.querySelectorAll('text > animate').length,
-      hasWidthAnimation: doc.querySelector('animate[attributeName="width"]') !== null,
-      hasVisibilityAnimation: doc.querySelector('animate[attributeName="visibility"]') !== null,
-      rectAnimateTiming: (() => {
-        const el = doc.querySelector('rect > animate');
-        return el ? { begin: el.getAttribute('begin'), dur: el.getAttribute('dur') } : null;
-      })(),
-      textAnimateTiming: (() => {
-        const el = doc.querySelector('text > animate');
-        return el ? { begin: el.getAttribute('begin'), dur: el.getAttribute('dur') } : null;
-      })(),
-      browsers: Array.from(doc.querySelectorAll('text'))
-        .map((el) => el.textContent?.trim())
-        .filter((t) => t && !t.includes('%')),
-    };
-  }, svgContent);
+    expect(diffPixels).toBeGreaterThan(100);
+  });
 
-  expect(svgDom.animateInRectCount).toBe(10);
-  expect(svgDom.animateInTextCount).toBe(10);
-  expect(svgDom.hasWidthAnimation).toBe(true);
-  expect(svgDom.hasVisibilityAnimation).toBe(true);
-  expect(svgDom.rectAnimateTiming).toEqual({ begin: '0s', dur: '1s' });
-  expect(svgDom.textAnimateTiming).toEqual({ begin: '1s', dur: '1s' });
-  expect(svgDom.browsers).toEqual(
-    expect.arrayContaining([expect.stringMatching(/Chrome|Firefox|Safari/)])
-  );
+  await test.step('analyze SVG structure', async () => {
+    // Parse SVG DOM in-browser to verify animation structure
+    const svgContent = await svgResponse.text();
+
+    const svgDom = await page.evaluate<SvgAnalysis, string>((svg) => {
+      const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+      return {
+        animateInRectCount: doc.querySelectorAll('rect > animate').length,
+        animateInTextCount: doc.querySelectorAll('text > animate').length,
+        hasWidthAnimation: doc.querySelector('animate[attributeName="width"]') !== null,
+        hasVisibilityAnimation: doc.querySelector('animate[attributeName="visibility"]') !== null,
+        rectAnimateTiming: (() => {
+          const el = doc.querySelector('rect > animate');
+          return el ? { begin: el.getAttribute('begin'), dur: el.getAttribute('dur') } : null;
+        })(),
+        textAnimateTiming: (() => {
+          const el = doc.querySelector('text > animate');
+          return el ? { begin: el.getAttribute('begin'), dur: el.getAttribute('dur') } : null;
+        })(),
+        browsers: Array.from(doc.querySelectorAll('text'))
+          .map((el) => el.textContent?.trim())
+          .filter((t) => t && !t.includes('%')),
+      };
+    }, svgContent);
+
+    expect(svgDom.animateInRectCount).toBe(10);
+    expect(svgDom.animateInTextCount).toBe(10);
+    expect(svgDom.hasWidthAnimation).toBe(true);
+    expect(svgDom.hasVisibilityAnimation).toBe(true);
+    expect(svgDom.rectAnimateTiming).toEqual({ begin: '0s', dur: '1s' });
+    expect(svgDom.textAnimateTiming).toEqual({ begin: '1s', dur: '1s' });
+    expect(svgDom.browsers).toEqual(
+      expect.arrayContaining([expect.stringMatching(/Chrome|Firefox|Safari/)])
+    );
+  });
 });
 
 test('system statistics', async ({ page }) => {
-  await page.goto(ServiceStatisticsPage.url);
-
-  await expectHeadings(page, [ServiceStatisticsPage.statistics, ServiceStatisticsPage.signIn]);
-
-  await expect(
-    page.getByRole('columnheader', {
-      name: ServiceStatisticsPage.colLp,
-      exact: true,
-    })
-  ).toBeVisible();
-  await expect(
-    page.getByRole('columnheader', {
-      name: ServiceStatisticsPage.colBrowsers,
-      exact: true,
-    })
-  ).toBeVisible();
-  await expect(
-    page.getByRole('columnheader', {
-      name: ServiceStatisticsPage.colCount,
-      exact: true,
-    })
-  ).toBeVisible();
-  await expect(
-    page.getByRole('columnheader', {
-      name: ServiceStatisticsPage.colPercent,
-      exact: true,
-    })
-  ).toBeVisible();
-
-  const rows = page.getByRole('table').first().getByRole('row');
-  const rowCount = await rows.count();
-  expect(rowCount).toBeGreaterThan(0);
-
-  // Read all data rows in one browser round-trip to avoid 246+ sequential awaits timing out
-  const dataRows = await page.evaluate<StatisticsRow[]>(() => {
-    const table = document.querySelector('table');
-    return table
-      ? Array.from(table.rows)
-          .slice(1, -3)
-          .map((row) => ({
-            lp: row.cells[0]?.textContent?.trim() ?? '',
-            count: row.cells[2]?.textContent?.trim() ?? '',
-            percent: row.cells[3]?.textContent?.trim() ?? '',
-          }))
-      : [];
+  await test.step('navigate to page', async () => {
+    await page.goto(ServiceStatisticsPage.url);
   });
-  expect(dataRows).toHaveLength(rowCount - 4); // 1 header row + 3 footer rows
-  for (let i = 0; i < dataRows.length; i++) {
-    expect(dataRows[i].lp, `row ${i + 1}: lp`).toBe(String(i + 1));
-    expect(dataRows[i].count, `row ${i + 1}: count`).toMatch(/^\d+$/);
-    expect(dataRows[i].percent, `row ${i + 1}: percent`).toMatch(/^\d+\.\d{2}%$/);
-  }
 
-  // Structural check: the table ends with exactly these 3 footer rows in order
-  await expect(rows.nth(rowCount - 3)).toContainText(ServiceStatisticsPage.totalRecognized);
-  await expect(rows.nth(rowCount - 2)).toContainText(ServiceStatisticsPage.unrecognized);
-  await expect(rows.last()).toContainText(ServiceStatisticsPage.total);
-
-  // Verify footer row values (count and percent) – located by content, not by index
-  const totalRecognized = rows.filter({ hasText: ServiceStatisticsPage.totalRecognized });
-  await expect(totalRecognized).toHaveCount(1);
-  await expect(totalRecognized.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
-  await expect(totalRecognized.getByRole('cell').nth(3)).toHaveText('100%');
-
-  const unrecognized = rows.filter({ hasText: ServiceStatisticsPage.unrecognized });
-  await expect(unrecognized).toHaveCount(1);
-  await expect(unrecognized.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
-  await expect(unrecognized.getByRole('cell').nth(3)).toHaveText('-');
-
-  // 'Łącznie' is a substring of 'Łącznie rozpoznane'; use exact cell name to avoid matching both
-  const total = rows.filter({
-    has: page.getByRole('cell', { name: ServiceStatisticsPage.total, exact: true }),
+  await test.step('verify page headings', async () => {
+    await expectHeadings(page, [ServiceStatisticsPage.statistics, ServiceStatisticsPage.signIn]);
   });
-  await expect(total).toHaveCount(1);
-  await expect(total.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
-  await expect(total.getByRole('cell').nth(3)).toHaveText('-');
+
+  await test.step('verify table headers', async () => {
+    await expect(
+      page.getByRole('columnheader', {
+        name: ServiceStatisticsPage.colLp,
+        exact: true,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('columnheader', {
+        name: ServiceStatisticsPage.colBrowsers,
+        exact: true,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('columnheader', {
+        name: ServiceStatisticsPage.colCount,
+        exact: true,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('columnheader', {
+        name: ServiceStatisticsPage.colPercent,
+        exact: true,
+      })
+    ).toBeVisible();
+  });
+
+  await test.step('verify data rows', async () => {
+    const rows = page.getByRole('table').first().getByRole('row');
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThan(0);
+
+    // Read all data rows in one browser round-trip to avoid 246+ sequential awaits timing out
+    const dataRows = await page.evaluate<StatisticsRow[]>(() => {
+      const table = document.querySelector('table');
+      return table
+        ? Array.from(table.rows)
+            .slice(1, -3)
+            .map((row) => ({
+              lp: row.cells[0]?.textContent?.trim() ?? '',
+              count: row.cells[2]?.textContent?.trim() ?? '',
+              percent: row.cells[3]?.textContent?.trim() ?? '',
+            }))
+        : [];
+    });
+    expect(dataRows).toHaveLength(rowCount - 4); // 1 header row + 3 footer rows
+    for (let i = 0; i < dataRows.length; i++) {
+      expect(dataRows[i].lp, `row ${i + 1}: lp`).toBe(String(i + 1));
+      expect(dataRows[i].count, `row ${i + 1}: count`).toMatch(/^\d+$/);
+      expect(dataRows[i].percent, `row ${i + 1}: percent`).toMatch(/^\d+\.\d{2}%$/);
+    }
+  });
+
+  await test.step('verify footer rows', async () => {
+    const rows = page.getByRole('table').first().getByRole('row');
+    const rowCount = await rows.count();
+
+    // Structural check: the table ends with exactly these 3 footer rows in order
+    await expect(rows.nth(rowCount - 3)).toContainText(ServiceStatisticsPage.totalRecognized);
+    await expect(rows.nth(rowCount - 2)).toContainText(ServiceStatisticsPage.unrecognized);
+    await expect(rows.last()).toContainText(ServiceStatisticsPage.total);
+
+    // Verify footer row values (count and percent) – located by content, not by index
+    const totalRecognized = rows.filter({ hasText: ServiceStatisticsPage.totalRecognized });
+    await expect(totalRecognized).toHaveCount(1);
+    await expect(totalRecognized.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
+    await expect(totalRecognized.getByRole('cell').nth(3)).toHaveText('100%');
+
+    const unrecognized = rows.filter({ hasText: ServiceStatisticsPage.unrecognized });
+    await expect(unrecognized).toHaveCount(1);
+    await expect(unrecognized.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
+    await expect(unrecognized.getByRole('cell').nth(3)).toHaveText('-');
+
+    // 'Łącznie' is a substring of 'Łącznie rozpoznane'; use exact cell name to avoid matching both
+    const total = rows.filter({
+      has: page.getByRole('cell', { name: ServiceStatisticsPage.total, exact: true }),
+    });
+    await expect(total).toHaveCount(1);
+    await expect(total.getByRole('cell').nth(2)).toHaveText(/^\d+$/);
+    await expect(total.getByRole('cell').nth(3)).toHaveText('-');
+  });
 });


### PR DESCRIPTION
## Summary

- Wraps logical action groups in `test.step()` in `statistics.spec.ts` (SVG chart test: 3 steps; table test: 4 steps)
- Wraps logical action groups in `test.step()` in `about-system.spec.ts` (6 steps)
- `svgResponse` is returned from the navigate step and consumed in the analyze step, preserving the original action order (screenshots taken before `svgResponse.text()`)

## Test plan

- [x] All tests in `statistics.spec.ts` and `about-system.spec.ts` pass without behavioral change
- [x] Steps are visible and collapsible in the Playwright trace viewer and HTML report
- [x] `tsc --noEmit` passes
- [x] `npm run format` applied with no changes

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)