### PR TITLE
[enhancement] Add multi-provider AI diagnosis with Gemini support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ ENV=
 # will silently send an empty password and all requests will return 401.
 BASIC_AUTH_USER=
 BASIC_AUTH_PASSWORD=
-# Optional: AI-powered test failure diagnosis (requires CLAUDE_DIAGNOSIS=true in .vars).
+# Optional: AI-powered test failure diagnosis (requires AI_DIAGNOSIS=true in .vars).
 # When absent the fixture behaves exactly as without it — no extra attachments, no errors.
+# Set AI_PROVIDER in .vars to choose which provider to use (default: anthropic).
 ANTHROPIC_API_KEY=
+GEMINI_API_KEY=

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -141,6 +141,9 @@ jobs:
           ORWELLSTAT_USER: ${{ secrets.ORWELLSTAT_USER }}
           ORWELLSTAT_PASSWORD: ${{ secrets.ORWELLSTAT_PASSWORD }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          AI_PROVIDER: ${{ vars.AI_PROVIDER }}
+          AI_DIAGNOSIS: ${{ vars.AI_DIAGNOSIS }}
           CLAUDE_DIAGNOSIS: ${{ vars.CLAUDE_DIAGNOSIS }}
       - name: Upload updated baselines
         if: ${{ github.event.inputs.update_visual_baselines == 'true' }}

--- a/.vars.example
+++ b/.vars.example
@@ -6,7 +6,11 @@ CLAUDE_REVIEW=
 PLAYWRIGHT_TYPESCRIPT=
 BRUNO=
 QUALITY_METRICS=
-# Required alongside ANTHROPIC_API_KEY in .env to enable AI-powered test failure diagnosis.
+# AI-powered test failure diagnosis. Set to "true" to enable.
+AI_DIAGNOSIS=
+# AI provider for test failure diagnosis. Accepted values: anthropic (default), gemini.
+AI_PROVIDER=
+# Deprecated: still works as a fallback for AI_DIAGNOSIS. Prefer AI_DIAGNOSIS above.
 CLAUDE_DIAGNOSIS=
 # Default runner for all workflow jobs. Set to "self-hosted" to route all jobs to the local
 # self-hosted runner when the runner input is not explicitly set. Leave empty to use ubuntu-latest.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Four project-scoped skills are available in Claude Code (stored in `.claude/skil
 
 ```
 .env                        # credentials (git-ignored); see .env.example
-.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY
+.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, GEMINI_API_KEY
 .vars                       # CI repository variables (git-ignored); see .vars.example
-.vars.example               # template: CLAUDE_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, CLAUDE_DIAGNOSIS
+.vars.example               # template: CLAUDE_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, AI_DIAGNOSIS, AI_PROVIDER, CLAUDE_DIAGNOSIS
 .mcp.json                   # MCP server definitions (MCP_DOCKER, playwright, playwright-report-mcp) — loaded by Claude Code and other MCP-compatible AI assistants
 .github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
@@ -59,9 +59,10 @@ ENV=<production|staging>
 BASIC_AUTH_USER=<staging basic auth user>
 BASIC_AUTH_PASSWORD=<staging basic auth password>
 ANTHROPIC_API_KEY=<Anthropic API key>
+GEMINI_API_KEY=<Gemini API key>
 ```
 
-`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` is optional — when present alongside `CLAUDE_DIAGNOSIS=true` in `.vars`, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. In CI, secrets are injected as GitHub Actions secrets and variables via GitHub Actions variables. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env` and `../../.vars`).
+`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` and `GEMINI_API_KEY` are optional — when the active provider's key is present alongside `AI_DIAGNOSIS=true` in `.vars`, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. Set `AI_PROVIDER` in `.vars` to choose the provider (`anthropic` by default, or `gemini`). In CI, secrets are injected as GitHub Actions secrets and variables via GitHub Actions variables. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env` and `../../.vars`).
 
 ### CI repository variables
 
@@ -69,7 +70,9 @@ The following variables are set in **GitHub → Settings → Variables → Actio
 
 | Variable                | Purpose                                      | When it applies                                                            |
 | ----------------------- | -------------------------------------------- | -------------------------------------------------------------------------- |
-| `CLAUDE_DIAGNOSIS`      | AI-powered test failure diagnosis attachment | Every Playwright run (local and CI)                                        |
+| `AI_DIAGNOSIS`          | AI-powered test failure diagnosis attachment | Every Playwright run (local and CI)                                        |
+| `AI_PROVIDER`           | AI provider for diagnosis (`anthropic` or `gemini`; default: `anthropic`) | Every Playwright run (local and CI)           |
+| `CLAUDE_DIAGNOSIS`      | Deprecated alias for `AI_DIAGNOSIS` (still works as fallback) | Every Playwright run (local and CI)                          |
 | `CLAUDE_REVIEW`         | `claude-code-review.yml`                     | PR events (opened, synchronize, ready_for_review, reopened)                |
 | `PLAYWRIGHT_TYPESCRIPT` | `playwright-typescript.yml`                  | PR events, push to main, Sunday 03:00 UTC schedule, `workflow_dispatch`    |
 | `BRUNO`                 | `bruno.yml`                                  | PR events, push to main, `workflow_dispatch`                               |
@@ -153,7 +156,7 @@ Update [coverage-matrix.json](./playwright/typescript/coverage-matrix.json) so i
 
 These are useful for Orwell Stat, but optional for a fork:
 
-- AI diagnosis in [diagnosis.util.ts](./playwright/typescript/utils/diagnosis.util.ts) if you do not want failed DOM snapshots sent to Anthropic
+- AI diagnosis in [diagnosis.util.ts](./playwright/typescript/utils/diagnosis.util.ts) if you do not want failed DOM snapshots sent to an external AI provider
 - visual regression snapshots in [tests/visual.spec.ts](./playwright/typescript/tests/visual.spec.ts) until your UI is stable
 - W3C validation checks in [tests/validation.spec.ts](./playwright/typescript/tests/validation.spec.ts) if your app is not XHTML/CSS-validator oriented
 - self-hosted runner automation in [setup-runners.sh](./scripts/setup-runners.sh) if you do not need push-back workflows
@@ -169,7 +172,7 @@ The most common adjustments are:
 - secret names and repository variables if your environment does not use `ORWELLSTAT_*`, `BASIC_AUTH_*`, `PLAYWRIGHT_TYPESCRIPT`, `BRUNO`, or `QUALITY_METRICS`
 - push-back workflows that commit generated files or visual baselines back to the repository
 - self-hosted runner configuration in [setup-runners.sh](./scripts/setup-runners.sh), which is currently hardcoded to this GitHub repository
-- optional Anthropic-based integrations such as AI diagnosis and PR review if you do not want external AI services in your pipeline
+- optional AI integrations such as AI diagnosis (Anthropic or Gemini) and PR review if you do not want external AI services in your pipeline
 
 Review these files first:
 
@@ -318,7 +321,7 @@ Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tes
 - `utils/string.util.ts` — `expectHeadings()` helper: asserts visibility of multiple headings on a page
 - `utils/validation.util.ts` — `expectValidXhtml(request, xhtml)` POSTs raw markup to the classic W3C Markup Validation Service (`validator.w3.org/check`) and asserts no errors (correct for XHTML 1.0 Strict; Nu is HTML5-only and gives false positives); `expectValidCss(request, cssUrl)` queries W3C CSS validator by URI and asserts zero errors
 - `utils/env.util.ts` — `loadEnv(importMetaUrl, levelsUp)` loads `.env` relative to the calling file; `requireCredentials()` validates and returns `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD`, throwing a descriptive error if either is missing
-- `utils/diagnosis.util.ts` — `attachAiDiagnosis(testInfo, logs, domContent)`: calls the Anthropic API (`claude-haiku-4-5`) to produce a diagnosis attachment on test failure; no-ops when `ANTHROPIC_API_KEY` or `CLAUDE_DIAGNOSIS=true` are absent; errors are caught and warned so diagnosis never fails a test
+- `utils/diagnosis.util.ts` — `attachAiDiagnosis(testInfo, logs, domContent)`: calls the configured AI provider (Anthropic or Gemini, selected by `AI_PROVIDER`) to produce a diagnosis and optional selector-fix attachment on test failure; no-ops when `AI_DIAGNOSIS=true` is absent or the provider's API key is missing; errors are caught and warned so diagnosis never fails a test
 - `types/` — Shared TypeScript interfaces; exported via path alias `@types-local/*`
   - `svg-analysis.ts` — `SvgAnalysis` interface: shape of the object returned by `page.evaluate()` in `statistics.spec.ts`
   - `statistics-row.ts` — `StatisticsRow` interface: shape of each data row returned by the bulk `page.evaluate()` in `statistics.spec.ts`

--- a/playwright/typescript/package-lock.json
+++ b/playwright/typescript/package-lock.json
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.87.0",
         "@axe-core/playwright": "^4.11.1",
+        "@google/generative-ai": "^0.24.1",
         "@playwright/test": "^1.59.1",
         "@types/node": "^25.6.0",
         "@types/pngjs": "^6.0.5",
@@ -59,6 +60,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@playwright/test": {

--- a/playwright/typescript/package.json
+++ b/playwright/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.87.0",
+    "@google/generative-ai": "^0.24.1",
     "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",

--- a/playwright/typescript/utils/diagnosis.util.ts
+++ b/playwright/typescript/utils/diagnosis.util.ts
@@ -156,7 +156,8 @@ Confidence guidelines:
       .trim();
     const parsed = JSON.parse(cleaned) as SelectorFixResponse;
     if (
-      typeof parsed.confidence !== 'string' ||
+      !['high', 'medium', 'low'].includes(parsed.confidence) ||
+      typeof parsed.brokenSelector !== 'string' ||
       typeof parsed.suggestedSelector !== 'string' ||
       typeof parsed.explanation !== 'string'
     ) {

--- a/playwright/typescript/utils/diagnosis.util.ts
+++ b/playwright/typescript/utils/diagnosis.util.ts
@@ -1,5 +1,4 @@
 import { writeFileSync } from 'fs';
-import Anthropic from '@anthropic-ai/sdk';
 import type { TestInfo } from '@playwright/test';
 
 const DOM_TRUNCATE_CHARS = 30_000;
@@ -17,6 +16,63 @@ interface SelectorFixResponse {
   explanation: string;
 }
 
+type AiCompletionFn = (opts: {
+  model: string;
+  maxTokens: number;
+  system: string;
+  userContent: string;
+}) => Promise<string>;
+
+const MODEL_MAP = {
+  anthropic: { fast: 'claude-haiku-4-5', strong: 'claude-sonnet-4-6' },
+  // Both tiers use the same model: free-tier Pro access is unavailable,
+  // and gemini-3.1-flash-lite-preview has the best RPD quota (500 vs 20).
+  gemini: { fast: 'gemini-3.1-flash-lite-preview', strong: 'gemini-3.1-flash-lite-preview' },
+} as const;
+
+type AiProvider = keyof typeof MODEL_MAP;
+
+function isAiProvider(value: string): value is AiProvider {
+  return value in MODEL_MAP;
+}
+
+const API_KEY_ENV: Record<AiProvider, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+};
+
+type CompletionFactory = (apiKey: string) => Promise<AiCompletionFn>;
+
+const PROVIDER_FACTORY: Record<AiProvider, CompletionFactory> = {
+  async anthropic(apiKey) {
+    const { default: Anthropic } = await import('@anthropic-ai/sdk');
+    const client = new Anthropic({ apiKey });
+    return async ({ model, maxTokens, system, userContent }) => {
+      const response = await client.messages.create({
+        model,
+        max_tokens: maxTokens,
+        system,
+        messages: [{ role: 'user', content: userContent }],
+      });
+      const firstBlock = response.content[0];
+      return firstBlock?.type === 'text' ? firstBlock.text : '';
+    };
+  },
+  async gemini(apiKey) {
+    const { GoogleGenerativeAI } = await import('@google/generative-ai');
+    const genAI = new GoogleGenerativeAI(apiKey);
+    return async ({ model, maxTokens, system, userContent }) => {
+      const generativeModel = genAI.getGenerativeModel({
+        model,
+        systemInstruction: system,
+        generationConfig: { maxOutputTokens: maxTokens },
+      });
+      const result = await generativeModel.generateContent(userContent);
+      return result.response.text();
+    };
+  },
+};
+
 function extractBrokenSelector(errorMessages: string): string | null {
   if (!SELECTOR_ERROR_PATTERN.test(errorMessages)) return null;
   const match = errorMessages.match(SELECTOR_EXTRACT_PATTERN);
@@ -26,49 +82,44 @@ function extractBrokenSelector(errorMessages: string): string | null {
   return match?.[1] ?? null;
 }
 
-async function requestHaikuDiagnosis(
-  anthropic: Anthropic,
+async function requestDiagnosis(
+  complete: AiCompletionFn,
+  models: (typeof MODEL_MAP)[AiProvider],
   testInfo: TestInfo,
   logs: string[],
   errorMessages: string,
   domSnippet: string
 ): Promise<string> {
-  const response = await anthropic.messages.create({
-    model: 'claude-haiku-4-5',
-    max_tokens: 1024,
+  return complete({
+    model: models.fast,
+    maxTokens: 1024,
     system:
       'You are a test-failure analyst for a Playwright E2E suite. Given failed test metadata, browser console logs, and a DOM snapshot, produce a concise diagnosis: (1) most likely root cause, (2) what assertion probably failed and why, (3) one suggested fix.',
-    messages: [
-      {
-        role: 'user',
-        content: [
-          `Test: ${testInfo.title}`,
-          `Project: ${testInfo.project.name}`,
-          `Status: ${testInfo.status} (expected: ${testInfo.expectedStatus})`,
-          `Errors:\n${errorMessages || '(none)'}`,
-          '',
-          '--- Console logs ---',
-          logs.length > 0 ? logs.join('\n') : '(none)',
-          '',
-          '--- DOM snapshot (may be truncated) ---',
-          domSnippet,
-        ].join('\n'),
-      },
-    ],
+    userContent: [
+      `Test: ${testInfo.title}`,
+      `Project: ${testInfo.project.name}`,
+      `Status: ${testInfo.status} (expected: ${testInfo.expectedStatus})`,
+      `Errors:\n${errorMessages || '(none)'}`,
+      '',
+      '--- Console logs ---',
+      logs.length > 0 ? logs.join('\n') : '(none)',
+      '',
+      '--- DOM snapshot (may be truncated) ---',
+      domSnippet,
+    ].join('\n'),
   });
-  const firstBlock = response.content[0];
-  return firstBlock?.type === 'text' ? firstBlock.text : '';
 }
 
 async function requestSelectorFix(
-  anthropic: Anthropic,
+  complete: AiCompletionFn,
+  models: (typeof MODEL_MAP)[AiProvider],
   brokenSelector: string,
   errorMessages: string,
   domSnippet: string
 ): Promise<SelectorFixResponse | null> {
-  const response = await anthropic.messages.create({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 1024,
+  const text = await complete({
+    model: models.strong,
+    maxTokens: 1024,
     system: `You are a Playwright test selector specialist. A test failed because a locator could not find an element or matched multiple elements.
 
 Given the broken selector, the error message, and a DOM snapshot, propose a replacement selector.
@@ -87,22 +138,15 @@ Confidence guidelines:
 - "high": The DOM clearly contains the target element and the fix is unambiguous.
 - "medium": The DOM likely contains the target element but the fix involves assumptions.
 - "low": The target element may not exist in the DOM or the fix is speculative.`,
-    messages: [
-      {
-        role: 'user',
-        content: [
-          `Broken selector: ${brokenSelector}`,
-          `Errors:\n${errorMessages}`,
-          '',
-          '--- DOM snapshot (may be truncated) ---',
-          domSnippet,
-        ].join('\n'),
-      },
-    ],
+    userContent: [
+      `Broken selector: ${brokenSelector}`,
+      `Errors:\n${errorMessages}`,
+      '',
+      '--- DOM snapshot (may be truncated) ---',
+      domSnippet,
+    ].join('\n'),
   });
 
-  const firstBlock = response.content[0];
-  const text = firstBlock?.type === 'text' ? firstBlock.text : '';
   if (!text) return null;
 
   try {
@@ -125,7 +169,8 @@ Confidence guidelines:
 }
 
 async function attachSelectorFix(
-  anthropic: Anthropic,
+  complete: AiCompletionFn,
+  models: (typeof MODEL_MAP)[AiProvider],
   testInfo: TestInfo,
   errorMessages: string,
   domSnippet: string
@@ -133,7 +178,7 @@ async function attachSelectorFix(
   const brokenSelector = extractBrokenSelector(errorMessages);
   if (!brokenSelector) return null;
 
-  const fix = await requestSelectorFix(anthropic, brokenSelector, errorMessages, domSnippet);
+  const fix = await requestSelectorFix(complete, models, brokenSelector, errorMessages, domSnippet);
   if (!fix) return null;
 
   if (fix.confidence === 'low') {
@@ -166,12 +211,23 @@ export async function attachAiDiagnosis(
   logs: string[],
   domContent: string
 ): Promise<void> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  const diagnosisEnabled = process.env.CLAUDE_DIAGNOSIS === 'true';
-  if (!apiKey || !diagnosisEnabled) return;
+  const diagnosisEnabled =
+    process.env.AI_DIAGNOSIS === 'true' || process.env.CLAUDE_DIAGNOSIS === 'true';
+  if (!diagnosisEnabled) return;
+
+  const provider = process.env.AI_PROVIDER ?? 'anthropic';
+  if (!isAiProvider(provider)) {
+    console.warn(`[AI diagnosis] unknown AI_PROVIDER "${provider}", skipping`);
+    return;
+  }
+
+  const apiKey = process.env[API_KEY_ENV[provider]];
+  if (!apiKey) return;
 
   try {
-    const anthropic = new Anthropic({ apiKey });
+    const complete = await PROVIDER_FACTORY[provider](apiKey);
+    const models = MODEL_MAP[provider];
+
     const domSnippet =
       domContent.length > DOM_TRUNCATE_CHARS
         ? domContent.slice(0, DOM_TRUNCATE_CHARS) + '\n...[truncated]'
@@ -183,8 +239,8 @@ export async function attachAiDiagnosis(
       .replace(/\x1b\[[0-9;]*m/g, '');
 
     const [diagnosisText, selectorNote] = await Promise.all([
-      requestHaikuDiagnosis(anthropic, testInfo, logs, errorMessages, domSnippet),
-      attachSelectorFix(anthropic, testInfo, errorMessages, domSnippet).catch((err) => {
+      requestDiagnosis(complete, models, testInfo, logs, errorMessages, domSnippet),
+      attachSelectorFix(complete, models, testInfo, errorMessages, domSnippet).catch((err) => {
         console.warn('[Selector fix] skipped:', err);
         return null;
       }),


### PR DESCRIPTION
## Summary

Closes #198

- Add Gemini as an alternative AI provider for test failure diagnosis and selector-fix proposals, selectable via `AI_PROVIDER` env var (default: `anthropic`)
- Introduce `AiCompletionFn` abstraction with `PROVIDER_FACTORY` map — adding a new provider is one entry
- Rename feature flag to `AI_DIAGNOSIS` (`CLAUDE_DIAGNOSIS` still works as fallback)
- SDKs are lazy-loaded via dynamic `import()` so workers that don't need diagnosis pay no startup cost

## Changed files

| File | Change |
|---|---|
| `playwright/typescript/utils/diagnosis.util.ts` | Provider abstraction, factory map, lazy imports, type guard |
| `playwright/typescript/package.json` | `@google/generative-ai` added to devDependencies |
| `.env.example` | `GEMINI_API_KEY` |
| `.vars.example` | `AI_PROVIDER`, `AI_DIAGNOSIS`, deprecation note on `CLAUDE_DIAGNOSIS` |
| `.github/workflows/playwright-typescript.yml` | New env vars in test step |
| `README.md` | Updated env var docs, utility description, fork guidance |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run format:check` passes
- [x] Anthropic provider: broke 2 selectors, verified diagnosis + selector-fix attachments appear with correct content
- [x] Gemini provider: same 2 broken selectors, verified identical attachment behavior
- [x] Missing API key: silent no-op (no errors, no attachments)
- [x] `CLAUDE_DIAGNOSIS=true` backward compat: still enables diagnosis when `AI_DIAGNOSIS` is unset
