### PR TITLE
59 Add @smoke and @regression tags to tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ Before committing changes to `playwright/typescript`, review against these crite
 - **Flakiness** — no fixed timeouts; animation waits use `requestAnimationFrame`; auth setup asserts login actually succeeded; no assumptions about element order without explicit count assertion
 - **Security** — no credentials hardcoded anywhere; `.env` and `bruno/.env` remain gitignored; Bruno dotenv secrets accessed via `{{process.env.VAR}}` / `bru.getProcessEnv()` (not plaintext in `.bru` files); no sensitive data in committed config files (`.actrc`, `playwright.config.ts`, etc.); `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD` sourced only from `.env` (local) or GitHub Actions secrets (CI)
 - **Formatting** — code is formatted with Prettier (`npm run format` from `playwright/typescript/`); never commit files that would fail `npm run format:check`
-- **Consistency with existing patterns** — new utils and test files documented in `README.md`; new page files exported via the appropriate `index.ts`; code style matches surrounding files; JSON/config files are valid (no stray braces, no syntax errors)
+- **Test tags** — every test (or its enclosing `test.describe`) must carry exactly one tag: `{ tag: '@smoke' }` for title/heading/HTTP status checks, `{ tag: '@regression' }` for deep content checks (table data, SVG analysis, link hrefs, accessibility, visual); new tests must follow the tag strategy documented in `README.md`
+- **Consistency with existing patterns** — new utils and test files documented in `README.md` (including the "Single test file" run list and the spec file description in the Architecture section); new spec files must also appear in the "Test tags" table and carry the appropriate tag; new page files exported via the appropriate `index.ts`; code style matches surrounding files; JSON/config files are valid (no stray braces, no syntax errors)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npx playwright test tests/about-system.spec.ts
 npx playwright test tests/contact.spec.ts
 npx playwright test tests/statistics.spec.ts
 npx playwright test tests/validation.spec.ts
+npx playwright test tests/visual.spec.ts
 
 # Specific browser
 npx playwright test --project=chromium
@@ -81,6 +82,18 @@ npx playwright test --project="Mobile Safari"
 
 # Single test by name
 npx playwright test -g "test name"
+
+# Smoke tests only (HTTP status, titles, heading visibility)
+npx playwright test --grep @smoke
+
+# Regression tests only (table content, SVG analysis, link hrefs, accessibility, visual)
+npx playwright test --grep @regression
+
+# All tests except smoke (equivalent to regression-only when all tests are tagged)
+npx playwright test --grep-invert @smoke
+
+# All tests except regression
+npx playwright test --grep-invert @regression
 
 # HTML report
 npx playwright show-report
@@ -95,20 +108,31 @@ npm run format
 npm run format:check
 ```
 
+### Test tags
+
+Tests are tagged `@smoke` or `@regression` using Playwright's test options syntax (`{ tag: '@smoke' }`).
+
+| Tag | Purpose | Files |
+|---|---|---|
+| `@smoke` | Quick health check: HTTP status, page titles, heading visibility | `api.spec.ts`, `navigation.spec.ts` |
+| `@regression` | Deep checks: table content, SVG analysis, external link hrefs, accessibility, visual | `home.spec.ts`, `about-system.spec.ts`, `contact.spec.ts`, `statistics.spec.ts`, `accessibility.spec.ts`, `validation.spec.ts`, `visual.spec.ts` |
+
+Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tests](#running-tests)).
+
 ### Architecture
 
 **Directory structure** (`playwright/typescript/`):
 
 - `tests/` — Playwright test specs (`.spec.ts`)
-  - `navigation.spec.ts` — UI navigation and accessibility tests
-  - `api.spec.ts` — HTTP-level tests for public and authenticated pages
-  - `accessibility.spec.ts` — WCAG accessibility tests across pages
-  - `home.spec.ts` — Home page content and navigation tests (including `PreviouslyAddedPage`)
-  - `about-system.spec.ts` — About System page headings and statsbar content tests
-  - `contact.spec.ts` — Contact page headings and statsbar content tests
-  - `statistics.spec.ts` — Service statistics page: SVG chart rendering and statistics table tests
-  - `validation.spec.ts` — W3C XHTML and CSS validation tests across all pages (classic W3C Markup Validator + CSS validator APIs); Chromium-only
-  - `visual.spec.ts` — Full-page visual regression snapshots for home (default and Purple Rain style), about system, contact, and statistics pages using `toHaveScreenshot()` with `maxDiffPixelRatio: 0.01`; home page masks `#statsbar` lists (dynamic new-browser/OS list items) via `getByRole('list')`; statistics page masks `getByRole('table')` (live data) and `object[type="image/svg+xml"]` (dynamic SVG chart), removes all but the first 5 rows from the statistics table via `page.evaluate()` to keep the footer at a stable position regardless of how many browser/OS rows live data contains (CSS height/overflow tricks are ineffective here: Playwright's `fullPage` screenshot and mask both use the element's full bounding box, not the clipped visual; physically removing rows is the only reliable fix), waits for `<object>` to be visible before screenshotting to stabilise layout, and disables animations; baselines stored in `tests/visual.spec.ts-snapshots/` with per-platform suffixes (`-darwin`, `-linux`)
+  - `navigation.spec.ts` — UI navigation and title tests; tagged `@smoke`
+  - `api.spec.ts` — HTTP-level tests for public and authenticated pages; tagged `@smoke`
+  - `accessibility.spec.ts` — WCAG accessibility tests across pages; tagged `@regression`
+  - `home.spec.ts` — Home page content and navigation tests (including `PreviouslyAddedPage`); tagged `@regression`
+  - `about-system.spec.ts` — About System page headings and statsbar content tests; tagged `@regression`
+  - `contact.spec.ts` — Contact page headings and statsbar content tests; tagged `@regression`
+  - `statistics.spec.ts` — Service statistics page: SVG chart rendering and statistics table tests; tagged `@regression`
+  - `validation.spec.ts` — W3C XHTML and CSS validation tests across all pages (classic W3C Markup Validator + CSS validator APIs); Chromium-only; tagged `@regression`
+  - `visual.spec.ts` — Full-page visual regression snapshots for home (default and Purple Rain style), about system, contact, and statistics pages using `toHaveScreenshot()` with `maxDiffPixelRatio: 0.01`; home page masks `#statsbar` lists (dynamic new-browser/OS list items) via `getByRole('list')`; statistics page masks `getByRole('table')` (live data) and `object[type="image/svg+xml"]` (dynamic SVG chart), removes all but the first 5 rows from the statistics table via `page.evaluate()` to keep the footer at a stable position regardless of how many browser/OS rows live data contains (CSS height/overflow tricks are ineffective here: Playwright's `fullPage` screenshot and mask both use the element's full bounding box, not the clipped visual; physically removing rows is the only reliable fix), waits for `<object>` to be visible before screenshotting to stabilise layout, and disables animations; baselines stored in `tests/visual.spec.ts-snapshots/` with per-platform suffixes (`-darwin`, `-linux`); tagged `@regression`
 - `auth.setup.ts` — Playwright auth setup: logs in via UI and saves storage state to `.auth/user.json`
 - `pages/` — Page Object Model classes
   - `base.page.ts` — `BasePage` interface (`url`, `title`, `goto()`, `heading`, optional `accessKey`)

--- a/playwright/typescript/tests/about-system.spec.ts
+++ b/playwright/typescript/tests/about-system.spec.ts
@@ -2,80 +2,90 @@ import { test, expect } from '@fixtures/base.fixture';
 import { AboutSystemPage } from '@pages/public/about-system.page';
 import { expectHeadings } from '@utils/string.util';
 
-test('about system page - headings and statsbar content', async ({ page }) => {
-  await test.step('navigate to page', async () => {
-    await page.goto(AboutSystemPage.url);
-  });
+test(
+  'about system page - headings and statsbar content',
+  { tag: '@regression' },
+  async ({ page }) => {
+    await test.step('navigate to page', async () => {
+      await page.goto(AboutSystemPage.url);
+    });
 
-  const statsbar = page.locator('#statsbar');
+    const statsbar = page.locator('#statsbar');
 
-  await test.step('verify headings', async () => {
-    await expectHeadings(page, [
-      AboutSystemPage.signIn,
-      AboutSystemPage.whatIsOrwellStat,
-      AboutSystemPage.whatDataIsCollected,
-      AboutSystemPage.browsersAndApps,
-      AboutSystemPage.operatingSystems,
-      AboutSystemPage.requirements,
-      AboutSystemPage.minimalRequirements,
-      AboutSystemPage.recommended,
-    ]);
-  });
+    await test.step('verify headings', async () => {
+      await expectHeadings(page, [
+        AboutSystemPage.signIn,
+        AboutSystemPage.whatIsOrwellStat,
+        AboutSystemPage.whatDataIsCollected,
+        AboutSystemPage.browsersAndApps,
+        AboutSystemPage.operatingSystems,
+        AboutSystemPage.requirements,
+        AboutSystemPage.minimalRequirements,
+        AboutSystemPage.recommended,
+      ]);
+    });
 
-  await test.step('verify statsbar login section', async () => {
-    await expect(statsbar.getByText(AboutSystemPage.loggedInAs, { exact: false })).toBeVisible();
-    await expect(
-      statsbar.getByRole('button', { name: AboutSystemPage.logoutButton, exact: true })
-    ).toBeVisible();
-  });
-
-  await test.step('verify intro and external links', async () => {
-    await expect(
-      statsbar.getByText(AboutSystemPage.orwellStatIntro, { exact: false })
-    ).toBeVisible();
-    await expect
-      .soft(statsbar.getByRole('link', { name: AboutSystemPage.wsbNlu.name, exact: true }))
-      .toHaveAttribute('href', AboutSystemPage.wsbNlu.href);
-    await expect
-      .soft(statsbar.getByRole('link', { name: AboutSystemPage.hubertGajewski.name, exact: true }))
-      .toHaveAttribute('href', AboutSystemPage.hubertGajewski.href);
-    await expect
-      .soft(statsbar.getByRole('link', { name: AboutSystemPage.tomaszGorazd.name, exact: true }))
-      .toHaveAttribute('href', AboutSystemPage.tomaszGorazd.href);
-  });
-
-  await test.step('verify browser and OS counts and lists', async () => {
-    await expect(statsbar.getByText(AboutSystemPage.browserCount, { exact: false })).toBeVisible();
-    await expect(statsbar.getByText(AboutSystemPage.osCount, { exact: false })).toBeVisible();
-
-    for (const browser of AboutSystemPage.sampleBrowsers) {
+    await test.step('verify statsbar login section', async () => {
+      await expect(statsbar.getByText(AboutSystemPage.loggedInAs, { exact: false })).toBeVisible();
       await expect(
-        statsbar.getByRole('listitem').getByText(browser, { exact: true })
+        statsbar.getByRole('button', { name: AboutSystemPage.logoutButton, exact: true })
       ).toBeVisible();
-    }
+    });
 
-    for (const os of AboutSystemPage.sampleOSes) {
-      await expect(statsbar.getByRole('listitem').getByText(os, { exact: true })).toBeVisible();
-    }
-  });
-
-  await test.step('verify requirements screenshots', async () => {
-    for (const screenshot of Object.values(AboutSystemPage.screenshots)) {
+    await test.step('verify intro and external links', async () => {
+      await expect(
+        statsbar.getByText(AboutSystemPage.orwellStatIntro, { exact: false })
+      ).toBeVisible();
       await expect
-        .soft(statsbar.locator(`img[src="${screenshot.src}"]`))
-        .toHaveAttribute('alt', screenshot.alt);
-    }
-  });
+        .soft(statsbar.getByRole('link', { name: AboutSystemPage.wsbNlu.name, exact: true }))
+        .toHaveAttribute('href', AboutSystemPage.wsbNlu.href);
+      await expect
+        .soft(
+          statsbar.getByRole('link', { name: AboutSystemPage.hubertGajewski.name, exact: true })
+        )
+        .toHaveAttribute('href', AboutSystemPage.hubertGajewski.href);
+      await expect
+        .soft(statsbar.getByRole('link', { name: AboutSystemPage.tomaszGorazd.name, exact: true }))
+        .toHaveAttribute('href', AboutSystemPage.tomaszGorazd.href);
+    });
 
-  await test.step('verify requirements text', async () => {
-    await expect
-      .soft(statsbar.getByRole('link', { name: AboutSystemPage.adobeSvgViewer.name, exact: true }))
-      .toHaveAttribute('href', AboutSystemPage.adobeSvgViewer.href);
-    await expect
-      .soft(statsbar.getByText(AboutSystemPage.vgaRequirementText, { exact: false }))
-      .toBeVisible();
-    await expect
-      .soft(statsbar.getByText(AboutSystemPage.hdRequirementText, { exact: false }))
-      .toBeVisible();
-  });
-});
+    await test.step('verify browser and OS counts and lists', async () => {
+      await expect(
+        statsbar.getByText(AboutSystemPage.browserCount, { exact: false })
+      ).toBeVisible();
+      await expect(statsbar.getByText(AboutSystemPage.osCount, { exact: false })).toBeVisible();
+
+      for (const browser of AboutSystemPage.sampleBrowsers) {
+        await expect(
+          statsbar.getByRole('listitem').getByText(browser, { exact: true })
+        ).toBeVisible();
+      }
+
+      for (const os of AboutSystemPage.sampleOSes) {
+        await expect(statsbar.getByRole('listitem').getByText(os, { exact: true })).toBeVisible();
+      }
+    });
+
+    await test.step('verify requirements screenshots', async () => {
+      for (const screenshot of Object.values(AboutSystemPage.screenshots)) {
+        await expect
+          .soft(statsbar.locator(`img[src="${screenshot.src}"]`))
+          .toHaveAttribute('alt', screenshot.alt);
+      }
+    });
+
+    await test.step('verify requirements text', async () => {
+      await expect
+        .soft(
+          statsbar.getByRole('link', { name: AboutSystemPage.adobeSvgViewer.name, exact: true })
+        )
+        .toHaveAttribute('href', AboutSystemPage.adobeSvgViewer.href);
+      await expect
+        .soft(statsbar.getByText(AboutSystemPage.vgaRequirementText, { exact: false }))
+        .toBeVisible();
+      await expect
+        .soft(statsbar.getByText(AboutSystemPage.hdRequirementText, { exact: false }))
+        .toBeVisible();
+    });
+  }
+);

--- a/playwright/typescript/tests/accessibility.spec.ts
+++ b/playwright/typescript/tests/accessibility.spec.ts
@@ -3,7 +3,7 @@ import { expectNoAccessibilityViolations } from '@utils/accessibility.util';
 import { PUBLIC_PAGE_CLASSES } from '@pages/public/index';
 import { AUTHENTICATED_PAGE_CLASSES } from '@pages/authenticated/index';
 
-test.describe('accessibility', () => {
+test.describe('accessibility', { tag: '@regression' }, () => {
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
     'Accessibility tests run on Chromium only'

--- a/playwright/typescript/tests/api.spec.ts
+++ b/playwright/typescript/tests/api.spec.ts
@@ -2,16 +2,20 @@ import { test, expect } from '@fixtures/api.fixture';
 import { PUBLIC_PAGE_CLASSES } from '@pages/public/index';
 import { AUTHENTICATED_PAGE_CLASSES } from '@pages/authenticated/index';
 
-test('public pages without authentication', async ({ unauthenticatedRequest }) => {
-  const responses = await Promise.all(
-    PUBLIC_PAGE_CLASSES.map((PageClass) => unauthenticatedRequest.get(PageClass.url))
-  );
-  for (const response of responses) {
-    expect(response.status()).toBe(200);
+test(
+  'public pages without authentication',
+  { tag: '@smoke' },
+  async ({ unauthenticatedRequest }) => {
+    const responses = await Promise.all(
+      PUBLIC_PAGE_CLASSES.map((PageClass) => unauthenticatedRequest.get(PageClass.url))
+    );
+    for (const response of responses) {
+      expect(response.status()).toBe(200);
+    }
   }
-});
+);
 
-test('public pages with authentication', async ({ authenticatedRequest }) => {
+test('public pages with authentication', { tag: '@smoke' }, async ({ authenticatedRequest }) => {
   const responses = await Promise.all(
     PUBLIC_PAGE_CLASSES.map((PageClass) => authenticatedRequest.get(PageClass.url))
   );
@@ -20,7 +24,7 @@ test('public pages with authentication', async ({ authenticatedRequest }) => {
   }
 });
 
-test('authenticated pages', async ({ authenticatedRequest }) => {
+test('authenticated pages', { tag: '@smoke' }, async ({ authenticatedRequest }) => {
   const responses = await Promise.all(
     AUTHENTICATED_PAGE_CLASSES.map((PageClass) => authenticatedRequest.get(PageClass.url))
   );
@@ -29,7 +33,7 @@ test('authenticated pages', async ({ authenticatedRequest }) => {
   }
 });
 
-test('failed authentication', async ({ request }) => {
+test('failed authentication', { tag: '@smoke' }, async ({ request }) => {
   const response = await request.post('/zone/', {
     form: {
       username: 'test',

--- a/playwright/typescript/tests/contact.spec.ts
+++ b/playwright/typescript/tests/contact.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@fixtures/base.fixture';
 import { ContactPage } from '@pages/public/contact.page';
 import { expectHeadings } from '@utils/string.util';
 
-test('contact page - headings and statsbar content', async ({ page }) => {
+test('contact page - headings and statsbar content', { tag: '@regression' }, async ({ page }) => {
   await page.goto(ContactPage.url);
 
   const statsbar = page.locator('#statsbar');

--- a/playwright/typescript/tests/home.spec.ts
+++ b/playwright/typescript/tests/home.spec.ts
@@ -3,7 +3,7 @@ import { HomePage } from '@pages/public';
 import { PreviouslyAddedPage } from '@pages/public/previously-added.page';
 import { expectHeadings } from '@utils/string.util';
 
-test('home page', async ({ page }) => {
+test('home page', { tag: '@regression' }, async ({ page }) => {
   await page.goto(HomePage.url);
 
   const previouslyAddedLinks = page.getByRole('link', {

--- a/playwright/typescript/tests/navigation.spec.ts
+++ b/playwright/typescript/tests/navigation.spec.ts
@@ -10,20 +10,20 @@ import {
 import { AUTHENTICATED_PAGE_CLASSES } from '@pages/authenticated/index';
 
 for (const PageClass of PUBLIC_PAGE_CLASSES) {
-  test(`${PageClass.url} has correct title`, async ({ page }) => {
+  test(`${PageClass.url} has correct title`, { tag: '@smoke' }, async ({ page }) => {
     await page.goto(PageClass.url);
     await expect(page).toHaveTitle(PageClass.title);
   });
 }
 
 for (const PageClass of AUTHENTICATED_PAGE_CLASSES) {
-  test(`${PageClass.url} has correct title`, async ({ page }) => {
+  test(`${PageClass.url} has correct title`, { tag: '@smoke' }, async ({ page }) => {
     await page.goto(PageClass.url);
     await expect(page).toHaveTitle(PageClass.title);
   });
 }
 
-test.describe('navigation', () => {
+test.describe('navigation', { tag: '@smoke' }, () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
   });

--- a/playwright/typescript/tests/statistics.spec.ts
+++ b/playwright/typescript/tests/statistics.spec.ts
@@ -4,7 +4,7 @@ import { expectHeadings } from '@utils/string.util';
 import { SvgAnalysis } from '@types-local/svg-analysis';
 import { StatisticsRow } from '@types-local/statistics-row';
 
-test('SVG chart is rendered on stats page', async ({ page }) => {
+test('SVG chart is rendered on stats page', { tag: '@regression' }, async ({ page }) => {
   const svgResponse = await test.step('navigate and wait for chart', async () => {
     // Firefox does not cache Basic Auth credentials for <object> sub-resources on staging.
     // Pre-navigate to chart_all.php so Firefox caches the credentials before the <object> loads it.
@@ -83,7 +83,7 @@ test('SVG chart is rendered on stats page', async ({ page }) => {
   });
 });
 
-test('system statistics', async ({ page }) => {
+test('system statistics', { tag: '@regression' }, async ({ page }) => {
   await test.step('navigate to page', async () => {
     await page.goto(ServiceStatisticsPage.url);
   });

--- a/playwright/typescript/tests/validation.spec.ts
+++ b/playwright/typescript/tests/validation.spec.ts
@@ -4,7 +4,7 @@ import { PUBLIC_PAGE_CLASSES } from '@pages/public/index';
 import { AUTHENTICATED_PAGE_CLASSES } from '@pages/authenticated/index';
 import { HomePage } from '@pages/public/home.page';
 
-test.describe('markup and CSS validation', () => {
+test.describe('markup and CSS validation', { tag: '@regression' }, () => {
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
     'Validation tests run on Chromium only'

--- a/playwright/typescript/tests/visual.spec.ts
+++ b/playwright/typescript/tests/visual.spec.ts
@@ -4,7 +4,7 @@ import { AboutSystemPage } from '@pages/public/about-system.page';
 import { ContactPage } from '@pages/public/contact.page';
 import { ServiceStatisticsPage } from '@pages/public/service-statistics.page';
 
-test('home page visual regression', async ({ page }) => {
+test('home page visual regression', { tag: '@regression' }, async ({ page }) => {
   await page.goto(HomePage.url);
   // The two lists inside #statsbar contain newly added browsers and OSes which change over
   // time; mask both to keep the baseline stable. #statsbar contains no other lists.
@@ -14,37 +14,41 @@ test('home page visual regression', async ({ page }) => {
   });
 });
 
-test('home page visual regression - Purple Rain style', async ({ page }) => {
-  await page.goto(HomePage.url);
-  // Select a non-default style and submit; each style gets its own baseline.
-  await page
-    .getByRole('combobox', { name: HomePage.styleSelector })
-    .selectOption(HomePage.stylePurpleRain);
-  await page.getByRole('button', { name: HomePage.styleSelector }).click();
-  try {
-    await expect(page).toHaveScreenshot({
-      fullPage: true,
-      mask: [page.locator('#statsbar').getByRole('list')],
-    });
-  } finally {
-    // Delete the SelectedStyle cookie — it is stored server-side in the session shared by
-    // all tests via .auth/user.json, so not cleaning up would cause subsequent tests to
-    // render in Purple Rain and fail their baselines.
-    await page.context().clearCookies({ name: 'SelectedStyle' });
+test(
+  'home page visual regression - Purple Rain style',
+  { tag: '@regression' },
+  async ({ page }) => {
+    await page.goto(HomePage.url);
+    // Select a non-default style and submit; each style gets its own baseline.
+    await page
+      .getByRole('combobox', { name: HomePage.styleSelector })
+      .selectOption(HomePage.stylePurpleRain);
+    await page.getByRole('button', { name: HomePage.styleSelector }).click();
+    try {
+      await expect(page).toHaveScreenshot({
+        fullPage: true,
+        mask: [page.locator('#statsbar').getByRole('list')],
+      });
+    } finally {
+      // Delete the SelectedStyle cookie — it is stored server-side in the session shared by
+      // all tests via .auth/user.json, so not cleaning up would cause subsequent tests to
+      // render in Purple Rain and fail their baselines.
+      await page.context().clearCookies({ name: 'SelectedStyle' });
+    }
   }
-});
+);
 
-test('about system page visual regression', async ({ page }) => {
+test('about system page visual regression', { tag: '@regression' }, async ({ page }) => {
   await page.goto(AboutSystemPage.url);
   await expect(page).toHaveScreenshot({ fullPage: true });
 });
 
-test('contact page visual regression', async ({ page }) => {
+test('contact page visual regression', { tag: '@regression' }, async ({ page }) => {
   await page.goto(ContactPage.url);
   await expect(page).toHaveScreenshot({ fullPage: true });
 });
 
-test('statistics page visual regression', async ({ page }) => {
+test('statistics page visual regression', { tag: '@regression' }, async ({ page }) => {
   // Wait for the SVG chart response before screenshotting to ensure it is fully loaded.
   // animations: 'disabled' freezes the SVG animation for a stable baseline.
   // The statistics table and SVG chart contain live data that changes frequently; mask both


### PR DESCRIPTION
## Summary

- Tags all existing tests with `{ tag: '@smoke' }` or `{ tag: '@regression' }` using Playwright's test options syntax
- `@smoke`: `api.spec.ts` (HTTP status checks) and `navigation.spec.ts` (title + heading visibility)
- `@regression`: `home.spec.ts`, `about-system.spec.ts`, `contact.spec.ts`, `statistics.spec.ts`, `accessibility.spec.ts`, `validation.spec.ts`, `visual.spec.ts`
- Documents the tag strategy in README.md (new "Test tags" section + run commands) and CLAUDE.md (checklist rule for new tests)

## Test plan

- [ ] `npx playwright test --grep @smoke` — runs only `api.spec.ts` and `navigation.spec.ts` tests
- [ ] `npx playwright test --grep @regression` — runs the remaining 7 spec files
- [ ] `npx playwright test` — all tests run regardless of tags
- [ ] `tsc --noEmit` passes, `npm run format:check` passes

Closes #59