### PR TITLE
158 Update quality metrics report (2026-03-23)

### DIFF
--- a/QUALITY_METRICS.md
+++ b/QUALITY_METRICS.md
@@ -1,15 +1,15 @@
 # Quality Metrics
 
-> Last updated: 2026-03-19
+> Last updated: 2026-03-23
 
 ## Defect Escape Rate
 
 | Discovery method | Count |
 |-----------------|-------|
-| Found by automated tests | 3 |
+| Found by automated tests | 4 |
 | Found by manual testing (staging) | 1 |
 | Found in production | 0 |
-| **Total bugs** | **4** |
+| **Total bugs** | **5** |
 | **Escape rate** | **0%** |
 
 > All bugs were caught before production (escape rate: 0%).
@@ -18,8 +18,8 @@
 
 | Scope | MTTR |
 |-------|------|
-| All closed bugs | 1.8 days |
-| Found by automated tests | 2.9 days |
+| All closed bugs | 1.5 days |
+| Found by automated tests | 2.2 days |
 | Found by manual testing (staging) | 2.2 hours |
 | Found in production | N/A |
 
@@ -47,12 +47,13 @@
 | adminSettings | :x: |
 | hitsFilter | :x: |
 | login | :x: |
-| styleSelector | :x: |
+| styleSelector | :white_check_mark: |
 
-**Overall coverage: 62%** (40/64 items covered)
+**Overall coverage: 64%** (41/64 items covered)
 
 ## Trends
 
 | Date | Escape Rate | MTTR | Coverage |
 |------|-------------|------|----------|
 | 2026-03-19 | 0% | 1.8 days | 62% |
+| 2026-03-23 | 0% | 1.5 days | 64% |

--- a/quality-metrics-history.json
+++ b/quality-metrics-history.json
@@ -4,5 +4,11 @@
     "escape_rate": "0%",
     "mttr": "1.8 days",
     "coverage": "62%"
+  },
+  {
+    "date": "2026-03-23",
+    "escape_rate": "0%",
+    "mttr": "1.5 days",
+    "coverage": "64%"
   }
 ]


### PR DESCRIPTION
## Summary

- Updates `QUALITY_METRICS.md` and `quality-metrics-history.json` with the 2026-03-23 data point
- Coverage improved from 62% → 64%, MTTR from 1.8 → 1.5 days, escape rate remains 0%
- Manual run triggered by issue #158 (scheduled workflow fails to push directly to main)

## Test plan

- [ ] Verify `QUALITY_METRICS.md` Trends table contains the 2026-03-23 row
- [ ] Verify `quality-metrics-history.json` contains the new data point

Closes #158
