### PR TITLE
66 Add quality metrics dashboard workflow and bug discovery labels

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -16,7 +16,7 @@ Description: $ARGUMENTS
 4. **Implementation Hint** — concrete code snippet showing the fix
 5. **Definition of Done** — checklist of observable, verifiable outcomes
 
-**Labels:** apply semantic labels such as `test-quality`, `flakiness`, `type-safety`, `pom`.
+**Labels:** apply semantic labels such as `test-quality`, `flakiness`, `type-safety`, `pom`. For bug issues (title prefix `[bug]`), also apply one of `found-by-test`, `found-by-manual-testing`, or `found-in-production` to record how the bug was discovered.
 
 **Milestone:** every issue must have a milestone. Pick the one that matches the nature of the work:
 

--- a/.github/scripts/mttr.py
+++ b/.github/scripts/mttr.py
@@ -1,0 +1,26 @@
+"""Compute MTTR from a JSON list of GitHub issues piped on stdin.
+
+Each issue must have 'createdAt' and 'closedAt' ISO-8601 timestamps.
+Accepts an optional argument for the "no data" label; defaults to "N/A".
+"""
+import json
+import sys
+from datetime import datetime
+
+
+def mttr(issues, na_label="N/A"):
+    if not issues:
+        return na_label
+    deltas = []
+    for i in issues:
+        created = datetime.fromisoformat(i["createdAt"].replace("Z", "+00:00"))
+        closed = datetime.fromisoformat(i["closedAt"].replace("Z", "+00:00"))
+        deltas.append((closed - created).total_seconds())
+    avg = sum(deltas) / len(deltas)
+    days = avg / 86400
+    return f"{days:.1f} days" if days >= 1 else f"{avg / 3600:.1f} hours"
+
+
+data = json.load(sys.stdin)
+na = sys.argv[1] if len(sys.argv) > 1 else "N/A"
+print(mttr(data, na))

--- a/.github/workflows/quality-metrics.yml
+++ b/.github/workflows/quality-metrics.yml
@@ -18,10 +18,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Defect escape rate
-          FOUND_BY_TEST=$(gh issue list --label "bug,found-by-test" --state all --json number --jq 'length')
-          FOUND_BY_MANUAL=$(gh issue list --label "bug,found-by-manual-testing" --state all --json number --jq 'length')
-          FOUND_IN_PROD=$(gh issue list --label "bug,found-in-production" --state all --json number --jq 'length')
+          # Defect escape rate — use --limit 1000 to avoid the default 30-item cap
+          FOUND_BY_TEST=$(gh issue list --label "bug,found-by-test" --state all --limit 1000 --json number --jq 'length')
+          FOUND_BY_MANUAL=$(gh issue list --label "bug,found-by-manual-testing" --state all --limit 1000 --json number --jq 'length')
+          FOUND_IN_PROD=$(gh issue list --label "bug,found-in-production" --state all --limit 1000 --json number --jq 'length')
           TOTAL=$((FOUND_BY_TEST + FOUND_BY_MANUAL + FOUND_IN_PROD))
 
           if [ "$TOTAL" -eq 0 ]; then
@@ -32,55 +32,17 @@ jobs:
           fi
 
           # MTTR — average resolution time for all closed bugs
-          MTTR_DATA=$(gh issue list --label "bug" --state closed --json number,createdAt,closedAt)
-          MTTR=$(echo "$MTTR_DATA" | python3 -c "
-          import json, sys
-          from datetime import datetime
-          issues = json.load(sys.stdin)
-          if not issues:
-              print('N/A (no closed bugs)')
-          else:
-              deltas = []
-              for i in issues:
-                  created = datetime.fromisoformat(i['createdAt'].replace('Z', '+00:00'))
-                  closed = datetime.fromisoformat(i['closedAt'].replace('Z', '+00:00'))
-                  deltas.append((closed - created).total_seconds())
-              avg = sum(deltas) / len(deltas)
-              days = avg / 86400
-              hours = avg / 3600
-              if days >= 1:
-                  print(f'{days:.1f} days')
-              else:
-                  print(f'{hours:.1f} hours')
-          ")
+          MTTR=$(gh issue list --label "bug" --state closed --limit 1000 --json number,createdAt,closedAt \
+            | python3 .github/scripts/mttr.py "N/A (no closed bugs)")
 
           # MTTR broken down by discovery label (closed bugs only)
           for LABEL in "found-by-test" "found-by-manual-testing" "found-in-production"; do
-            DATA=$(gh issue list --label "bug,$LABEL" --state closed --json number,createdAt,closedAt)
-            MTTR_BY_LABEL=$(echo "$DATA" | python3 -c "
-          import json, sys
-          from datetime import datetime
-          issues = json.load(sys.stdin)
-          if not issues:
-              print('N/A')
-          else:
-              deltas = []
-              for i in issues:
-                  created = datetime.fromisoformat(i['createdAt'].replace('Z', '+00:00'))
-                  closed = datetime.fromisoformat(i['closedAt'].replace('Z', '+00:00'))
-                  deltas.append((closed - created).total_seconds())
-              avg = sum(deltas) / len(deltas)
-              days = avg / 86400
-              hours = avg / 3600
-              if days >= 1:
-                  print(f'{days:.1f} days')
-              else:
-                  print(f'{hours:.1f} hours')
-          ")
+            MTTR_BY_LABEL=$(gh issue list --label "bug,$LABEL" --state closed --limit 1000 --json number,createdAt,closedAt \
+              | python3 .github/scripts/mttr.py)
             case "$LABEL" in
-              "found-by-test")       MTTR_TEST="$MTTR_BY_LABEL" ;;
+              "found-by-test")           MTTR_TEST="$MTTR_BY_LABEL" ;;
               "found-by-manual-testing") MTTR_MANUAL="$MTTR_BY_LABEL" ;;
-              "found-in-production") MTTR_PROD="$MTTR_BY_LABEL" ;;
+              "found-in-production")     MTTR_PROD="$MTTR_BY_LABEL" ;;
             esac
           done
 

--- a/.github/workflows/quality-metrics.yml
+++ b/.github/workflows/quality-metrics.yml
@@ -1,0 +1,106 @@
+name: Quality Metrics Dashboard
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 6 AM UTC
+  workflow_dispatch:
+
+jobs:
+  calculate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Calculate quality metrics
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Defect escape rate
+          FOUND_BY_TEST=$(gh issue list --label "bug,found-by-test" --state all --json number --jq 'length')
+          FOUND_BY_MANUAL=$(gh issue list --label "bug,found-by-manual-testing" --state all --json number --jq 'length')
+          FOUND_IN_PROD=$(gh issue list --label "bug,found-in-production" --state all --json number --jq 'length')
+          TOTAL=$((FOUND_BY_TEST + FOUND_BY_MANUAL + FOUND_IN_PROD))
+
+          if [ "$TOTAL" -eq 0 ]; then
+            RATE="N/A (no bugs labeled yet)"
+          else
+            RATE=$(echo "scale=2; $FOUND_IN_PROD * 100 / $TOTAL" | bc)
+            RATE="${RATE}%"
+          fi
+
+          # MTTR — average resolution time for all closed bugs
+          MTTR_DATA=$(gh issue list --label "bug" --state closed --json number,createdAt,closedAt)
+          MTTR=$(echo "$MTTR_DATA" | python3 -c "
+          import json, sys
+          from datetime import datetime
+          issues = json.load(sys.stdin)
+          if not issues:
+              print('N/A (no closed bugs)')
+          else:
+              deltas = []
+              for i in issues:
+                  created = datetime.fromisoformat(i['createdAt'].replace('Z', '+00:00'))
+                  closed = datetime.fromisoformat(i['closedAt'].replace('Z', '+00:00'))
+                  deltas.append((closed - created).total_seconds())
+              avg = sum(deltas) / len(deltas)
+              days = avg / 86400
+              hours = avg / 3600
+              if days >= 1:
+                  print(f'{days:.1f} days')
+              else:
+                  print(f'{hours:.1f} hours')
+          ")
+
+          # MTTR broken down by discovery label (closed bugs only)
+          for LABEL in "found-by-test" "found-by-manual-testing" "found-in-production"; do
+            DATA=$(gh issue list --label "bug,$LABEL" --state closed --json number,createdAt,closedAt)
+            MTTR_BY_LABEL=$(echo "$DATA" | python3 -c "
+          import json, sys
+          from datetime import datetime
+          issues = json.load(sys.stdin)
+          if not issues:
+              print('N/A')
+          else:
+              deltas = []
+              for i in issues:
+                  created = datetime.fromisoformat(i['createdAt'].replace('Z', '+00:00'))
+                  closed = datetime.fromisoformat(i['closedAt'].replace('Z', '+00:00'))
+                  deltas.append((closed - created).total_seconds())
+              avg = sum(deltas) / len(deltas)
+              days = avg / 86400
+              hours = avg / 3600
+              if days >= 1:
+                  print(f'{days:.1f} days')
+              else:
+                  print(f'{hours:.1f} hours')
+          ")
+            case "$LABEL" in
+              "found-by-test")       MTTR_TEST="$MTTR_BY_LABEL" ;;
+              "found-by-manual-testing") MTTR_MANUAL="$MTTR_BY_LABEL" ;;
+              "found-in-production") MTTR_PROD="$MTTR_BY_LABEL" ;;
+            esac
+          done
+
+          echo "## Quality Metrics Report — $(date -u +%Y-%m-%d)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Defect Escape Rate" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Discovery method | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Found by automated tests | $FOUND_BY_TEST |" >> $GITHUB_STEP_SUMMARY
+          echo "| Found by manual testing (staging) | $FOUND_BY_MANUAL |" >> $GITHUB_STEP_SUMMARY
+          echo "| Found in production | $FOUND_IN_PROD |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Total bugs** | **$TOTAL** |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Escape rate** | **$RATE** |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### MTTR (Mean Time To Resolve)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Scope | MTTR |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|------|" >> $GITHUB_STEP_SUMMARY
+          echo "| All closed bugs | $MTTR |" >> $GITHUB_STEP_SUMMARY
+          echo "| Found by automated tests | $MTTR_TEST |" >> $GITHUB_STEP_SUMMARY
+          echo "| Found by manual testing (staging) | $MTTR_MANUAL |" >> $GITHUB_STEP_SUMMARY
+          echo "| Found in production | $MTTR_PROD |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/quality-metrics.yml
+++ b/.github/workflows/quality-metrics.yml
@@ -12,7 +12,7 @@ jobs:
       issues: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Calculate quality metrics
         env:

--- a/README.md
+++ b/README.md
@@ -192,6 +192,21 @@ Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tes
 
 **Automated code review:** `.github/workflows/claude-code-review.yml` — triggers on pull request events (opened, synchronize, ready_for_review, reopened); runs `anthropics/claude-code-action@v1` (model: `claude-sonnet-4-6`) to review the PR and post inline comments; focuses on Playwright test correctness, POM conventions, TypeScript quality, and consistency; requires `ANTHROPIC_API_KEY` secret.
 
+**Quality Metrics Dashboard:** `.github/workflows/quality-metrics.yml` — runs on schedule (every Monday at 6 AM UTC) and on `workflow_dispatch`; queries all issues labeled `bug` to calculate two metrics and writes them to the GitHub Actions step summary:
+
+- **Defect escape rate** = `found-in-production / (found-by-test + found-by-manual-testing + found-in-production)` — measures how effective testing is at catching bugs before users hit them.
+- **MTTR (Mean Time To Resolve)** = average of `(closedAt − createdAt)` across all closed `bug` issues, displayed in days/hours; also broken down by discovery label.
+
+Bug issues must carry one of three discovery labels (in addition to `bug`) for the escape rate formula to work:
+
+| Label | Meaning | Color |
+|---|---|---|
+| `found-by-test` | Caught by automated Playwright (or other) tests | green |
+| `found-by-manual-testing` | Discovered manually during staging testing | yellow |
+| `found-in-production` | Reported by actual users on production | red |
+
+MTTR is calculated for all `bug`-labeled issues regardless of discovery method, and also broken down per discovery label for insight into resolution speed by source.
+
 ---
 
 ## bruno


### PR DESCRIPTION
## Summary

- Creates `found-by-test`, `found-by-manual-testing`, and `found-in-production` labels for distinguishing bug discovery method
- Retroactively labels existing bug issues #47–50 (all found by automated tests, except #50 found by manual CI log inspection)
- Adds `.github/workflows/quality-metrics.yml`: weekly scheduled + `workflow_dispatch` workflow calculating defect escape rate and MTTR (all bugs + broken down by discovery label), results written to GitHub Actions step summary
- Adds `.github/scripts/mttr.py`: shared Python helper for MTTR calculation (avoids duplication in workflow)
- Documents the new workflow, labels, and metrics in `README.md`
- Adds bug discovery label guidance to `.claude/skills/create-issue/SKILL.md`

Closes #66

## Test plan

- [x] Labels `found-by-test`, `found-by-manual-testing`, and `found-in-production` created in the repository
- [x] Issues #47–49 labeled `found-by-test`; issue #50 labeled `found-by-manual-testing`
- [x] Workflow file present at `.github/workflows/quality-metrics.yml` with `schedule` + `workflow_dispatch` triggers
- [x] `timeout-minutes: 10` set at job level; `permissions: issues: read` scoped to minimum needed
- [x] `actions/checkout@v6` matches all other workflows in the repo
- [x] All `gh issue list` calls include `--limit 1000` to avoid silent truncation at 30
- [x] MTTR logic extracted to `.github/scripts/mttr.py` — no duplication
- [x] `README.md` updated with workflow description, label table, and metric definitions
- [x] `.claude/skills/create-issue/SKILL.md` updated with bug discovery label guidance
- [ ] Workflow runs successfully on GitHub Actions (`workflow_dispatch` — trigger manually to verify step summary output)
- [ ] Step summary shows defect escape rate table and MTTR table after a run