### PR TITLE
66 Fix workflow: add missing permissions and tools for act/CI compatibility

### DIFF
--- a/.github/workflows/quality-metrics.yml
+++ b/.github/workflows/quality-metrics.yml
@@ -15,9 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install gh CLI
-        # No-op on GitHub-hosted runners (gh pre-installed); installs for act containers
-        run: type -p gh > /dev/null || (sudo apt-get update -qq && sudo apt-get install -y gh)
+      - name: Install missing tools
+        # No-op on GitHub-hosted runners (gh and bc pre-installed); installs for act containers
+        run: |
+          type -p gh > /dev/null && type -p bc > /dev/null && exit 0
+          sudo apt-get update -qq
+          type -p gh > /dev/null || sudo apt-get install -y gh
+          type -p bc > /dev/null || sudo apt-get install -y bc
 
       - name: Calculate quality metrics
         env:

--- a/.github/workflows/quality-metrics.yml
+++ b/.github/workflows/quality-metrics.yml
@@ -9,10 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      contents: read
       issues: read
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install gh CLI
+        # No-op on GitHub-hosted runners (gh pre-installed); installs for act containers
+        run: type -p gh > /dev/null || (sudo apt-get update -qq && sudo apt-get install -y gh)
 
       - name: Calculate quality metrics
         env:


### PR DESCRIPTION
## Summary

- Adds `contents: read` permission (explicit `permissions:` block stripped the default, breaking `actions/checkout`)
- Adds install step for `gh` and `bc` — both are pre-installed on GitHub-hosted runners but absent from `act` containers, making the workflow untestable locally without this

Closes #66

## Test plan

- [x] `act workflow_dispatch -W .github/workflows/quality-metrics.yml --secret GH_TOKEN=$(gh auth token) --container-architecture linux/amd64` completes successfully locally
- [ ] Workflow runs successfully on GitHub Actions after merge (`workflow_dispatch`)
- [ ] Step summary shows defect escape rate table and MTTR table