### PR TITLE
61 Use satisfies operator and Record utility type for type safety

### DIFF
--- a/playwright/typescript/pages/authenticated/index.ts
+++ b/playwright/typescript/pages/authenticated/index.ts
@@ -1,3 +1,4 @@
+import { AbstractPage } from '@pages/abstract.page';
 import { InformationPage } from './information.page';
 import { StatsPage } from './stats.page';
 import { HitsPage } from './hits.page';
@@ -12,4 +13,4 @@ export const AUTHENTICATED_PAGE_CLASSES = [
   HitsPage,
   ScriptsPage,
   AdminPage,
-] as const;
+] as const satisfies readonly (typeof AbstractPage)[];

--- a/playwright/typescript/pages/public/about-system.page.ts
+++ b/playwright/typescript/pages/public/about-system.page.ts
@@ -47,7 +47,7 @@ export class AboutSystemPage extends AbstractPage {
       src: '/images/screenshots/firefox_p_small.jpg',
       alt: 'Zrzut ekranu użytkownika używającego przeglądarki Firefox z ustawionym stylem Wersja do druku',
     },
-  } as const;
+  } as const satisfies Record<string, { src: string; alt: string }>;
 
   static readonly adobeSvgViewer = {
     name: 'Adobe SVG Viewer',

--- a/playwright/typescript/pages/public/index.ts
+++ b/playwright/typescript/pages/public/index.ts
@@ -1,3 +1,4 @@
+import { AbstractPage } from '@pages/abstract.page';
 import { HomePage } from './home.page';
 import { AboutSystemPage } from './about-system.page';
 import { ServiceStatisticsPage } from './service-statistics.page';
@@ -21,4 +22,4 @@ export const PUBLIC_PAGE_CLASSES = [
   ContactPage,
   RegisterPage,
   PasswordResetPage,
-] as const;
+] as const satisfies readonly (typeof AbstractPage)[];

--- a/playwright/typescript/types/statistics-row.ts
+++ b/playwright/typescript/types/statistics-row.ts
@@ -1,5 +1,1 @@
-export interface StatisticsRow {
-  lp: string;
-  count: string;
-  percent: string;
-}
+export type StatisticsRow = Record<'lp' | 'count' | 'percent', string>;


### PR DESCRIPTION
## Summary
- Add `satisfies Record<string, { src: string; alt: string }>` to `AboutSystemPage.screenshots` for compile-time shape validation
- Add `satisfies readonly (typeof AbstractPage)[]` to `PUBLIC_PAGE_CLASSES` and `AUTHENTICATED_PAGE_CLASSES` to validate page class arrays at definition site
- Replace `StatisticsRow` interface with `Record<'lp' | 'count' | 'percent', string>` type alias

## Test plan
- [x] `tsc --noEmit` passes (verified locally)
- [x] `npm run format:check` passes (verified locally)
- [x] No behavioral changes — all tests pass identically

Closes #61