### PR TITLE
130 Fix check-approval GraphQL error by switching to REST API for PR reviews

### DIFF
--- a/.github/workflows/bruno.yml
+++ b/.github/workflows/bruno.yml
@@ -27,9 +27,8 @@ jobs:
             echo "approved=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          COUNT=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-            --json reviews \
-            --jq '[.reviews[] | select(.state == "APPROVED")] | length')
+          COUNT=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.state == "APPROVED")] | length')
           if [ "$COUNT" -gt 0 ]; then
             echo "approved=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -85,9 +85,8 @@ jobs:
             echo "approved=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          COUNT=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-            --json reviews \
-            --jq '[.reviews[] | select(.state == "APPROVED")] | length')
+          COUNT=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.state == "APPROVED")] | length')
           if [ "$COUNT" -gt 0 ]; then
             echo "approved=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

- Replace `gh pr view --json reviews` (GraphQL) with `gh api .../reviews` (REST) in `check-approval` job in both `playwright-typescript.yml` and `bruno.yml`
- GraphQL fetches review commit details which `GITHUB_TOKEN` cannot access, causing a crash on every PR trigger; REST endpoint returns only what is needed

Closes #130

## Test plan

- [x] Both `playwright-typescript.yml` and `bruno.yml` updated consistently
- [x] `pull-requests: read` permission is sufficient for the REST endpoint — no permission change needed
- [x] Open a PR and verify `check-approval` passes (returns `approved=false`) without a GraphQL error when no review exists
- [x] Approve the PR and verify `check-approval` passes (returns `approved=true`) and test jobs run