### PR TITLE
Bump fast-xml-parser to 5.5.7 (CVE-2026-33349)

### DIFF
--- a/bruno/package-lock.json
+++ b/bruno/package-lock.json
@@ -3994,9 +3994,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
-      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
+      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
       "dev": true,
       "funding": [
         {
@@ -4008,7 +4008,7 @@
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
         "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/bruno/package.json
+++ b/bruno/package.json
@@ -7,6 +7,6 @@
     "test": "bru run --env production"
   },
   "overrides": {
-    "fast-xml-parser": ">=4.5.4"
+    "fast-xml-parser": ">=5.5.7"
   }
 }


### PR DESCRIPTION
## Summary

- Tightens the `fast-xml-parser` npm override in `bruno/package.json` from `>=4.5.4` to `>=5.5.7`
- Resolves Dependabot alert [#4](https://github.com/hubertgajewski/orwellstat/security/dependabot/4) — CVE-2026-33349 (entity expansion limits bypassed when set to zero)

## Test plan

- [x] `npm install` in `bruno/` resolves `fast-xml-parser` to `5.5.7`
- [x] Bruno test suite passes (2/2 requests, 2/2 tests)
- [x] Dependabot alert [#4](https://github.com/hubertgajewski/orwellstat/security/dependabot/4) closes after merge