### PR TITLE
123 Add CODEX.md entrypoint and document it in README

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,5 @@
+# CODEX.md
+
+Follow the repository guidance in [CLAUDE.md](./CLAUDE.md).
+
+Add instructions here only when Codex-specific behavior needs to differ from `CLAUDE.md`.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,3 @@
 # CODEX.md
 
 Follow the repository guidance in [CLAUDE.md](./CLAUDE.md).
-
-Add instructions here only when Codex-specific behavior needs to differ from `CLAUDE.md`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Three project-scoped skills are available in Claude Code (stored in `.claude/ski
 ```
 .env                        # credentials (git-ignored); see .env.example
 .env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, CLAUDE_DIAGNOSIS
+CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
+CODEX.md                    # Codex entrypoint; delegates shared repository guidance to CLAUDE.md
 .github/workflows/          # CI workflows (one per sub-project)
 QUALITY_METRICS.md          # auto-generated quality metrics report (escape rate, MTTR, coverage, trends)
 SECURITY.md                 # security policy and vulnerability reporting

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Three project-scoped skills are available in Claude Code (stored in `.claude/ski
 ```
 .env                        # credentials (git-ignored); see .env.example
 .env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, CLAUDE_DIAGNOSIS
+.github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
 CODEX.md                    # Codex entrypoint; delegates shared repository guidance to CLAUDE.md
-.github/workflows/          # CI workflows (one per sub-project)
 QUALITY_METRICS.md          # auto-generated quality metrics report (escape rate, MTTR, coverage, trends)
 SECURITY.md                 # security policy and vulnerability reporting
 quality-metrics-history.json  # historical quality metrics data points (auto-committed by workflow)


### PR DESCRIPTION
Closes #123

## Summary

- add a root `CODEX.md` file that points Codex to `CLAUDE.md`
- document `CLAUDE.md` and `CODEX.md` in the repository structure section of `README.md`

## Test plan

- [x] Verify `CODEX.md` exists at the repository root
- [x] Verify `CODEX.md` references `CLAUDE.md` instead of duplicating the shared guidance
- [x] Verify `README.md` documents the new root guidance file
- [x] Run `git diff --check -- README.md CODEX.md`
- [x] Reviewer confirms the new guidance file is discoverable in GitHub UI after merge
