### PR TITLE
63 Add network mocking with page.route() for edge case testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,18 @@ When creating GitHub issues for requirements, bugs, or code review findings, use
 
 ---
 
+## Commit message convention
+
+Commit messages are always a **short, single-line description** with no body and no `Co-Authored-By` trailer. When a commit relates to one or more GitHub issues, **prefix the message with the issue number(s)** separated by spaces, followed by the description:
+
+- Single issue: `63 Add network mocking tests`
+- Multiple issues: `63 64 Add network mocking tests and fixtures`
+- No issue: `Fix typo in README`
+
+The ticket prefix must come first so `git log --oneline` and GitHub cross-references work at a glance.
+
+---
+
 ## Issue fix workflow
 
 When fixing a GitHub issue, follow these steps in order:
@@ -69,5 +81,5 @@ When fixing a GitHub issue, follow these steps in order:
    - Secrets written to disk (e.g. `echo "KEY=${{ secrets.KEY }}" >> .env`) must be scoped to the minimum needed and never logged.
    - Steps that only make sense in specific contexts (e.g. artifact upload skipped under `act`) must have an `if:` condition with a clear comment explaining the guard.
 8. **Verify all acceptance criteria and the Definition of Done** — read every Given/When/Then scenario and every DoD checkbox in the issue. For each item, explicitly confirm it is satisfied or identify what is missing. Do not proceed to commit until all criteria pass.
-9. Commit with a **short, single-line message** in the format `<issue-number> <short description>` (e.g. `19 Add explicit SvgAnalysis type to page.evaluate()`). No body, no `Co-Authored-By` trailer — single line only.
+9. Commit following the [commit message convention](#commit-message-convention) — prefix with the issue number (e.g. `19 Add explicit SvgAnalysis type to page.evaluate()`).
 10. Push and create a PR — include `Closes #<issue-number>` in the PR body so GitHub links and auto-closes the issue on merge

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ npx playwright test tests/contact.spec.ts
 npx playwright test tests/statistics.spec.ts
 npx playwright test tests/validation.spec.ts
 npx playwright test tests/visual.spec.ts
+npx playwright test tests/network-mocking.spec.ts
 
 # Specific browser
 npx playwright test --project=chromium
@@ -115,7 +116,7 @@ Tests are tagged `@smoke` or `@regression` using Playwright's test options synta
 | Tag           | Purpose                                                                              | Files                                                                                                                                            |
 | ------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `@smoke`      | Quick health check: HTTP status, page titles, heading visibility                     | `api.spec.ts`, `navigation.spec.ts`                                                                                                              |
-| `@regression` | Deep checks: table content, SVG analysis, external link hrefs, accessibility, visual | `home.spec.ts`, `about-system.spec.ts`, `contact.spec.ts`, `statistics.spec.ts`, `accessibility.spec.ts`, `validation.spec.ts`, `visual.spec.ts` |
+| `@regression` | Deep checks: table content, SVG analysis, external link hrefs, accessibility, visual | `home.spec.ts`, `about-system.spec.ts`, `contact.spec.ts`, `statistics.spec.ts`, `accessibility.spec.ts`, `validation.spec.ts`, `visual.spec.ts`, `network-mocking.spec.ts` |
 
 Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tests](#running-tests)).
 
@@ -132,6 +133,7 @@ Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tes
   - `contact.spec.ts` — Contact page headings and statsbar content tests; tagged `@regression`
   - `statistics.spec.ts` — Service statistics page: SVG chart rendering and statistics table tests; tagged `@regression`
   - `validation.spec.ts` — W3C XHTML and CSS validation tests across all pages (classic W3C Markup Validator + CSS validator APIs); Chromium-only; tagged `@regression`
+  - `network-mocking.spec.ts` — Network mocking tests using `page.route()`: mocks the SVG chart endpoint with a static response (deterministic render, no animation timing) and mocks the W3C markup validator to return validation errors (negative test for error detection); Chromium-only; tagged `@regression`
   - `visual.spec.ts` — Full-page visual regression snapshots for home (default and Purple Rain style), about system, contact, and statistics pages using `toHaveScreenshot()` with `maxDiffPixelRatio: 0.01`; home page masks `#statsbar` lists (dynamic new-browser/OS list items) via `getByRole('list')`; statistics page masks `getByRole('table')` (live data) and `object[type="image/svg+xml"]` (dynamic SVG chart), removes all but the first 5 rows from the statistics table via `page.evaluate()` to keep the footer at a stable position regardless of how many browser/OS rows live data contains (CSS height/overflow tricks are ineffective here: Playwright's `fullPage` screenshot and mask both use the element's full bounding box, not the clipped visual; physically removing rows is the only reliable fix), waits for `<object>` to be visible before screenshotting to stabilise layout, and disables animations; baselines stored in `tests/visual.spec.ts-snapshots/` with per-platform suffixes (`-darwin`, `-linux`); tagged `@regression`
 - `auth.setup.ts` — Playwright auth setup: logs in via UI and saves storage state to `.auth/user.json`
 - `pages/` — Page Object Model classes

--- a/playwright/typescript/tests/network-mocking.spec.ts
+++ b/playwright/typescript/tests/network-mocking.spec.ts
@@ -48,7 +48,7 @@ test.describe('network mocking with page.route()', { tag: '@regression' }, () =>
       });
     });
 
-    await page.goto(ServiceStatisticsPage.url);
+    await page.goto('about:blank');
 
     const result = await page.evaluate<W3cResponse, string>(async (url) => {
       const response = await fetch(`${url}?output=json`);

--- a/playwright/typescript/tests/network-mocking.spec.ts
+++ b/playwright/typescript/tests/network-mocking.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@fixtures/base.fixture';
+import { ServiceStatisticsPage } from '@pages/public/service-statistics.page';
+
+const SVG_CONTENT_TYPE = 'image/svg+xml';
+const W3C_MARKUP_VALIDATOR = 'https://validator.w3.org/check';
+
+// Minimal valid SVG returned instead of the animated chart — no timing variables, deterministic render
+const STATIC_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200"><rect width="400" height="200" fill="steelblue"/></svg>`;
+
+type W3cResponse = {
+  messages: Array<{ type: string; message: string; lastLine?: number }>;
+};
+
+test.describe('network mocking with page.route()', { tag: '@regression' }, () => {
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Network mocking tests run on Chromium only'
+  );
+
+  test('SVG chart renders with mocked static response', async ({ page }) => {
+    // Intercept the chart sub-resource loaded by the <object> element and return a static SVG.
+    // This eliminates animation timing variability: the chart is visible and deterministic
+    // regardless of how long the real endpoint takes.
+    await page.route(`**/${ServiceStatisticsPage.svgChartUrl}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: SVG_CONTENT_TYPE,
+        body: STATIC_SVG,
+      });
+    });
+
+    await page.goto(ServiceStatisticsPage.url);
+    await expect(page.locator(`object[type="${SVG_CONTENT_TYPE}"]`)).toBeVisible();
+  });
+
+  test('W3C validation errors are detected from mocked response', async ({ page }) => {
+    // Intercept requests to the W3C markup validator and return a controlled error payload.
+    // The fetch is made from within page.evaluate() so it goes through the browser context
+    // and is intercepted by page.route() — this is a negative test that would be impossible
+    // to run reliably against the live validator (rate limiting, downtime).
+    await page.route(`${W3C_MARKUP_VALIDATOR}**`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          messages: [{ type: 'error', message: 'Stray end tag div', lastLine: 42 }],
+        }),
+      });
+    });
+
+    await page.goto(ServiceStatisticsPage.url);
+
+    const result = await page.evaluate<W3cResponse, string>(async (url) => {
+      const response = await fetch(`${url}?output=json`);
+      return response.json();
+    }, W3C_MARKUP_VALIDATOR);
+
+    const errors = result.messages.filter(
+      (m) => m.type === 'error' || m.type === 'non-document-error'
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe('Stray end tag div');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `tests/network-mocking.spec.ts` with two `page.route()` tests: mocking the SVG chart endpoint (static, deterministic response) and mocking the W3C markup validator to return validation errors (negative test)
- Documents the commit message convention (ticket prefix) in `CLAUDE.md`
- Updates `README.md` with the new spec file in the single-test-file list, test tags table, and architecture section

## Test plan

- [x] `npx playwright test tests/network-mocking.spec.ts --project=chromium` — both tests pass
- [x] Original `statistics.spec.ts` and `validation.spec.ts` are untouched and continue passing
- [x] `tsc --noEmit` passes with no errors
- [x] `npm run format:check` passes

Closes #63