### PR TITLE
#191 Prefix commit message issue numbers with # for GitHub auto-linking

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -58,7 +58,7 @@ Scripts calling external APIs (e.g. `gh issue list`, REST calls):
 Read every Given/When/Then scenario and every DoD checkbox in the issue. For each item, explicitly confirm it is satisfied or identify what is missing. Do not proceed to commit until all criteria pass.
 
 **Step 8 — Commit**
-Stage changed files by name (never `git add -A`). Follow the **Commit message convention** in `CLAUDE.md`: prefix with the issue number, single line, no body, no `Co-Authored-By` trailer.
+Stage changed files by name (never `git add -A`). Follow the **Commit message convention** in `CLAUDE.md`: prefix with `#` and the issue number, single line, no body, no `Co-Authored-By` trailer.
 
 **Step 9 — Push and create a PR**
 Push the branch and run `gh pr create`. The PR body must include:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,13 @@ When creating GitHub issues for requirements, bugs, or code review findings, fol
 
 ## Commit message convention
 
-Commit messages are always a **short, single-line description** with no body and no `Co-Authored-By` trailer. When a commit relates to one or more GitHub issues, **prefix the message with the issue number(s)** separated by spaces, followed by the description:
+Commit messages are always a **short, single-line description** with no body and no `Co-Authored-By` trailer. When a commit relates to one or more GitHub issues, **prefix the message with `#` and the issue number(s)**, followed by the description:
 
-- Single issue: `63 Add network mocking tests`
-- Multiple issues: `63 64 Add network mocking tests and fixtures`
+- Single issue: `#63 Add network mocking tests`
+- Multiple issues: `#63 #64 Add network mocking tests and fixtures`
 - No issue: `Fix typo in README`
 
-The ticket prefix must come first so `git log --oneline` and GitHub cross-references work at a glance.
+The `#N` prefix must come first so `git log --oneline` and GitHub cross-references work at a glance.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update commit message convention in `CLAUDE.md` and `.claude/skills/fix-issue/SKILL.md` to use `#N` prefix (e.g., `#63`) instead of bare numbers (`63`)
- GitHub auto-links `#N` references to issues, making commit history more navigable

Closes #191
