### PR TITLE
143 Add Playwright runner MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,11 @@ An MCP server that runs the Playwright test suite and returns structured JSON re
 ```bash
 cd mcp/playwright-runner
 npm ci
-npm run build
 ```
 
-Restart Claude Code after building to pick up the `playwright-runner` entry from `.mcp.json`.
+`npm ci` automatically builds the server via the `prepare` script — no separate build step needed.
+
+Restart Claude Code after installing to pick up the `playwright-runner` entry from `.mcp.json`.
 
 > The path in `.mcp.json` (`mcp/playwright-runner/dist/index.js`) is relative to the working directory from which Claude Code is launched. Always open Claude Code from the **repo root**.
 

--- a/mcp/playwright-runner/index.ts
+++ b/mcp/playwright-runner/index.ts
@@ -1,13 +1,10 @@
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
 import { spawnSync } from 'child_process';
 import { existsSync, readFileSync, statSync } from 'fs';
 import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
+import { z } from 'zod';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 // __dirname = <repo>/mcp/playwright-runner/dist/ — three levels up to reach repo root
@@ -96,189 +93,144 @@ function err(message: string) {
 
 // ---------- server ----------
 
-const server = new Server(
-  { name: 'playwright-runner', version: '1.0.0' },
-  { capabilities: { tools: {} } }
-);
+const server = new McpServer({ name: 'playwright-runner', version: '1.0.0' });
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
-    {
-      name: 'run_tests',
-      description: 'Run Playwright tests and return structured results.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          spec:    { type: 'string', description: 'Spec file path, e.g. tests/navigation.spec.ts' },
-          browser: { type: 'string', enum: ['Chromium', 'Firefox', 'Webkit', 'Mobile Chrome', 'Mobile Safari'] },
-          tag:     { type: 'string', description: 'Tag filter, e.g. @smoke or @regression' },
-        },
-      },
-    },
-    {
-      name: 'get_failed_tests',
-      description: 'Return failed tests from the last run with error messages and attachment paths.',
-      inputSchema: { type: 'object', properties: {} },
-    },
-    {
-      name: 'get_test_attachment',
-      description: 'Read the content of a named attachment for a specific test from the last run.',
-      inputSchema: {
-        type: 'object',
-        required: ['testTitle', 'attachmentName'],
-        properties: {
-          testTitle:      { type: 'string', description: 'Exact test title as shown in the report' },
-          attachmentName: { type: 'string', description: 'Attachment name, e.g. "AI diagnosis", "DOM"' },
-        },
-      },
-    },
-    {
-      name: 'list_tests',
-      description: 'List all tests with their spec file and tags without running them.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          tag: { type: 'string', description: 'Filter by tag, e.g. @smoke' },
-        },
-      },
-    },
-  ],
-}));
+server.registerTool('run_tests', {
+  description: 'Run Playwright tests and return structured results.',
+  inputSchema: {
+    spec:    z.string().optional().describe('Spec file path, e.g. tests/navigation.spec.ts'),
+    browser: z.enum(['Chromium', 'Firefox', 'Webkit', 'Mobile Chrome', 'Mobile Safari']).optional(),
+    tag:     z.string().optional().describe('Tag filter, e.g. @smoke or @regression'),
+  },
+}, async ({ spec, browser, tag }) => {
+  const cmd = ['npx', 'playwright', 'test'];
+  if (spec)    cmd.push(spec);
+  if (browser) cmd.push('--project', browser);
+  if (tag)     cmd.push('--grep', tag);
 
-server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  const { name, arguments: args = {} } = req.params;
+  const result = spawnSync(cmd[0], cmd.slice(1), {
+    cwd: PW_DIR,
+    encoding: 'utf8',
+    timeout: 300_000,
+  });
 
-  // ── run_tests ──────────────────────────────────────────────────────────────
-  if (name === 'run_tests') {
-    const cmd = ['npx', 'playwright', 'test'];
-    if (args.spec)    cmd.push(String(args.spec));
-    if (args.browser) cmd.push('--project', String(args.browser));
-    if (args.tag)     cmd.push('--grep', String(args.tag));
+  if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
 
-    const result = spawnSync(cmd[0], cmd.slice(1), {
-      cwd: PW_DIR,
-      encoding: 'utf8',
-      timeout: 300_000,
-    });
+  const report = readLastReport();
+  if (!report) return err(`Test run completed but results.json was not found.\nstderr: ${result.stderr ?? ''}`);
 
-    if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
+  const specs = collectSpecs(report.suites);
+  const summary = specs.map(({ spec: s, file }) => ({
+    title:   s.title,
+    file,
+    ok:      s.ok,
+    // results.at(-1) = final retry attempt — authoritative status on CI with retries: 2
+    results: s.tests.map((t) => ({
+      project:  t.projectName,
+      status:   t.results.at(-1)?.status ?? 'unknown',
+      duration: t.results.at(-1)?.duration ?? 0,
+      error:    t.results.at(-1)?.error?.message ?? null,
+    })),
+  }));
 
-    const report = readLastReport();
-    if (!report) return err(`Test run completed but results.json was not found.\nstderr: ${result.stderr ?? ''}`);
+  return ok({ exitCode: result.status ?? -1, stats: report.stats, tests: summary });
+});
 
-    const specs = collectSpecs(report.suites);
-    const summary = specs.map(({ spec, file }) => ({
-      title:   spec.title,
+server.registerTool('get_failed_tests', {
+  description: 'Return failed tests from the last run with error messages and attachment paths.',
+  inputSchema: {},
+}, async () => {
+  const report = readLastReport();
+  if (!report) return err('No results.json found — run tests first.');
+
+  const failed = collectSpecs(report.suites)
+    .filter(({ spec }) => !spec.ok)
+    .map(({ spec, file }) => ({
+      title: spec.title,
       file,
-      ok:      spec.ok,
-      // results.at(-1) = final retry attempt — authoritative status on CI with retries: 2
-      results: spec.tests.map((t) => ({
-        project:  t.projectName,
-        status:   t.results.at(-1)?.status ?? 'unknown',
-        duration: t.results.at(-1)?.duration ?? 0,
-        error:    t.results.at(-1)?.error?.message ?? null,
-      })),
+      failures: spec.tests
+        .filter((t) => t.results.at(-1)?.status !== 'passed')
+        .map((t) => ({
+          project:     t.projectName,
+          status:      t.results.at(-1)?.status,
+          error:       t.results.at(-1)?.error?.message ?? null,
+          attachments: t.results.at(-1)?.attachments.map((a) => ({
+            name: a.name,
+            path: a.path,
+          })),
+        })),
     }));
 
-    return ok({
-      exitCode: result.status ?? -1,
-      stats:    report.stats,
-      tests:    summary,
-    });
-  }
+  return ok({ failedCount: failed.length, tests: failed });
+});
 
-  // ── get_failed_tests ───────────────────────────────────────────────────────
-  if (name === 'get_failed_tests') {
-    const report = readLastReport();
-    if (!report) return err('No results.json found — run tests first.');
+server.registerTool('get_test_attachment', {
+  description: 'Read the content of a named attachment for a specific test from the last run.',
+  inputSchema: {
+    testTitle:      z.string().describe('Exact test title as shown in the report'),
+    attachmentName: z.string().describe('Attachment name, e.g. "AI diagnosis", "DOM"'),
+  },
+}, async ({ testTitle, attachmentName }) => {
+  const report = readLastReport();
+  if (!report) return err('No results.json found — run tests first.');
 
-    const failed = collectSpecs(report.suites)
-      .filter(({ spec }) => !spec.ok)
-      .map(({ spec, file }) => ({
-        title: spec.title,
-        file,
-        failures: spec.tests
-          .filter((t) => t.results.at(-1)?.status !== 'passed')
-          .map((t) => ({
-            project:     t.projectName,
-            status:      t.results.at(-1)?.status,
-            error:       t.results.at(-1)?.error?.message ?? null,
-            attachments: t.results.at(-1)?.attachments.map((a) => ({
-              name: a.name,
-              path: a.path,
-            })),
-          })),
-      }));
+  const match = collectSpecs(report.suites).find(({ spec }) => spec.title === testTitle);
+  if (!match) return err(`Test not found in last report: "${testTitle}"`);
 
-    return ok({ failedCount: failed.length, tests: failed });
-  }
-
-  // ── get_test_attachment ────────────────────────────────────────────────────
-  if (name === 'get_test_attachment') {
-    const { testTitle, attachmentName } = args as { testTitle: string; attachmentName: string };
-    const report = readLastReport();
-    if (!report) return err('No results.json found — run tests first.');
-
-    const match = collectSpecs(report.suites).find(({ spec }) => spec.title === testTitle);
-    if (!match) return err(`Test not found in last report: "${testTitle}"`);
-
-    for (const test of match.spec.tests) {
-      for (const result of test.results) {
-        const attachment = result.attachments.find((a) => a.name === attachmentName);
-        if (attachment?.path && existsSync(attachment.path)) {
-          const MAX_BYTES = 1_000_000;
-          const { size } = statSync(attachment.path);
-          if (size > MAX_BYTES)
-            return err(`Attachment "${attachmentName}" is too large to return inline (${size} bytes).`);
-          return ok({
-            testTitle,
-            attachmentName,
-            content: readFileSync(attachment.path, 'utf8'),
-          });
-        }
+  for (const test of match.spec.tests) {
+    for (const result of test.results) {
+      const attachment = result.attachments.find((a) => a.name === attachmentName);
+      if (attachment?.path && existsSync(attachment.path)) {
+        const MAX_BYTES = 1_000_000;
+        const { size } = statSync(attachment.path);
+        if (size > MAX_BYTES)
+          return err(`Attachment "${attachmentName}" is too large to return inline (${size} bytes).`);
+        return ok({ testTitle, attachmentName, content: readFileSync(attachment.path, 'utf8') });
       }
     }
-    return err(`Attachment "${attachmentName}" not found for test "${testTitle}".`);
   }
+  return err(`Attachment "${attachmentName}" not found for test "${testTitle}".`);
+});
 
-  // ── list_tests ─────────────────────────────────────────────────────────────
-  if (name === 'list_tests') {
-    const cmd = ['npx', 'playwright', 'test', '--list'];
-    if (args.tag) cmd.push('--grep', String(args.tag));
+server.registerTool('list_tests', {
+  description: 'List all tests with their spec file and tags without running them.',
+  inputSchema: {
+    tag: z.string().optional().describe('Filter by tag, e.g. @smoke'),
+  },
+}, async ({ tag }) => {
+  const cmd = ['npx', 'playwright', 'test', '--list'];
+  if (tag) cmd.push('--grep', tag);
 
-    const result = spawnSync(cmd[0], cmd.slice(1), {
-      cwd: PW_DIR,
-      encoding: 'utf8',
-      timeout: 30_000,
-    });
+  const result = spawnSync(cmd[0], cmd.slice(1), {
+    cwd: PW_DIR,
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
 
-    if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
+  if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
 
-    // Output format: "  [Chromium] › tests/navigation.spec.ts:6:1 › home page @smoke"
-    const lines = (result.stdout ?? '').split('\n');
-    const seen = new Set<string>();
-    const tests: Array<{ title: string; file: string; tags: string[] }> = [];
+  // Output format: "  [Chromium] › tests/navigation.spec.ts:6:1 › home page @smoke"
+  const lines = (result.stdout ?? '').split('\n');
+  const seen = new Set<string>();
+  const tests: Array<{ title: string; file: string; tags: string[] }> = [];
 
-    for (const line of lines) {
-      const m = line.match(/›\s+(.+?):(\d+):\d+\s+›\s+(.+)/);
-      if (!m) continue;
-      const [, file, , titleRaw] = m;
-      const tags = [...titleRaw.matchAll(/@\w+/g)].map((t) => t[0]);
-      const title = titleRaw.trim();
-      const key = `${file}::${title}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        tests.push({ title, file, tags });
-      }
+  for (const line of lines) {
+    const m = line.match(/›\s+(.+?):(\d+):\d+\s+›\s+(.+)/);
+    if (!m) continue;
+    const [, file, , titleRaw] = m;
+    const tags = [...titleRaw.matchAll(/@\w+/g)].map((t) => t[0]);
+    const title = titleRaw.trim();
+    const key = `${file}::${title}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      tests.push({ title, file, tags });
     }
-
-    if (tests.length === 0 && lines.some((l) => l.trim().length > 0))
-      return err('list_tests parsed 0 tests from non-empty output — Playwright --list format may have changed.');
-
-    return ok({ count: tests.length, tests });
   }
 
-  return err(`Unknown tool: ${name}`);
+  if (tests.length === 0 && lines.some((l) => l.trim().length > 0))
+    return err('list_tests parsed 0 tests from non-empty output — Playwright --list format may have changed.');
+
+  return ok({ count: tests.length, tests });
 });
 
 const transport = new StdioServerTransport();

--- a/mcp/playwright-runner/index.ts
+++ b/mcp/playwright-runner/index.ts
@@ -112,6 +112,7 @@ server.registerTool('run_tests', {
     cwd: PW_DIR,
     encoding: 'utf8',
     timeout: 300_000,
+    maxBuffer: 10 * 1024 * 1024,
   });
 
   if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);
@@ -149,7 +150,7 @@ server.registerTool('get_failed_tests', {
       title: spec.title,
       file,
       failures: spec.tests
-        .filter((t) => t.results.at(-1)?.status !== 'passed')
+        .filter((t) => { const s = t.results.at(-1)?.status; return s === 'failed' || s === 'timedOut'; })
         .map((t) => ({
           project:     t.projectName,
           status:      t.results.at(-1)?.status,
@@ -178,15 +179,17 @@ server.registerTool('get_test_attachment', {
   if (!match) return err(`Test not found in last report: "${testTitle}"`);
 
   for (const test of match.spec.tests) {
-    for (const result of test.results) {
-      const attachment = result.attachments.find((a) => a.name === attachmentName);
-      if (attachment?.path && existsSync(attachment.path)) {
-        const MAX_BYTES = 1_000_000;
-        const { size } = statSync(attachment.path);
-        if (size > MAX_BYTES)
-          return err(`Attachment "${attachmentName}" is too large to return inline (${size} bytes).`);
-        return ok({ testTitle, attachmentName, content: readFileSync(attachment.path, 'utf8') });
-      }
+    const result = test.results.at(-1);
+    if (!result) continue;
+    const attachment = result.attachments.find((a) => a.name === attachmentName);
+    if (attachment?.path && existsSync(attachment.path)) {
+      if (!attachment.contentType.startsWith('text/'))
+        return err(`Attachment "${attachmentName}" is binary (${attachment.contentType}) and cannot be returned as text.`);
+      const MAX_BYTES = 1_000_000;
+      const { size } = statSync(attachment.path);
+      if (size > MAX_BYTES)
+        return err(`Attachment "${attachmentName}" is too large to return inline (${size} bytes).`);
+      return ok({ testTitle, attachmentName, content: readFileSync(attachment.path, 'utf8') });
     }
   }
   return err(`Attachment "${attachmentName}" not found for test "${testTitle}".`);
@@ -205,6 +208,7 @@ server.registerTool('list_tests', {
     cwd: PW_DIR,
     encoding: 'utf8',
     timeout: 30_000,
+    maxBuffer: 10 * 1024 * 1024,
   });
 
   if (result.error) return err(`Failed to spawn Playwright: ${result.error.message}`);

--- a/mcp/playwright-runner/package.json
+++ b/mcp/playwright-runner/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/mcp/playwright-runner/package.json
+++ b/mcp/playwright-runner/package.json
@@ -9,7 +9,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.0"
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
Closes #143

## Summary

- Adds `mcp/playwright-runner/` — an MCP server exposing four tools: `run_tests`, `get_failed_tests`, `get_test_attachment`, `list_tests`
- Registers the server in `.mcp.json` so Claude Code loads it automatically
- Adds `prepare: tsc` to `package.json` so `npm ci` builds the server without a separate step

## Test plan

- [x] `tsc` compiles without errors
- [x] `run_tests`, `get_failed_tests`, `get_test_attachment`, `list_tests` tools registered via `McpServer.registerTool`
- [x] `spawnSync` uses array args (no `shell: true`) — no command injection
- [x] `results.at(-1)` used throughout for authoritative retry result on CI
- [x] `readLastReport()` wrapped in `try/catch` — malformed `results.json` returns `null` instead of crashing
- [x] Attachment size capped at 1 MB
- [x] `list_tests` warns when output is non-empty but 0 tests parsed
- [x] `PW_DIR` resolves three levels up from `dist/` to reach `playwright/typescript`
- [ ] MCP server loads in Claude Code after `npm ci` in `mcp/playwright-runner/`
