### PR TITLE
148 Allow workflow_dispatch to bypass PR approval gate

### DIFF
--- a/.github/workflows/bruno.yml
+++ b/.github/workflows/bruno.yml
@@ -1,5 +1,6 @@
 name: Bruno Tests
 on:
+  workflow_dispatch:
   push:
     branches: [main, master]
   pull_request:
@@ -9,7 +10,7 @@ on:
     types: [submitted, dismissed]
 jobs:
   check-approval:
-    if: vars.BRUNO == 'true'
+    if: vars.BRUNO == 'true' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
@@ -38,7 +39,7 @@ jobs:
 
   test:
     needs: check-approval
-    if: needs.check-approval.outputs.approved == 'true'
+    if: always() && (needs.check-approval.outputs.approved == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   setup-matrix:
     needs: check-approval
-    if: needs.check-approval.outputs.approved == 'true'
+    if: always() && (needs.check-approval.outputs.approved == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -67,7 +67,7 @@ jobs:
           fi
 
   check-approval:
-    if: vars.PLAYWRIGHT_TYPESCRIPT == 'true'
+    if: vars.PLAYWRIGHT_TYPESCRIPT == 'true' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
@@ -96,7 +96,7 @@ jobs:
 
   test:
     needs: [setup-matrix, check-approval]
-    if: needs.check-approval.outputs.approved == 'true'
+    if: always() && (needs.check-approval.outputs.approved == 'true' || github.event_name == 'workflow_dispatch')
     name: ${{ matrix.project }}
     timeout-minutes: 15
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ ANTHROPIC_API_KEY=<Anthropic API key>
 
 ### CI repository variables
 
-The following variables are set in **GitHub → Settings → Variables → Actions** (not secrets, not `.env`). Locally they live in `.vars` (loaded by Playwright via dotenv and by `act` via `--var-file`). Each is an opt-in gate: set to exactly `true` to enable; when absent or any other value the feature or workflow job is skipped.
+The following variables are set in **GitHub → Settings → Variables → Actions** (not secrets, not `.env`). Locally they live in `.vars` (loaded by Playwright via dotenv and by `act` via `--var-file`). Each is an opt-in gate: set to exactly `true` to enable; when absent or any other value the feature or workflow job is skipped. Exception: `workflow_dispatch` runs always bypass the approval gate and run tests regardless of the variable value.
 
 | Variable | Purpose | When it applies |
 |---|---|---|
 | `CLAUDE_DIAGNOSIS` | AI-powered test failure diagnosis attachment | Every Playwright run (local and CI) |
 | `CLAUDE_REVIEW` | `claude-code-review.yml` | PR events (opened, synchronize, ready_for_review, reopened) |
 | `PLAYWRIGHT_TYPESCRIPT` | `playwright-typescript.yml` | PR events, push to main, Sunday 03:00 UTC schedule, `workflow_dispatch` |
-| `BRUNO` | `bruno.yml` | PR events, push to main |
+| `BRUNO` | `bruno.yml` | PR events, push to main, `workflow_dispatch` |
 | `QUALITY_METRICS` | `quality-metrics.yml` | Monday 06:00 UTC schedule, `workflow_dispatch` |
 
 ---
@@ -286,7 +286,7 @@ In `.bru` files:
 | `login-valid.bru`   | POST `/zone/` with valid credentials — expects 200   |
 | `login-invalid.bru` | POST `/zone/` with invalid credentials — expects 401 |
 
-**CI:** `.github/workflows/bruno.yml` — runs on push/PR to main/master and on `pull_request_review` (submitted/dismissed); a `check-approval` pre-check job requires at least one `APPROVED` review before tests run — push events bypass the gate automatically; writes secrets into `bruno/.env` and runs `bru run --env production`.
+**CI:** `.github/workflows/bruno.yml` — runs on push/PR to main/master, `pull_request_review` (submitted/dismissed), and `workflow_dispatch`; a `check-approval` pre-check job requires at least one `APPROVED` review before tests run — push and `workflow_dispatch` events bypass the gate automatically; writes secrets into `bruno/.env` and runs `bru run --env production`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Added `workflow_dispatch` trigger to `bruno.yml` (was missing entirely)
- `check-approval` job now skips on `workflow_dispatch` in both workflows, preventing the skip cascade when the variable gate is absent
- Downstream jobs (`test` in Bruno, `setup-matrix` + `test` in Playwright) use `always()` with an explicit `workflow_dispatch` bypass so they run unconditionally on manual triggers
- Updated README "CI repository variables" section to document the new `workflow_dispatch` exception

Closes #148

## Test plan

- [x] `bruno.yml` diff reviewed: `workflow_dispatch` trigger added, `check-approval` condition updated, `test` condition updated with `always()` + bypass
- [x] `playwright-typescript.yml` diff reviewed: `check-approval` condition updated, `setup-matrix` and `test` conditions updated with `always()` + bypass
- [x] README updated: variable table row for `BRUNO` includes `workflow_dispatch`; "CI repository variables" description updated; Bruno CI description updated
- [x] Manually trigger `bruno.yml` via Actions → "Bruno Tests" → "Run workflow" and verify the `test` job runs (not skipped)
- [x] Manually trigger `playwright-typescript.yml` via Actions → "Playwright Typescript Tests" → "Run workflow" and verify `setup-matrix` and `test` jobs run
- [x] Open a PR without approval and verify `test` jobs are still skipped in both workflows (regression check)