### PR TITLE
94 Add Claude Code hooks for automated tsc and format checks

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -58,4 +58,9 @@ Read every Given/When/Then scenario and every DoD checkbox in the issue. For eac
 Stage changed files by name (never `git add -A`). Commit with a short, single-line message in the format `$ARGUMENTS <short description>` (e.g. `$ARGUMENTS Add explicit SvgAnalysis type to page.evaluate()`). No body, no `Co-Authored-By` trailer — single line only.
 
 **Step 11 — Push and create a PR**
-Push the branch and run `gh pr create` with `Closes #$ARGUMENTS` in the PR body so GitHub links and auto-closes the issue on merge.
+Push the branch and run `gh pr create`. The PR body must include:
+- `Closes #$ARGUMENTS` so GitHub links and auto-closes the issue on merge
+- A **Test plan** section with a checklist of observable, verifiable steps. Mark steps already verified during development as `[x]`. Steps that require a reviewer or CI to verify must be left as `[ ]`.
+
+**Step 12 — Verify the PR test plan**
+Re-read every test plan item. For each `[ ]` item that can be verified now, execute and confirm it. Update the PR body via `gh pr edit` to mark newly confirmed items as `[x]`. For items that genuinely require a reviewer or CI, leave them as `[ ]` and note what is needed. If any item is found to be wrong or failing, implement a fix on the **same branch**: apply the fix, run tsc and format, work through the code review checklist, run the affected tests, then commit and push to the same branch before considering the task done.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // empty'); if echo \"$FILE\" | grep -q 'playwright/typescript'; then ROOT=$(git -C \"$(dirname \"$FILE\")\" rev-parse --show-toplevel 2>/dev/null) && cd \"$ROOT/playwright/typescript\" && npx tsc --noEmit; npm run format; fi; true",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // empty'); if echo \"$FILE\" | grep -q 'playwright/typescript'; then ROOT=$(git -C \"$(dirname \"$FILE\")\" rev-parse --show-toplevel 2>/dev/null) && cd \"$ROOT/playwright/typescript\" && npx tsc --noEmit && npm run format; fi; true",
             "timeout": 60,
             "statusMessage": "Checking types and formatting..."
           }
@@ -55,7 +55,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); if echo \"$INPUT\" | jq -r '.tool_input.command // empty' | grep -q 'git commit'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && cd \"$ROOT/playwright/typescript\" && npx tsc --noEmit && npm run format:check; fi",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -q 'git commit'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 2; cd \"$ROOT/playwright/typescript\" || exit 2; OUT=$(npx tsc --noEmit 2>&1); TSC_EXIT=$?; if [ $TSC_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; OUT=$(npm run format:check 2>&1); FMT_EXIT=$?; if [ $FMT_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; fi",
             "timeout": 60,
             "statusMessage": "Verifying types and format before commit..."
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,5 +34,33 @@
       "Read(**/*.pem)",
       "Read(**/*.pfx)"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // empty'); if echo \"$FILE\" | grep -q 'playwright/typescript'; then ROOT=$(git -C \"$(dirname \"$FILE\")\" rev-parse --show-toplevel 2>/dev/null) && cd \"$ROOT/playwright/typescript\" && npx tsc --noEmit; npm run format; fi; true",
+            "timeout": 60,
+            "statusMessage": "Checking types and formatting..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); if echo \"$INPUT\" | jq -r '.tool_input.command // empty' | grep -q 'git commit'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && cd \"$ROOT/playwright/typescript\" && npx tsc --noEmit && npm run format:check; fi",
+            "timeout": 60,
+            "statusMessage": "Verifying types and format before commit..."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,4 +84,7 @@ When fixing a GitHub issue, follow these steps in order:
    - Steps that only make sense in specific contexts (e.g. artifact upload skipped under `act`) must have an `if:` condition with a clear comment explaining the guard.
 8. **Verify all acceptance criteria and the Definition of Done** — read every Given/When/Then scenario and every DoD checkbox in the issue. For each item, explicitly confirm it is satisfied or identify what is missing. Do not proceed to commit until all criteria pass.
 9. Commit following the [commit message convention](#commit-message-convention) — prefix with the issue number (e.g. `19 Add explicit SvgAnalysis type to page.evaluate()`).
-10. Push and create a PR — include `Closes #<issue-number>` in the PR body so GitHub links and auto-closes the issue on merge
+10. Push and create a PR — the PR body must include:
+    - `Closes #<issue-number>` so GitHub links and auto-closes the issue on merge
+    - A **Test plan** section with a checklist of observable, verifiable steps. Mark steps already verified during development as `[x]`. Steps that require a reviewer or CI to verify must be left as `[ ]`.
+11. **Verify the PR test plan** — after the PR is created, re-read every test plan item. For each `[ ]` item that can be verified now, execute and confirm it. Update the PR body via `gh pr edit` to mark newly confirmed items as `[x]`. For items that genuinely require a reviewer or CI, leave them as `[ ]` and note what is needed. If any item is found to be wrong or failing, implement a fix on the **same branch**: apply the fix, run tsc and format, work through the code review checklist, run the affected tests, then commit and push to the same branch before considering the task done.


### PR DESCRIPTION
## Summary

- Adds `PostToolUse` hook to `.claude/settings.json`: fires after any Edit/Write on a file inside `playwright/typescript/`, runs `npx tsc --noEmit` then `npm run format` automatically; ends with `; true` so it never blocks Claude on type errors (informational)
- Adds `PreToolUse` hook: fires before any Bash call containing `git commit`, runs `npx tsc --noEmit && npm run format:check` and **blocks the commit** if either fails
- Both hooks resolve the repo root via `git rev-parse --show-toplevel` — no hardcoded absolute paths; safe to commit and clone

## Test plan

- [x] JSON is valid (`jq -e` passes)
- [x] After editing a `.ts` file in `playwright/typescript/`, tsc and format run automatically (no manual step)
- [x] Attempting `git commit` with type errors causes the commit to be blocked
- [x] Editing a file outside `playwright/typescript/` (e.g. `README.md`) does not trigger the hook
- [x] Non-commit Bash commands (e.g. `git status`) are not affected by the pre-commit hook

Closes #94