### PR TITLE
[infra] Establish Gemini CLI foundational mandates

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,15 @@
+# GEMINI.md - Foundational Mandates for Orwell Stat
+
+Follow the repository guidance in [CLAUDE.md](./CLAUDE.md).
+
+Also read [`.claude/settings.json`](./.claude/settings.json) as the repository's concrete allow/deny baseline for tool usage and sensitive file access.
+
+When Gemini tooling does not enforce that file directly, apply it manually:
+
+- Treat entries in `permissions.allow` as the default safe scope for commands and web access.
+- Treat entries in `permissions.deny` as hard no-read / no-access rules.
+- Follow the intent of the configured hooks before committing or after relevant edits, especially the TypeScript and formatting checks for `playwright/typescript`.
+- If Gemini-specific runtime rules (system prompt) are stricter than `.claude/settings.json`, follow the stricter rule.
+- If Gemini-specific runtime rules are looser than `.claude/settings.json`, still follow `.claude/settings.json` for work in this repository.
+
+If [CLAUDE.md](./CLAUDE.md), [`.claude/settings.json`](./.claude/settings.json), or the documents they reference contain instructions that are specific to Claude tooling or Claude-only features, do not ignore them silently. Use the closest Gemini-equivalent workflow or safety rule available (e.g., using `run_shell_command` for bash, `web_fetch` for web access). State what Claude-specific instruction could not be followed literally, what you did instead, and any practical limitation or behavior difference that remains.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,4 @@
-# GEMINI.md - Foundational Mandates for Orwell Stat
+# GEMINI.md
 
 Follow the repository guidance in [CLAUDE.md](./CLAUDE.md).
 
@@ -6,10 +6,10 @@ Also read [`.claude/settings.json`](./.claude/settings.json) as the repository's
 
 When Gemini tooling does not enforce that file directly, apply it manually:
 
-- Treat entries in `permissions.allow` as the default safe scope for commands and web access.
-- Treat entries in `permissions.deny` as hard no-read / no-access rules.
-- Follow the intent of the configured hooks before committing or after relevant edits, especially the TypeScript and formatting checks for `playwright/typescript`.
-- If Gemini-specific runtime rules (system prompt) are stricter than `.claude/settings.json`, follow the stricter rule.
-- If Gemini-specific runtime rules are looser than `.claude/settings.json`, still follow `.claude/settings.json` for work in this repository.
+- treat entries in `permissions.allow` as the default safe scope for commands and web access
+- treat entries in `permissions.deny` as hard no-read / no-access rules
+- follow the intent of the configured hooks before committing or after relevant edits, especially the TypeScript and formatting checks for `playwright/typescript`
+- if Gemini-specific runtime rules (system prompt) are stricter than `.claude/settings.json`, follow the stricter rule
+- if Gemini-specific runtime rules are looser than `.claude/settings.json`, still follow `.claude/settings.json` for work in this repository
 
 If [CLAUDE.md](./CLAUDE.md), [`.claude/settings.json`](./.claude/settings.json), or the documents they reference contain instructions that are specific to Claude tooling or Claude-only features, do not ignore them silently. Use the closest Gemini-equivalent workflow or safety rule available (e.g., using `run_shell_command` for bash, `web_fetch` for web access). State what Claude-specific instruction could not be followed literally, what you did instead, and any practical limitation or behavior difference that remains.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Three project-scoped skills are available in Claude Code (stored in `.claude/ski
 .github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
 CODEX.md                    # Codex entrypoint; delegates shared repository guidance to CLAUDE.md
+GEMINI.md                   # Gemini entrypoint; delegates shared repository guidance to CLAUDE.md
 QUALITY_METRICS.md          # auto-generated quality metrics report (escape rate, MTTR, coverage, trends)
 SECURITY.md                 # security policy and vulnerability reporting
 quality-metrics-history.json  # historical quality metrics data points (auto-committed by workflow)


### PR DESCRIPTION
### Closes #127

### Description
This PR establishes 'GEMINI.md' as the minimalist entry point for Gemini CLI, aligning its behavioral guidance and security protocols with 'CLAUDE.md' and '.claude/settings.json'.

### Test Plan
- **Verification:** Confirm 'GEMINI.md' exists and mirrors the structure of 'CODEX.md'.
- **Enforcement:** Verify that Gemini CLI follows 'deny' rules from '.claude/settings.json' (e.g., refusing to read '.env' or '*password*' files).
- **Tooling Hooks:** Verify that TypeScript and formatting checks are manually respected when editing 'playwright/typescript'.