### PR TITLE
143 Enable MCP servers and document playwright-runner setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "enableAllProjectMcpServers": true,
   "permissions": {
     "allow": [
       "Bash(bru run*)",
@@ -15,9 +16,15 @@
       "Bash(npx playwright show-report*)",
       "Bash(npx playwright test*)",
       "Bash(npx tsc*)",
+      "mcp__MCP_DOCKER__mcp-exec",
+      "mcp__MCP_DOCKER__mcp-find",
       "mcp__playwright__browser_click",
       "mcp__playwright__browser_evaluate",
       "mcp__playwright__browser_navigate",
+      "mcp__playwright-runner__get_failed_tests",
+      "mcp__playwright-runner__get_test_attachment",
+      "mcp__playwright-runner__list_tests",
+      "mcp__playwright-runner__run_tests",
       "Read(**/password-reset.page.ts)",
       "WebFetch(domain:docs.usebruno.com)",
       "WebFetch(domain:orwellstat.hubertgajewski.com)",
@@ -26,13 +33,13 @@
     ],
     "deny": [
       "Read(.env)",
-      "Read(**/*credentials*)",
-      "Read(**/*password*)",
-      "Read(**/*secret*)",
       "Read(**/*.key)",
       "Read(**/*.p12)",
       "Read(**/*.pem)",
-      "Read(**/*.pfx)"
+      "Read(**/*.pfx)",
+      "Read(**/*credentials*)",
+      "Read(**/*password*)",
+      "Read(**/*secret*)"
     ]
   },
   "hooks": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,10 @@ This repository defines MCP (Model Context Protocol) servers in `.mcp.json` at t
 
 | Server | Purpose |
 |---|---|
-| `MCP_DOCKER` | Docker MCP gateway — manage containers, images, and services |
+| `playwright-runner` | Run the Playwright test suite and retrieve structured results (pass/fail, errors, attachments) |
 | `playwright` | Browser automation — navigate pages, take screenshots, interact with UI elements |
+| `MCP_DOCKER` | Docker MCP gateway — interact with containers (used with `act` for local CI) |
 
-Use the `playwright` MCP for exploratory or diagnostic tasks that benefit from live browser interaction (e.g. inspecting the running application, verifying a UI fix, taking screenshots). Prefer it over describing what the page looks like from memory.
+- Use `playwright-runner` when you need to run or inspect test results programmatically — e.g. during self-healing workflows, verifying a fix, or checking which tests are failing. Prefer it over invoking `npx playwright test` via shell and parsing stdout.
+- Use `playwright` for exploratory or diagnostic tasks that benefit from live browser interaction — e.g. inspecting the running application, verifying a UI fix, taking screenshots. Prefer it over describing what the page looks like from memory.
+- Use `MCP_DOCKER` when interacting with Docker containers started by `act` — e.g. running a command inside a container or finding a container by name.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ scripts/
   generate-quality-metrics.py  # generates QUALITY_METRICS.md and updates quality-metrics-history.json
 mcp/
   playwright-runner/        # MCP server: run Playwright tests and retrieve structured results
+                            # (MCP_DOCKER and playwright servers are external — defined in .mcp.json, no local files)
 playwright/
   typescript/               # Playwright tests in TypeScript
 selenium/                   # Selenium tests (planned)
@@ -83,11 +84,11 @@ After cloning the repo and filling in `.env`, run these three setup steps:
 # 1. Playwright tests
 cd playwright/typescript && npm ci && npx playwright install --with-deps && cd ../..
 
-# 2. MCP server (playwright-runner) — needed for Claude Code agentic workflows
+# 2. MCP server (playwright-runner) — needed for agentic workflows
 cd mcp/playwright-runner && npm ci && cd ../..
 ```
 
-Then open Claude Code from the **repo root** so `.mcp.json` is picked up and the `playwright-runner` tools are available.
+Then open your AI assistant from the **repo root** so `.mcp.json` is picked up and all MCP server tools are available.
 
 ---
 
@@ -251,24 +252,23 @@ After calculating metrics, the workflow runs `scripts/generate-quality-metrics.p
 
 ---
 
-## mcp/playwright-runner
+## MCP servers
+
+Three MCP servers are declared in `.mcp.json` and loaded automatically by any MCP-compatible AI assistant opened from the repo root. `mcp/playwright-runner` requires a one-time `npm ci` (see Getting started); the other two are external and need no local setup.
+
+| Server | Key in `.mcp.json` | Purpose |
+|---|---|---|
+| playwright-runner | `playwright-runner` | Run Playwright tests and retrieve structured results |
+| playwright (browser) | `playwright` | Live browser automation — navigate, click, screenshot, snapshot |
+| Docker MCP gateway | `MCP_DOCKER` | Interact with Docker containers (used with `act` for local CI) |
+
+### playwright-runner
 
 An MCP server that runs the Playwright test suite and returns structured JSON results, enabling agentic workflows (self-healing, test generation verification) to act on test outcomes without parsing shell output.
 
-### Setup
+**Setup:** `cd mcp/playwright-runner && npm ci` — `npm ci` automatically builds the server via the `prepare` script; no separate build step needed. Restart your AI assistant after installing.
 
-```bash
-cd mcp/playwright-runner
-npm ci
-```
-
-`npm ci` automatically builds the server via the `prepare` script — no separate build step needed.
-
-Restart Claude Code after installing to pick up the `playwright-runner` entry from `.mcp.json`.
-
-> The path in `.mcp.json` (`mcp/playwright-runner/dist/index.js`) is relative to the working directory from which Claude Code is launched. Always open Claude Code from the **repo root**.
-
-### Tools
+> The path in `.mcp.json` (`mcp/playwright-runner/dist/index.js`) is relative to the working directory from which the AI assistant is launched. Always open it from the **repo root**.
 
 | Tool | Description |
 |---|---|
@@ -276,6 +276,33 @@ Restart Claude Code after installing to pick up the `playwright-runner` entry fr
 | `get_failed_tests` | Return failed tests from the last run with error messages and attachment paths |
 | `get_test_attachment` | Read the content of a named attachment (`dom.xhtml`, `diagnosis.md`) for a specific test |
 | `list_tests` | List all tests with their spec file and tags without running them |
+
+### playwright (browser automation)
+
+Browser automation server from `@playwright/mcp`. Allows MCP-compatible AI assistants to navigate pages, take screenshots, interact with UI elements, and inspect the running application directly from agentic workflows.
+
+**Setup:** No local setup — launched on demand via `npx @playwright/mcp@0.0.68`. Requires Node.js and a network connection on first use.
+
+> Additional tools beyond those listed below are available but not pre-approved in `.claude/settings.json` — Claude Code will prompt for confirmation before using them; other AI assistants may handle this differently.
+
+| Tool | Description |
+|---|---|
+| `browser_navigate` | Navigate to a URL |
+| `browser_click` | Click an element |
+| `browser_evaluate` | Execute JavaScript in the page context |
+| `browser_snapshot` | Capture an accessibility snapshot of the current page |
+| `browser_take_screenshot` | Take a screenshot |
+
+### MCP_DOCKER
+
+Docker MCP gateway. Used for interacting with Docker containers when running GitHub Actions locally via [`act`](https://github.com/nektos/act).
+
+**Setup:** Requires Docker Desktop (or Docker Engine) with the `docker mcp` plugin. No local setup — started on demand via `.mcp.json`.
+
+| Tool | Description |
+|---|---|
+| `mcp-exec` | Execute a command inside a running container |
+| `mcp-find` | Find containers by name or label |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ The following variables are set in **GitHub → Settings → Variables → Actio
 | `BRUNO` | `bruno.yml` | PR events, push to main, `workflow_dispatch` |
 | `QUALITY_METRICS` | `quality-metrics.yml` | Monday 06:00 UTC schedule, `workflow_dispatch` |
 
+## Getting started
+
+After cloning the repo and filling in `.env`, run these three setup steps:
+
+```bash
+# 1. Playwright tests
+cd playwright/typescript && npm ci && npx playwright install --with-deps && cd ../..
+
+# 2. MCP server (playwright-runner) — needed for Claude Code agentic workflows
+cd mcp/playwright-runner && npm ci && cd ../..
+```
+
+Then open Claude Code from the **repo root** so `.mcp.json` is picked up and the `playwright-runner` tools are available.
+
 ---
 
 ## playwright/typescript


### PR DESCRIPTION
Closes #143

## Summary

- Adds `mcp/playwright-runner` — an MCP server exposing `run_tests`, `get_failed_tests`, `get_test_attachment`, and `list_tests` tools so MCP-compatible AI assistants can drive Playwright directly from agentic workflows
- Declares all three servers (`playwright-runner`, `playwright`, `MCP_DOCKER`) in `.mcp.json`
- Updates `.claude/settings.json` to enable all project MCP servers and pre-approve tool permissions
- Documents all three MCP servers in `CLAUDE.md` (when to use each) and `README.md` (setup, tools, usage)

## Test plan

- [x] `cd mcp/playwright-runner && npm ci && npm run build` completes without errors
- [x] Open AI assistant from repo root and verify `playwright-runner` tools appear in the MCP tool list
- [x] Run `mcp__playwright-runner__run_tests` and confirm it executes the Playwright suite and returns results
- [x] Run `mcp__playwright-runner__get_failed_tests` after a run with failures and confirm failed tests are returned
- [x] Run `mcp__playwright-runner__list_tests` and confirm it lists discovered specs

Generated with [Claude Code](https://claude.com/claude-code)
