### PR TITLE
Fix picomatch ReDoS vulnerability in bruno via npm override

### DIFF
--- a/bruno/package-lock.json
+++ b/bruno/package-lock.json
@@ -5285,9 +5285,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6235,9 +6235,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/bruno/package.json
+++ b/bruno/package.json
@@ -7,6 +7,7 @@
     "test": "bru run --env production"
   },
   "overrides": {
-    "fast-xml-parser": ">=5.5.7"
+    "fast-xml-parser": ">=5.5.7",
+    "picomatch": ">=2.3.2"
   }
 }


### PR DESCRIPTION
## Summary

- Pins `picomatch` to `>=2.3.2` via npm `overrides` in `bruno/package.json`
- Resolves Dependabot alerts #6 (high) and #7 (medium): ReDoS vulnerability (GHSA-c2c7-rcm5-vvqj) and Method Injection in POSIX Character Classes (GHSA-3v7f-55p6-f55p)
- Follows the same pattern already used for `fast-xml-parser` in this project

## Test plan

- [x] `npm audit` reports 0 vulnerabilities locally after the override
- [ ] CI audit step passes on the self-hosted runner
