### PR TITLE
58 Use expect.soft() for independent assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ npm run format:check
 
 **Page Object Model pattern:** Each page class extends `AbstractPage` and defines static `url`, `title` (and optionally `accessKey`) properties used in data-driven loops. The constructor calls `super(page, url, title, accessKey)`. Only the `heading` getter and page-specific static string constants need to be defined per class.
 
+**Soft assertions:** Use `expect.soft()` for independent checks within a test (e.g. link `href` attributes, image `alt` attributes, display text) so all failures are reported in a single run rather than stopping at the first one. Reserve hard `expect()` for critical prerequisites — page navigation, table visibility, row count — where a failure makes subsequent steps meaningless. Tests that mix both follow the pattern: hard assertions first to confirm the page loaded, then soft assertions for each independent property.
+
 **Path aliases** (defined in `tsconfig.json`):
 
 - `@fixtures/*` → `./fixtures/*`

--- a/playwright/typescript/tests/about-system.spec.ts
+++ b/playwright/typescript/tests/about-system.spec.ts
@@ -33,15 +33,15 @@ test('about system page - headings and statsbar content', async ({ page }) => {
     await expect(
       statsbar.getByText(AboutSystemPage.orwellStatIntro, { exact: false })
     ).toBeVisible();
-    await expect(
-      statsbar.getByRole('link', { name: AboutSystemPage.wsbNlu.name, exact: true })
-    ).toHaveAttribute('href', AboutSystemPage.wsbNlu.href);
-    await expect(
-      statsbar.getByRole('link', { name: AboutSystemPage.hubertGajewski.name, exact: true })
-    ).toHaveAttribute('href', AboutSystemPage.hubertGajewski.href);
-    await expect(
-      statsbar.getByRole('link', { name: AboutSystemPage.tomaszGorazd.name, exact: true })
-    ).toHaveAttribute('href', AboutSystemPage.tomaszGorazd.href);
+    await expect
+      .soft(statsbar.getByRole('link', { name: AboutSystemPage.wsbNlu.name, exact: true }))
+      .toHaveAttribute('href', AboutSystemPage.wsbNlu.href);
+    await expect
+      .soft(statsbar.getByRole('link', { name: AboutSystemPage.hubertGajewski.name, exact: true }))
+      .toHaveAttribute('href', AboutSystemPage.hubertGajewski.href);
+    await expect
+      .soft(statsbar.getByRole('link', { name: AboutSystemPage.tomaszGorazd.name, exact: true }))
+      .toHaveAttribute('href', AboutSystemPage.tomaszGorazd.href);
   });
 
   await test.step('verify browser and OS counts and lists', async () => {
@@ -61,22 +61,21 @@ test('about system page - headings and statsbar content', async ({ page }) => {
 
   await test.step('verify requirements screenshots', async () => {
     for (const screenshot of Object.values(AboutSystemPage.screenshots)) {
-      await expect(statsbar.locator(`img[src="${screenshot.src}"]`)).toHaveAttribute(
-        'alt',
-        screenshot.alt
-      );
+      await expect
+        .soft(statsbar.locator(`img[src="${screenshot.src}"]`))
+        .toHaveAttribute('alt', screenshot.alt);
     }
   });
 
   await test.step('verify requirements text', async () => {
-    await expect(
-      statsbar.getByRole('link', { name: AboutSystemPage.adobeSvgViewer.name, exact: true })
-    ).toHaveAttribute('href', AboutSystemPage.adobeSvgViewer.href);
-    await expect(
-      statsbar.getByText(AboutSystemPage.vgaRequirementText, { exact: false })
-    ).toBeVisible();
-    await expect(
-      statsbar.getByText(AboutSystemPage.hdRequirementText, { exact: false })
-    ).toBeVisible();
+    await expect
+      .soft(statsbar.getByRole('link', { name: AboutSystemPage.adobeSvgViewer.name, exact: true }))
+      .toHaveAttribute('href', AboutSystemPage.adobeSvgViewer.href);
+    await expect
+      .soft(statsbar.getByText(AboutSystemPage.vgaRequirementText, { exact: false }))
+      .toBeVisible();
+    await expect
+      .soft(statsbar.getByText(AboutSystemPage.hdRequirementText, { exact: false }))
+      .toBeVisible();
   });
 });

--- a/playwright/typescript/tests/statistics.spec.ts
+++ b/playwright/typescript/tests/statistics.spec.ts
@@ -139,9 +139,9 @@ test('system statistics', async ({ page }) => {
     });
     expect(dataRows).toHaveLength(rowCount - 4); // 1 header row + 3 footer rows
     for (let i = 0; i < dataRows.length; i++) {
-      expect(dataRows[i].lp, `row ${i + 1}: lp`).toBe(String(i + 1));
-      expect(dataRows[i].count, `row ${i + 1}: count`).toMatch(/^\d+$/);
-      expect(dataRows[i].percent, `row ${i + 1}: percent`).toMatch(/^\d+\.\d{2}%$/);
+      expect.soft(dataRows[i].lp, `row ${i + 1}: lp`).toBe(String(i + 1));
+      expect.soft(dataRows[i].count, `row ${i + 1}: count`).toMatch(/^\d+$/);
+      expect.soft(dataRows[i].percent, `row ${i + 1}: percent`).toMatch(/^\d+\.\d{2}%$/);
     }
   });
 


### PR DESCRIPTION
## Summary

- Applied `expect.soft()` to external link `href` checks, screenshot `alt` attributes, and display requirement text in `about-system.spec.ts`
- Applied `expect.soft()` to per-row `lp`/`count`/`percent` format checks in `statistics.spec.ts`
- Hard `expect()` retained for critical prerequisites (page load, headings, table visibility, row count)
- Documented soft assertion convention in `README.md`

## Test plan

- [x] Chromium: 4 tests pass locally
- [x] All 5 browser projects pass in CI

Closes #58