### PR TITLE
130 Ensure claudebot always appears in PR reviewers list

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,11 +37,11 @@ jobs:
             - Potential bugs or flaky test patterns
             - Consistency with existing patterns in the codebase
 
-            Use `gh pr review` to submit a formal GitHub review with a status:
+            Always finish by submitting a formal GitHub review using `gh pr review` — this is mandatory regardless of what other tools you used:
             - `gh pr review <number> --approve -b "..."` if the PR looks good
             - `gh pr review <number> --request-changes -b "..."` if changes are needed
             - `gh pr review <number> --comment -b "..."` if you have feedback but no verdict
-            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+            You may also use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues, but it does not replace the required `gh pr review` call.
             Only post GitHub review/comments - don't submit review text as messages.
 
           claude_args: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,24 @@ When fixing a GitHub issue, follow the steps in `.claude/skills/fix-issue/SKILL.
 
 ---
 
+## Creating pull requests
+
+When creating a PR with `gh pr create`, always write the body to a temp file and use `--body-file`:
+
+```bash
+# Write body to temp file (via Write tool or Bash heredoc)
+cat > /tmp/pr_body.md << 'EOF'
+## Summary
+...
+EOF
+
+gh pr create --title "..." --body-file /tmp/pr_body.md
+```
+
+Never use `--body "..."` or a heredoc directly in the `gh pr create` call when the body contains backticks or code blocks — shell quoting causes backticks to render as `\`` in the GitHub description or produces an "unexpected EOF" error.
+
+---
+
 ## MCP servers
 
 This repository defines MCP (Model Context Protocol) servers in `.mcp.json` at the repo root. Any MCP-compatible AI assistant should load this file and use the declared servers when they are the most appropriate tool for a task:


### PR DESCRIPTION
Closes #130

## Summary
- Makes `gh pr review` mandatory as the final step in the review prompt, regardless of whether inline comments were posted via `mcp__github_inline_comment__create_inline_comment`

## Root cause
When Claude posted inline comments but skipped `gh pr review`, the bot was not added to the PR reviewers list. Approvals rarely come with inline comments, so the bot only appeared consistently when approving.

## Test plan
- [ ] Open a PR and wait for Claude bot review with a request-changes or comment verdict — verify claudebot appears in the Reviewers section

Generated with [Claude Code](https://claude.com/claude-code)
