### PR TITLE
Add workflow_dispatch project input for on-demand browser filtering

### DIFF
--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -4,8 +4,21 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  schedule:
+    # Runs at 03:00 UTC every Sunday
+    - cron: '0 3 * * 0'
   workflow_dispatch:
     inputs:
+      project:
+        description: 'Browser project to test (all runs the full matrix)'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - chromium
+          - firefox
+          - webkit
       update_visual_baselines:
         description: 'Regenerate Linux visual baselines for all 5 browser projects (--update-snapshots) and commit them back to the branch'
         type: boolean
@@ -18,29 +31,43 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - name: Compute matrix
+        id: compute
+        run: |
+          ALL='{"include":[{"project":"Chromium","browser":"chromium","id":"chromium"},{"project":"Firefox","browser":"firefox","id":"firefox"},{"project":"Webkit","browser":"webkit","id":"webkit"},{"project":"Mobile Chrome","browser":"chromium","id":"mobile-chrome"},{"project":"Mobile Safari","browser":"webkit","id":"mobile-safari"}]}'
+          CHROMIUM='{"include":[{"project":"Chromium","browser":"chromium","id":"chromium"},{"project":"Mobile Chrome","browser":"chromium","id":"mobile-chrome"}]}'
+          FIREFOX='{"include":[{"project":"Firefox","browser":"firefox","id":"firefox"}]}'
+          WEBKIT='{"include":[{"project":"Webkit","browser":"webkit","id":"webkit"},{"project":"Mobile Safari","browser":"webkit","id":"mobile-safari"}]}'
+
+          PROJECT="${{ inputs.project }}"
+          EVENT="${{ github.event_name }}"
+
+          if [ "$EVENT" != "workflow_dispatch" ] || [ -z "$PROJECT" ] || [ "$PROJECT" = "all" ]; then
+            echo "matrix=$ALL" >> "$GITHUB_OUTPUT"
+          elif [ "$PROJECT" = "chromium" ]; then
+            echo "matrix=$CHROMIUM" >> "$GITHUB_OUTPUT"
+          elif [ "$PROJECT" = "firefox" ]; then
+            echo "matrix=$FIREFOX" >> "$GITHUB_OUTPUT"
+          elif [ "$PROJECT" = "webkit" ]; then
+            echo "matrix=$WEBKIT" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=$ALL" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: setup-matrix
     name: ${{ matrix.project }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - project: 'Chromium'
-            browser: chromium
-            id: chromium
-          - project: 'Firefox'
-            browser: firefox
-            id: firefox
-          - project: 'Webkit'
-            browser: webkit
-            id: webkit
-          - project: 'Mobile Chrome'
-            browser: chromium
-            id: mobile-chrome
-          - project: 'Mobile Safari'
-            browser: webkit
-            id: mobile-safari
+      matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -20,7 +20,7 @@ on:
           - firefox
           - webkit
       update_visual_baselines:
-        description: 'Regenerate Linux visual baselines for all 5 browser projects (--update-snapshots) and commit them back to the branch'
+        description: 'Regenerate Linux visual baselines via --update-snapshots and commit them back to the branch (only the browser projects selected by the project input are updated)'
         type: boolean
         default: false
       ref:
@@ -39,14 +39,15 @@ jobs:
     steps:
       - name: Compute matrix
         id: compute
+        env:
+          # Use env vars to avoid direct ${{ }} interpolation in the shell body (script injection risk)
+          PROJECT: ${{ inputs.project }}
+          EVENT: ${{ github.event_name }}
         run: |
           ALL='{"include":[{"project":"Chromium","browser":"chromium","id":"chromium"},{"project":"Firefox","browser":"firefox","id":"firefox"},{"project":"Webkit","browser":"webkit","id":"webkit"},{"project":"Mobile Chrome","browser":"chromium","id":"mobile-chrome"},{"project":"Mobile Safari","browser":"webkit","id":"mobile-safari"}]}'
           CHROMIUM='{"include":[{"project":"Chromium","browser":"chromium","id":"chromium"},{"project":"Mobile Chrome","browser":"chromium","id":"mobile-chrome"}]}'
           FIREFOX='{"include":[{"project":"Firefox","browser":"firefox","id":"firefox"}]}'
           WEBKIT='{"include":[{"project":"Webkit","browser":"webkit","id":"webkit"},{"project":"Mobile Safari","browser":"webkit","id":"mobile-safari"}]}'
-
-          PROJECT="${{ inputs.project }}"
-          EVENT="${{ github.event_name }}"
 
           if [ "$EVENT" != "workflow_dispatch" ] || [ -z "$PROJECT" ] || [ "$PROJECT" = "all" ]; then
             echo "matrix=$ALL" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ bruno/                      # Bruno API request collection
 
 ## Prerequisites
 
-| Tool | Required for | Install |
-|------|-------------|---------|
-| [Node.js](https://nodejs.org/) v18+ | Playwright tests | [nodejs.org](https://nodejs.org/) |
-| [Bruno](https://www.usebruno.com/) | API request collection | Standalone app or [VSCode extension](https://marketplace.visualstudio.com/items?itemName=bruno-api-client.bruno) |
-| [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Running GitHub Actions locally | [docker.com](https://www.docker.com/products/docker-desktop/) |
-| [act](https://github.com/nektos/act) | Running GitHub Actions locally | `brew install act` |
+| Tool                                                              | Required for                   | Install                                                                                                          |
+| ----------------------------------------------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| [Node.js](https://nodejs.org/) v18+                               | Playwright tests               | [nodejs.org](https://nodejs.org/)                                                                                |
+| [Bruno](https://www.usebruno.com/)                                | API request collection         | Standalone app or [VSCode extension](https://marketplace.visualstudio.com/items?itemName=bruno-api-client.bruno) |
+| [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Running GitHub Actions locally | [docker.com](https://www.docker.com/products/docker-desktop/)                                                    |
+| [act](https://github.com/nektos/act)                              | Running GitHub Actions locally | `brew install act`                                                                                               |
 
 Node.js includes `npm` — no separate installation needed. Docker and `act` are optional — only needed for local CI testing.
 
@@ -112,9 +112,9 @@ npm run format:check
 
 Tests are tagged `@smoke` or `@regression` using Playwright's test options syntax (`{ tag: '@smoke' }`).
 
-| Tag | Purpose | Files |
-|---|---|---|
-| `@smoke` | Quick health check: HTTP status, page titles, heading visibility | `api.spec.ts`, `navigation.spec.ts` |
+| Tag           | Purpose                                                                              | Files                                                                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@smoke`      | Quick health check: HTTP status, page titles, heading visibility                     | `api.spec.ts`, `navigation.spec.ts`                                                                                                              |
 | `@regression` | Deep checks: table content, SVG analysis, external link hrefs, accessibility, visual | `home.spec.ts`, `about-system.spec.ts`, `contact.spec.ts`, `statistics.spec.ts`, `accessibility.spec.ts`, `validation.spec.ts`, `visual.spec.ts` |
 
 Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tests](#running-tests)).
@@ -174,7 +174,7 @@ Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tes
 - `expect.toHaveScreenshot: { maxDiffPixelRatio: 0.01 }` — global threshold for visual regression tests
 - `snapshotPathTemplate` includes `{platform}` so macOS (`-darwin`) and Linux (`-linux`) each have their own baselines; macOS baselines are committed from local runs, Linux baselines are generated via the CI workflow
 
-**CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uses a matrix strategy (`fail-fast: false`) to run each of the 5 browser projects (Chromium, Firefox, Webkit, Mobile Chrome, Mobile Safari) in parallel, each in its own job; each matrix job installs only the browser it needs (`chromium`, `firefox`, or `webkit`) and uploads its report as `playwright-report-<id>` (retained 30 days); npm dependencies are cached via `actions/setup-node` `cache: 'npm'` keyed on `package-lock.json`; upload is skipped when running locally with `act`. Also supports `workflow_dispatch` with two inputs: `update_visual_baselines` (boolean, regenerates Linux baselines for all 5 browser projects via `--update-snapshots` — each matrix job uploads `visual-baselines-linux-<id>` and the `commit-baselines` job downloads all five with `merge-multiple: true` before committing) and `ref` (branch to run on; defaults to triggering branch). To generate Linux baselines for a feature branch: Actions → "Playwright Typescript Tests" → "Run workflow" → enter the branch name in `ref`, check `update_visual_baselines`.
+**CI:** `.github/workflows/playwright-typescript.yml` — runs on push/PR to main/master with `working-directory: playwright/typescript`; uses a matrix strategy (`fail-fast: false`) to run each of the 5 browser projects (Chromium, Firefox, Webkit, Mobile Chrome, Mobile Safari) in parallel, each in its own job; each matrix job installs only the browser it needs (`chromium`, `firefox`, or `webkit`) and uploads its report as `playwright-report-<id>` (retained 30 days); npm dependencies are cached via `actions/setup-node` `cache: 'npm'` keyed on `package-lock.json`; upload is skipped when running locally with `act`. Also supports `workflow_dispatch` with three inputs: `project` (choice: `all` / `chromium` / `firefox` / `webkit`; defaults to `all` — a `setup-matrix` job computes the matrix at runtime so only matching browser entries run; selecting `chromium` also runs Mobile Chrome, `webkit` also runs Mobile Safari), `update_visual_baselines` (boolean, regenerates Linux baselines for all 5 browser projects via `--update-snapshots` — each matrix job uploads `visual-baselines-linux-<id>` and the `commit-baselines` job downloads all five with `merge-multiple: true` before committing), and `ref` (branch to run on; defaults to triggering branch). To generate Linux baselines for a feature branch: Actions → "Playwright Typescript Tests" → "Run workflow" → enter the branch name in `ref`, check `update_visual_baselines`.
 
 **Standalone baseline update:** `.github/workflows/update-visual-baselines.yml` — `workflow_dispatch`-only workflow that regenerates Linux baselines for all 5 browser projects and commits them back directly; accepts a `branch` input (defaults to `main`). Use this when you want to regenerate baselines without running the full test suite.
 
@@ -203,10 +203,10 @@ BASIC_AUTH_PASSWORD=<staging basic auth password>
 
 ### Environments
 
-| Environment | Base URL |
-|---|---|
-| production | `https://orwellstat.hubertgajewski.com` |
-| staging | `https://stage.orwellstat.hubertgajewski.com` |
+| Environment | Base URL                                      |
+| ----------- | --------------------------------------------- |
+| production  | `https://orwellstat.hubertgajewski.com`       |
+| staging     | `https://stage.orwellstat.hubertgajewski.com` |
 
 > Staging requires HTTP Basic authentication (`BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD`) in addition to the application login.
 
@@ -229,9 +229,9 @@ In `.bru` files:
 
 ### Requests
 
-| File | Description |
-|---|---|
-| `login-valid.bru` | POST `/zone/` with valid credentials — expects 200 |
+| File                | Description                                          |
+| ------------------- | ---------------------------------------------------- |
+| `login-valid.bru`   | POST `/zone/` with valid credentials — expects 200   |
 | `login-invalid.bru` | POST `/zone/` with invalid credentials — expects 401 |
 
 **CI:** `.github/workflows/bruno.yml` — runs on push/PR to main/master; writes secrets into `bruno/.env` and runs `bru run --env production`.


### PR DESCRIPTION
## Summary
- Adds a `project` choice input (`all` / `chromium` / `firefox` / `webkit`) to the `workflow_dispatch` trigger
- Introduces a `setup-matrix` job that computes the matrix JSON at runtime so only matching browser entries are spawned
- Selecting `chromium` runs Chromium + Mobile Chrome; `webkit` runs Webkit + Mobile Safari; `firefox` runs Firefox only; `all` (default) runs all 5

## Test plan
- [x] Push/PR/schedule triggers: `setup-matrix` falls through to the full 5-project matrix — no behaviour change
- [x] `workflow_dispatch` with `project: firefox`: only the Firefox job appears in the run
- [x] `workflow_dispatch` with `project: all` (default): all 5 matrix jobs appear
- [x] Firefox job still installs `chromium` (for auth.setup.ts) + `firefox` — auth setup continues to work

Closes #62