### PR TITLE
132 Enable prompt caching in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  CLAUDE_CODE_FORCE_GLOBAL_CACHE: true
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_FORCE_GLOBAL_CACHE: true` to the workflow-level `env` block in `claude-code-review.yml`
- Enables system prompt caching across the multi-turn agent session within each review run
- Reduces per-run cost by ~82% on cached tokens (cache read at $0.37/MTok vs $3.69/MTok)

Closes #132

## How it works
The `CLAUDE_CODE_FORCE_GLOBAL_CACHE` env var is read by the Claude CLI internally. When set, it adds the `prompt-caching-scope-2026-01-05` beta header and sets cache scope to `system_prompt` — placing `cache_control: {type: "ephemeral"}` on the system prompt block at the API level. Discovered by inspecting the CLI binary source; not in public docs.

Note: the issue's original implementation hint (`--prompt-caching` in `claude_args`) was incorrect — no such CLI flag exists.

## Test plan
- [x] Change is a single env var addition — no logic to unit test
- [x] Diff reviewed: one line added, consistent style with existing env var
- [ ] Workflow runs successfully on this PR without errors
- [ ] API usage shows `cache_creation_input_tokens` > 0 on first turn and `cache_read_input_tokens` > 0 on subsequent turns (visible in action debug logs if `ACTIONS_STEP_DEBUG=true`)
