### PR TITLE
96 Address review: fix command picker preview text

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,6 +1,6 @@
-> **Maintenance:** This file embeds the GitHub issue format from `CLAUDE.md` verbatim. Whenever that section in `CLAUDE.md` changes, update this file to match.
+Draft and create a GitHub issue in the project's documented format.
 
-Create a GitHub issue for the following: $ARGUMENTS
+Description: $ARGUMENTS
 
 Scaffold the issue in the exact format from CLAUDE.md, then create it via `gh issue create`.
 

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,6 +1,6 @@
-> **Maintenance:** This file embeds the issue fix workflow and code review checklist from `CLAUDE.md` verbatim. Whenever either section in `CLAUDE.md` changes, update this file to match.
+Fix a GitHub issue end-to-end: fetch, implement, test, review, commit, and open a PR.
 
-Fix GitHub issue $ARGUMENTS following the issue fix workflow from CLAUDE.md. Execute every step in order and do not proceed past step N until step N is verified complete.
+Issue number: $ARGUMENTS
 
 **Step 1 — Fetch the issue**
 Run `gh issue view $ARGUMENTS` and read every section: User Story, Context, Acceptance Criteria, Implementation Hint, and Definition of Done. State what the issue requires before touching any code.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,6 +1,4 @@
-> **Maintenance:** This file embeds the code review checklist from `CLAUDE.md` verbatim. Whenever that section in `CLAUDE.md` changes, update this file to match.
-
-Review all staged and unstaged changes against the code review checklist from CLAUDE.md.
+Review staged and unstaged changes against the project's code review checklist.
 
 Run `git diff HEAD` to see all changes, then work through every checklist item below. For each item, explicitly state a finding: **pass**, **fail** (with the specific problem), or **N/A** (with the reason it does not apply). Saying "no issues" without articulating what was checked is not acceptable.
 


### PR DESCRIPTION
Closes #96

- Removes maintenance blockquote notes from command files (were showing as raw markdown in the picker preview)
- Rewrites the first line of each command file to a short, human-readable goal description with no `$ARGUMENTS` literal