### PR TITLE
140 Add opt-in CI workflow gates via repository variables

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,1 +1,2 @@
 --secret-file .env
+--var-file .vars

--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,6 @@ ENV=
 # will silently send an empty password and all requests will return 401.
 BASIC_AUTH_USER=
 BASIC_AUTH_PASSWORD=
-# Optional: AI-powered test failure diagnosis.
-# Both vars must be set to enable. When either is absent the fixture behaves
-# exactly as without them — no extra attachments, no errors.
-# Set CLAUDE_DIAGNOSIS to exactly "true" (without quotes) to opt in.
+# Optional: AI-powered test failure diagnosis (requires CLAUDE_DIAGNOSIS=true in .vars).
+# When absent the fixture behaves exactly as without it — no extra attachments, no errors.
 ANTHROPIC_API_KEY=
-CLAUDE_DIAGNOSIS=

--- a/.github/workflows/bruno.yml
+++ b/.github/workflows/bruno.yml
@@ -9,6 +9,7 @@ on:
     types: [submitted, dismissed]
 jobs:
   check-approval:
+    if: vars.BRUNO == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   review:
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && vars.CLAUDE_REVIEW == 'true'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -67,6 +67,7 @@ jobs:
           fi
 
   check-approval:
+    if: vars.PLAYWRIGHT_TYPESCRIPT == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:

--- a/.github/workflows/quality-metrics.yml
+++ b/.github/workflows/quality-metrics.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   calculate:
+    if: vars.QUALITY_METRICS == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.vars
 .auth/
 .idea/
 *.bak

--- a/.vars.example
+++ b/.vars.example
@@ -1,0 +1,10 @@
+# CI repository variables — loaded by Playwright via dotenv (local runs) and by act via --var-file (local CI).
+# In real GitHub Actions these are set under Settings → Variables → Actions.
+# Copy to .vars and set each variable to "true" to enable the corresponding workflow or feature.
+# When absent or any other value the workflow job or feature is skipped.
+CLAUDE_REVIEW=
+PLAYWRIGHT_TYPESCRIPT=
+BRUNO=
+QUALITY_METRICS=
+# Required alongside ANTHROPIC_API_KEY in .env to enable AI-powered test failure diagnosis.
+CLAUDE_DIAGNOSIS=

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Three project-scoped skills are available in Claude Code (stored in `.claude/ski
 
 ```
 .env                        # credentials (git-ignored); see .env.example
-.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, CLAUDE_DIAGNOSIS
+.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY
+.vars                       # CI repository variables (git-ignored); see .vars.example
+.vars.example               # template: CLAUDE_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, CLAUDE_DIAGNOSIS
 .github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
 CODEX.md                    # Codex entrypoint; delegates shared repository guidance to CLAUDE.md
@@ -54,10 +56,21 @@ ENV=<production|staging>
 BASIC_AUTH_USER=<staging basic auth user>
 BASIC_AUTH_PASSWORD=<staging basic auth password>
 ANTHROPIC_API_KEY=<Anthropic API key>
-CLAUDE_DIAGNOSIS=true
 ```
 
-`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` and `CLAUDE_DIAGNOSIS=true` are both optional — when both are present, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. In CI, all vars are injected as GitHub Actions secrets. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env`).
+`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` is optional — when present alongside `CLAUDE_DIAGNOSIS=true` in `.vars`, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. In CI, secrets are injected as GitHub Actions secrets and variables via GitHub Actions variables. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env` and `../../.vars`).
+
+### CI repository variables
+
+The following variables are set in **GitHub → Settings → Variables → Actions** (not secrets, not `.env`). Locally they live in `.vars` (loaded by Playwright via dotenv and by `act` via `--var-file`). Each is an opt-in gate: set to exactly `true` to enable; when absent or any other value the feature or workflow job is skipped.
+
+| Variable | Purpose | When it applies |
+|---|---|---|
+| `CLAUDE_DIAGNOSIS` | AI-powered test failure diagnosis attachment | Every Playwright run (local and CI) |
+| `CLAUDE_REVIEW` | `claude-code-review.yml` | PR events (opened, synchronize, ready_for_review, reopened) |
+| `PLAYWRIGHT_TYPESCRIPT` | `playwright-typescript.yml` | PR events, push to main, Sunday 03:00 UTC schedule, `workflow_dispatch` |
+| `BRUNO` | `bruno.yml` | PR events, push to main |
+| `QUALITY_METRICS` | `quality-metrics.yml` | Monday 06:00 UTC schedule, `workflow_dispatch` |
 
 ---
 
@@ -308,7 +321,7 @@ On first run, `act` will ask for a Docker image size — choose **Medium** (~500
 
 > **Note (macOS Apple Silicon):** The `--container-architecture linux/amd64` flag is required on Apple Silicon (M-series) Macs to avoid compatibility issues. Linux and Windows 11 users running on x86-64 hardware can omit this flag.
 
-> **Credentials:** The repo root contains `.actrc` which automatically passes `--secret-file .env` to every `act` invocation. `ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` from `.env` are loaded as secrets with no extra flags needed.
+> **Credentials:** The repo root contains `.actrc` which automatically passes `--secret-file .env` and `--var-file .vars` to every `act` invocation. `ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` from `.env` are loaded as secrets with no extra flags needed. Copy `.vars.example` to `.vars` and set variables to `true` to enable the corresponding workflow jobs and features — without this, all gated jobs are skipped.
 
 ### Docker RAM requirements for the Playwright matrix
 

--- a/playwright/typescript/utils/env.util.ts
+++ b/playwright/typescript/utils/env.util.ts
@@ -6,6 +6,7 @@ export function loadEnv(importMetaUrl: string, levelsUp: number): void {
   const dir = dirname(fileURLToPath(importMetaUrl));
   const parts = Array(levelsUp).fill('..');
   dotenv.config({ path: resolve(dir, ...parts, '.env') });
+  dotenv.config({ path: resolve(dir, ...parts, '.vars') });
 }
 
 export function requireCredentials(): { user: string; password: string } {


### PR DESCRIPTION
## Summary

- Added `if: vars.X == 'true'` gates to the entry-point jobs of all four active workflows (`claude-code-review.yml`, `playwright-typescript.yml`, `bruno.yml`, `quality-metrics.yml`)
- Consolidated `CLAUDE_DIAGNOSIS` into `.vars` as single source of truth: `env.util.ts` now loads `.vars` alongside `.env`, so local runs, `act`, and CI all use the same variable
- Added `.vars.example` template, updated `.actrc` (`--var-file .vars`), `.gitignore`, and README

## Test plan

- [x] Set each workflow variable to `true` in GitHub → Settings → Variables → Actions and verify the corresponding workflow runs
- [x] Leave a variable unset and verify the workflow is skipped
- [x] Copy `.vars.example` to `.vars`, set `CLAUDE_DIAGNOSIS=true` alongside `ANTHROPIC_API_KEY` in `.env`, run `npx playwright test` locally and confirm AI diagnosis attachment appears on failure
- [x] Run `act push -W .github/workflows/playwright-typescript.yml` with `PLAYWRIGHT_TYPESCRIPT=true` in `.vars` and confirm the workflow executes

Closes #140