### PR TITLE
#176 Add self-healing GitHub Actions workflow for selector repairs

### DIFF
--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -170,6 +170,29 @@ jobs:
           name: blob-report-${{ matrix.id }}
           path: playwright/typescript/blob-report/
           retention-days: 30
+      - name: Collect self-healing data
+        if: ${{ failure() }}
+        working-directory: playwright/typescript
+        run: |
+          mkdir -p self-healing-data
+          cp test-results/results.json self-healing-data/ 2>/dev/null || true
+          find test-results -maxdepth 2 -name 'selector-fix.md' -not -path '*/attachments/*' | while IFS= read -r f; do
+            dir="self-healing-data/$(dirname "$f")"
+            mkdir -p "$dir"
+            cp "$f" "$dir/"
+          done
+          find test-results -maxdepth 2 -name 'dom.xhtml' -not -path '*/attachments/*' | while IFS= read -r f; do
+            dir="self-healing-data/$(dirname "$f")"
+            mkdir -p "$dir"
+            cp "$f" "$dir/"
+          done
+      - uses: actions/upload-artifact@v7
+        if: ${{ failure() && steps.detect-act.outputs.running != 'true' }}
+        with:
+          name: self-healing-data-${{ matrix.id }}
+          path: playwright/typescript/self-healing-data/
+          retention-days: 7
+          if-no-files-found: ignore
 
   commit-baselines:
     needs: test

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -181,10 +181,12 @@ jobs:
             mkdir -p "$dir"
             cp "$f" "$dir/"
           done
-          find test-results -maxdepth 2 -name 'dom.xhtml' -not -path '*/attachments/*' | while IFS= read -r f; do
-            dir="self-healing-data/$(dirname "$f")"
-            mkdir -p "$dir"
-            cp "$f" "$dir/"
+          for name in dom.xhtml error-context.md; do
+            find test-results -maxdepth 2 -name "$name" -not -path '*/attachments/*' | while IFS= read -r f; do
+              dir="self-healing-data/$(dirname "$f")"
+              mkdir -p "$dir"
+              cp "$f" "$dir/"
+            done
           done
       - uses: actions/upload-artifact@v7
         if: ${{ failure() && steps.detect-act.outputs.running != 'true' }}

--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -53,4 +53,5 @@ jobs:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_ID: ${{ github.event.workflow_run.id }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: python3 scripts/self-healing.py self-healing-data

--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -1,0 +1,56 @@
+name: Self-Healing Selector Fix
+on:
+  workflow_run:
+    workflows: ["Playwright Typescript Tests"]
+    types: [completed]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: self-healing-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  self-heal:
+    # Layer 1: branch guard — never process self-healing branches (loop prevention)
+    # Layer 6: conclusion check — only process failed runs
+    if: >-
+      github.repository == 'hubertgajewski/orwellstat' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      vars.SELF_HEALING == 'true' &&
+      !startsWith(github.event.workflow_run.head_branch, 'fix/self-healing-')
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          # Fetch full history so we can create and push a new branch from head_sha.
+          fetch-depth: 0
+
+      - name: Download self-healing data
+        uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: self-healing-data-*
+          merge-multiple: true
+          path: self-healing-data
+        continue-on-error: true
+
+      - name: Run self-healing
+        if: hashFiles('self-healing-data/**') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          AI_PROVIDER: ${{ vars.AI_PROVIDER }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: python3 scripts/self-healing.py self-healing-data

--- a/.vars.example
+++ b/.vars.example
@@ -12,6 +12,11 @@ AI_DIAGNOSIS=
 AI_PROVIDER=
 # Deprecated: still works as a fallback for AI_DIAGNOSIS. Prefer AI_DIAGNOSIS above.
 CLAUDE_DIAGNOSIS=
+# Self-healing selector fix workflow. Set to "true" to enable automatic draft PRs / PR comments
+# when Playwright tests fail due to locator/selector errors. Uses the same AI_PROVIDER setting
+# and API key (ANTHROPIC_API_KEY or GEMINI_API_KEY) as AI_DIAGNOSIS for the fallback path
+# (when AI_DIAGNOSIS is disabled and no pre-computed selector-fix.md exists).
+SELF_HEALING=
 # Default runner for all workflow jobs. Set to "self-hosted" to route all jobs to the local
 # self-hosted runner when the runner input is not explicitly set. Leave empty to use ubuntu-latest.
 RUNNER=

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Four project-scoped skills are available in Claude Code (stored in `.claude/skil
 .env                        # credentials (git-ignored); see .env.example
 .env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, GEMINI_API_KEY
 .vars                       # CI repository variables (git-ignored); see .vars.example
-.vars.example               # template: CLAUDE_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, AI_DIAGNOSIS, AI_PROVIDER, CLAUDE_DIAGNOSIS
+.vars.example               # template: CLAUDE_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, AI_DIAGNOSIS, AI_PROVIDER, CLAUDE_DIAGNOSIS, SELF_HEALING
 .mcp.json                   # MCP server definitions (MCP_DOCKER, playwright, playwright-report-mcp) — loaded by Claude Code and other MCP-compatible AI assistants
 .github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
@@ -30,6 +30,8 @@ SECURITY.md                 # security policy and vulnerability reporting
 quality-metrics-history.json  # historical quality metrics data points (auto-committed by workflow)
 scripts/
   generate-quality-metrics.py  # generates QUALITY_METRICS.md and updates quality-metrics-history.json
+  self-healing.py              # self-healing selector fix: parses test artifacts, posts PR comments or creates draft PRs
+  test_self_healing.py         # unit tests for self-healing.py (all loop prevention and classification scenarios)
   setup-runners.sh             # registers and starts 8 self-hosted runner instances as launchd services
 playwright/
   typescript/               # Playwright tests in TypeScript
@@ -77,6 +79,7 @@ The following variables are set in **GitHub → Settings → Variables → Actio
 | `PLAYWRIGHT_TYPESCRIPT` | `playwright-typescript.yml`                  | PR events, push to main, Sunday 03:00 UTC schedule, `workflow_dispatch`    |
 | `BRUNO`                 | `bruno.yml`                                  | PR events, push to main, `workflow_dispatch`                               |
 | `QUALITY_METRICS`       | `quality-metrics.yml`                        | 1st of every month 06:00 UTC schedule, `workflow_dispatch`                 |
+| `SELF_HEALING`          | `self-healing.yml`                           | After any failed Playwright Typescript Tests workflow run                  |
 | `RUNNER`                | Default runner for all workflow jobs         | Push, PR, schedule, `workflow_dispatch` (dispatch dropdown overrides this) |
 
 ## Getting started
@@ -374,6 +377,8 @@ Bug issues must carry one of three discovery labels (in addition to `bug`) for t
 MTTR is calculated for all `bug`-labeled issues regardless of discovery method, and also broken down per discovery label for insight into resolution speed by source.
 
 After calculating metrics, the workflow runs `scripts/generate-quality-metrics.py` to generate `QUALITY_METRICS.md` (a persistent, unified view readable directly on GitHub) and update `quality-metrics-history.json` with a new data point. Both files are committed to a new branch and a pull request is opened automatically.
+
+**Self-Healing Selector Fix:** `.github/workflows/self-healing.yml` — triggers via `workflow_run` after "Playwright Typescript Tests" completes with a failure; detects selector/locator errors in the test results and proposes fixes. When a PR's tests fail due to a broken selector, posts a comment on the PR with the fix suggestion. When tests on `main` or a schedule run fail, creates a draft PR applying the fix. The workflow uses pre-computed `selector-fix.md` attachments when `AI_DIAGNOSIS` is enabled, or falls back to calling the AI provider (Anthropic/Gemini, configured via `AI_PROVIDER`) directly with the DOM snapshot. Requires `SELF_HEALING=true` in repository variables. Loop prevention is enforced via six layers: branch name guard (skips `fix/self-healing-*` branches), the existing approval gate (draft PRs have no approval so tests don't run on them), max 2 comments per PR, draft PR deduplication, per-branch concurrency groups, and failure-only triggering. The script (`scripts/self-healing.py`) has a comprehensive unit test suite (`scripts/test_self_healing.py`) covering all loop prevention scenarios.
 
 ---
 

--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -1,0 +1,659 @@
+"""Self-healing selector fix for Playwright test failures.
+
+Downloads test artifacts (results.json, selector-fix.md, dom.xhtml) produced by
+the Playwright CI workflow, classifies selector/locator errors, and either posts
+a comment on the originating PR or creates a draft PR with the proposed fix.
+
+Designed to be invoked by .github/workflows/self-healing.yml after a failed
+Playwright Typescript Tests workflow run.
+
+Usage (env vars set by the workflow):
+    python3 scripts/self-healing.py <data-dir>
+
+Environment variables:
+    HEAD_BRANCH   — branch that triggered the failed workflow run
+    HEAD_SHA      — commit SHA of the failed run
+    RUN_ID        — workflow run ID (for linking in comments)
+    GH_TOKEN      — GitHub token (used by gh CLI)
+    ANTHROPIC_API_KEY — Anthropic API key (fallback path)
+    GEMINI_API_KEY    — Gemini API key (fallback path)
+    AI_PROVIDER       — "anthropic" (default) or "gemini"
+    DRY_RUN           — set to "true" to print actions without executing
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_ATTEMPTS = 2
+COMMENT_MARKER = "<!-- self-healing-selector-fix -->"
+SELF_HEALING_LABEL = "self-healing"
+BRANCH_PREFIX = "fix/self-healing-"
+
+# Must stay in sync with diagnosis.util.ts SELECTOR_ERROR_PATTERN (line 6-7).
+SELECTOR_ERROR_PATTERN = re.compile(
+    r"strict mode violation|waiting for locator|waiting for getBy|locator\.\w+:.*timeout",
+    re.IGNORECASE,
+)
+
+DOM_TRUNCATE_CHARS = 30_000
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+class SelectorFix:
+    """Parsed selector fix proposal."""
+
+    __slots__ = ("confidence", "broken_selector", "suggested_selector", "explanation")
+
+    def __init__(
+        self,
+        confidence: str,
+        broken_selector: str,
+        suggested_selector: str,
+        explanation: str,
+    ):
+        self.confidence = confidence
+        self.broken_selector = broken_selector
+        self.suggested_selector = suggested_selector
+        self.explanation = explanation
+
+
+class FailedTest:
+    """A failed test extracted from results.json."""
+
+    __slots__ = ("title", "project", "file", "line", "error_message")
+
+    def __init__(
+        self,
+        title: str,
+        project: str,
+        file: str,
+        line: int,
+        error_message: str,
+    ):
+        self.title = title
+        self.project = project
+        self.file = file
+        self.line = line
+        self.error_message = error_message
+
+
+# ---------------------------------------------------------------------------
+# Branch guard
+# ---------------------------------------------------------------------------
+
+
+def should_skip_branch(head_branch: str) -> bool:
+    """Return True if the branch is a self-healing branch (loop prevention)."""
+    return head_branch.startswith(BRANCH_PREFIX)
+
+
+# ---------------------------------------------------------------------------
+# Selector error classification
+# ---------------------------------------------------------------------------
+
+
+def is_selector_error(error_message: str) -> bool:
+    """Return True if the error message indicates a selector/locator failure."""
+    return bool(SELECTOR_ERROR_PATTERN.search(error_message))
+
+
+# ---------------------------------------------------------------------------
+# Parse selector-fix.md
+# ---------------------------------------------------------------------------
+
+_CONFIDENCE_RE = re.compile(r"\*\*Confidence:\*\*\s+(\w+)")
+_BROKEN_RE = re.compile(r"\*\*Broken selector:\*\*\s+`([^`]+)`")
+_SUGGESTED_RE = re.compile(r"\*\*Suggested selector:\*\*\s+`([^`]+)`")
+
+
+def parse_selector_fix(content: str) -> SelectorFix | None:
+    """Parse a selector-fix.md file into a SelectorFix, or None if malformed."""
+    m_conf = _CONFIDENCE_RE.search(content)
+    m_broken = _BROKEN_RE.search(content)
+    m_suggested = _SUGGESTED_RE.search(content)
+    if not (m_conf and m_broken and m_suggested):
+        return None
+    confidence = m_conf.group(1).lower()
+    if confidence not in ("high", "medium", "low"):
+        return None
+    # Extract explanation: everything after "## Explanation"
+    explanation = ""
+    idx = content.find("## Explanation")
+    if idx != -1:
+        explanation = content[idx + len("## Explanation") :].strip()
+    return SelectorFix(
+        confidence=confidence,
+        broken_selector=m_broken.group(1),
+        suggested_selector=m_suggested.group(1),
+        explanation=explanation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Confidence filter
+# ---------------------------------------------------------------------------
+
+
+def filter_by_confidence(fixes: list[SelectorFix]) -> list[SelectorFix]:
+    """Keep only medium and high confidence fixes."""
+    return [f for f in fixes if f.confidence in ("high", "medium")]
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+def deduplicate_fixes(fixes: list[SelectorFix]) -> list[SelectorFix]:
+    """Remove duplicate fixes (same broken_selector from multiple browsers)."""
+    seen: dict[str, SelectorFix] = {}
+    for fix in fixes:
+        if fix.broken_selector not in seen:
+            seen[fix.broken_selector] = fix
+        elif fix.confidence == "high" and seen[fix.broken_selector].confidence != "high":
+            # Prefer higher confidence
+            seen[fix.broken_selector] = fix
+    return list(seen.values())
+
+
+# ---------------------------------------------------------------------------
+# Extract failed tests from results.json
+# ---------------------------------------------------------------------------
+
+
+def extract_failed_tests(results_path: Path) -> list[FailedTest]:
+    """Parse results.json and return failed tests with selector errors."""
+    with open(results_path) as f:
+        data = json.load(f)
+
+    failed: list[FailedTest] = []
+    for suite in data.get("suites", []):
+        _walk_suite(suite, failed)
+    return failed
+
+
+def _walk_suite(suite: dict, failed: list[FailedTest]) -> None:
+    """Recursively walk suite/spec/test structure."""
+    for spec in suite.get("specs", []):
+        for test in spec.get("tests", []):
+            if test.get("status") != "unexpected":
+                continue
+            results = test.get("results", [])
+            if not results:
+                continue
+            # Use the last result (final retry)
+            last = results[-1]
+            if last.get("status") != "failed":
+                continue
+            errors = last.get("errors", [])
+            error_msg = "\n".join(
+                e.get("message", "") for e in errors
+            )
+            # Strip ANSI codes
+            error_msg = re.sub(r"\x1b\[[0-9;]*m", "", error_msg)
+            # Extract file path (relative to playwright/typescript/)
+            file_path = spec.get("file", "")
+            line = spec.get("line", 0)
+            failed.append(
+                FailedTest(
+                    title=spec.get("title", ""),
+                    project=test.get("projectName", ""),
+                    file=file_path,
+                    line=line,
+                    error_message=error_msg,
+                )
+            )
+    for child in suite.get("suites", []):
+        _walk_suite(child, failed)
+
+
+# ---------------------------------------------------------------------------
+# Find selector-fix.md files in artifact directory
+# ---------------------------------------------------------------------------
+
+
+def find_selector_fixes(data_dir: Path) -> list[SelectorFix]:
+    """Find and parse all selector-fix.md files, excluding attachments/ dirs."""
+    fixes: list[SelectorFix] = []
+    for fix_path in data_dir.rglob("selector-fix.md"):
+        if "attachments" in fix_path.parts:
+            continue
+        content = fix_path.read_text(encoding="utf-8", errors="replace")
+        fix = parse_selector_fix(content)
+        if fix:
+            fixes.append(fix)
+    return fixes
+
+
+# ---------------------------------------------------------------------------
+# AI provider fallback — call API for selector fix
+# ---------------------------------------------------------------------------
+
+_SELECTOR_FIX_SYSTEM_PROMPT = textwrap.dedent("""\
+    You are a Playwright test selector specialist. A test failed because a \
+    locator could not find an element or matched multiple elements.
+
+    Given the broken selector, the error message, and a DOM snapshot, propose \
+    a replacement selector.
+
+    This project uses getByRole/getByText with exact: true as the preferred \
+    selector strategy. Avoid CSS selectors unless absolutely necessary.
+
+    Reply with ONLY a JSON object (no markdown fencing, no extra text) matching \
+    this schema:
+    {
+      "confidence": "high" | "medium" | "low",
+      "brokenSelector": "<the original broken selector>",
+      "suggestedSelector": "<your proposed replacement>",
+      "explanation": "<why the original failed and why this fix should work>"
+    }""")
+
+_SELECTOR_EXTRACT = re.compile(
+    r"((?:locator|getByRole|getByText|getByLabel|getByTestId|getByPlaceholder|getByAltText|getByTitle)"
+    r"\([^)\n]*(?:\)[^)\n]*)*\))"
+)
+
+
+def _extract_broken_selector(error_message: str) -> str | None:
+    m = _SELECTOR_EXTRACT.search(error_message)
+    return m.group(1) if m else None
+
+
+def _call_anthropic(api_key: str, user_content: str) -> str | None:
+    body = json.dumps({
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 1024,
+        "system": _SELECTOR_FIX_SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": user_content}],
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read())
+        for block in data.get("content", []):
+            if block.get("type") == "text":
+                return block["text"]
+    except (urllib.error.URLError, json.JSONDecodeError, KeyError) as exc:
+        print(f"[self-healing] Anthropic API call failed: {exc}", file=sys.stderr)
+    return None
+
+
+def _call_gemini(api_key: str, user_content: str) -> str | None:
+    model = "gemini-3.1-flash-lite-preview"
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
+    body = json.dumps({
+        "systemInstruction": {"parts": [{"text": _SELECTOR_FIX_SYSTEM_PROMPT}]},
+        "contents": [{"parts": [{"text": user_content}]}],
+        "generationConfig": {"maxOutputTokens": 1024},
+    }).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read())
+        candidates = data.get("candidates", [])
+        if candidates:
+            parts = candidates[0].get("content", {}).get("parts", [])
+            if parts:
+                return parts[0].get("text", "")
+    except (urllib.error.URLError, json.JSONDecodeError, KeyError) as exc:
+        print(f"[self-healing] Gemini API call failed: {exc}", file=sys.stderr)
+    return None
+
+
+def _parse_ai_response(text: str, broken_selector: str) -> SelectorFix | None:
+    """Parse JSON response from AI provider into a SelectorFix."""
+    cleaned = re.sub(r"^```(?:json)?\s*", "", text.strip())
+    cleaned = re.sub(r"\s*```$", "", cleaned).strip()
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError:
+        return None
+    conf = data.get("confidence", "")
+    if conf not in ("high", "medium", "low"):
+        return None
+    suggested = data.get("suggestedSelector", "")
+    explanation = data.get("explanation", "")
+    if not isinstance(suggested, str) or not isinstance(explanation, str):
+        return None
+    return SelectorFix(
+        confidence=conf,
+        broken_selector=broken_selector,
+        suggested_selector=suggested,
+        explanation=explanation,
+    )
+
+
+def request_selector_fix_from_ai(
+    error_message: str,
+    dom_content: str,
+    provider: str = "anthropic",
+) -> SelectorFix | None:
+    """Call AI provider to get a selector fix proposal (fallback path)."""
+    broken = _extract_broken_selector(error_message)
+    if not broken:
+        return None
+
+    api_key_env = {"anthropic": "ANTHROPIC_API_KEY", "gemini": "GEMINI_API_KEY"}
+    api_key = os.environ.get(api_key_env.get(provider, ""), "")
+    if not api_key:
+        return None
+
+    dom_snippet = dom_content[:DOM_TRUNCATE_CHARS]
+    if len(dom_content) > DOM_TRUNCATE_CHARS:
+        dom_snippet += "\n...[truncated]"
+
+    user_content = "\n".join([
+        f"Broken selector: {broken}",
+        f"Errors:\n{error_message}",
+        "",
+        "--- DOM snapshot (may be truncated) ---",
+        dom_snippet,
+    ])
+
+    callers = {"anthropic": _call_anthropic, "gemini": _call_gemini}
+    caller = callers.get(provider)
+    if not caller:
+        print(f"[self-healing] Unknown AI_PROVIDER: {provider}", file=sys.stderr)
+        return None
+
+    text = caller(api_key, user_content)
+    if not text:
+        return None
+    return _parse_ai_response(text, broken)
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (via gh CLI)
+# ---------------------------------------------------------------------------
+
+
+def gh(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a gh CLI command and return the result."""
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def find_pr_for_branch(branch: str) -> int | None:
+    """Return the PR number for a branch, or None if no open PR exists."""
+    result = gh(
+        "pr", "list",
+        "--head", branch,
+        "--state", "open",
+        "--json", "number",
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    prs = json.loads(result.stdout)
+    return prs[0]["number"] if prs else None
+
+
+def count_self_healing_comments(pr_number: int) -> int:
+    """Count comments on a PR that contain the self-healing marker."""
+    result = gh(
+        "api",
+        f"repos/{{owner}}/{{repo}}/issues/{pr_number}/comments",
+        "--paginate",
+        "--jq", f'[.[] | select(.body | contains("{COMMENT_MARKER}"))] | length',
+        check=False,
+    )
+    if result.returncode != 0:
+        return 0
+    try:
+        return int(result.stdout.strip())
+    except ValueError:
+        return 0
+
+
+def has_existing_self_healing_pr(base_branch: str = "main") -> bool:
+    """Check if an open draft PR with the self-healing label already exists."""
+    result = gh(
+        "pr", "list",
+        "--label", SELF_HEALING_LABEL,
+        "--state", "open",
+        "--base", base_branch,
+        "--json", "number",
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    prs = json.loads(result.stdout)
+    return len(prs) > 0
+
+
+# ---------------------------------------------------------------------------
+# Compose comment body
+# ---------------------------------------------------------------------------
+
+
+def compose_comment(fixes: list[SelectorFix], run_id: str) -> str:
+    """Build the markdown comment body with all fix proposals."""
+    lines = [
+        COMMENT_MARKER,
+        "## Self-Healing: Selector Fix Proposal",
+        "",
+        f"Workflow run: [{run_id}](../actions/runs/{run_id})",
+        "",
+    ]
+    for i, fix in enumerate(fixes, 1):
+        if len(fixes) > 1:
+            lines.append(f"### Fix {i}")
+            lines.append("")
+        lines.extend([
+            f"**Confidence:** {fix.confidence}",
+            "",
+            "**Broken selector:**",
+            f"```",
+            fix.broken_selector,
+            "```",
+            "",
+            "**Suggested selector:**",
+            f"```",
+            fix.suggested_selector,
+            "```",
+            "",
+            f"**Explanation:** {fix.explanation}",
+            "",
+            "---",
+            "",
+        ])
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Actions: post comment / create draft PR
+# ---------------------------------------------------------------------------
+
+
+def post_comment(pr_number: int, body: str, *, dry_run: bool = False) -> None:
+    """Post a comment on the given PR."""
+    if dry_run:
+        print(f"[DRY RUN] Would post comment on PR #{pr_number}:")
+        print(body)
+        return
+    body_file = Path("/tmp/self-healing-comment.md")
+    body_file.write_text(body, encoding="utf-8")
+    gh("pr", "comment", str(pr_number), "--body-file", str(body_file))
+    print(f"[self-healing] Posted comment on PR #{pr_number}")
+
+
+def create_draft_pr(
+    fixes: list[SelectorFix],
+    head_sha: str,
+    run_id: str,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Apply fixes, commit, push, and create a draft PR."""
+    short_sha = head_sha[:7]
+    fix_branch = f"{BRANCH_PREFIX}{short_sha}"
+    comment_body = compose_comment(fixes, run_id)
+
+    if dry_run:
+        print(f"[DRY RUN] Would create draft PR on branch {fix_branch}:")
+        print(comment_body)
+        return
+
+    # Configure git author for the bot commit
+    git_run("git", "config", "user.name", "github-actions[bot]")
+    git_run("git", "config", "user.email", "github-actions[bot]@users.noreply.github.com")
+
+    # Ensure the self-healing label exists (idempotent)
+    gh("label", "create", SELF_HEALING_LABEL,
+       "--color", "FFA500",
+       "--description", "Auto-generated selector fix",
+       check=False)
+
+    # Create branch from the failing commit
+    git_run("git", "checkout", "-b", fix_branch, head_sha)
+
+    # Apply each fix to test source files
+    pw_dir = Path("playwright/typescript")
+    applied = 0
+    for fix in fixes:
+        for ts_file in pw_dir.rglob("*.spec.ts"):
+            content = ts_file.read_text(encoding="utf-8")
+            if fix.broken_selector in content:
+                new_content = content.replace(
+                    fix.broken_selector, fix.suggested_selector, 1
+                )
+                ts_file.write_text(new_content, encoding="utf-8")
+                git_run("git", "add", str(ts_file))
+                applied += 1
+                break  # Only fix first occurrence
+
+    if applied == 0:
+        print("[self-healing] No fixes could be applied to source files", file=sys.stderr)
+        return
+
+    git_run(
+        "git", "commit", "-m",
+        f"fix: self-healing selector repair ({short_sha})",
+    )
+    git_run("git", "push", "origin", fix_branch)
+
+    body_file = Path("/tmp/self-healing-pr-body.md")
+    body_file.write_text(comment_body, encoding="utf-8")
+    gh(
+        "pr", "create",
+        "--draft",
+        "--title", f"fix: self-healing selector repair ({short_sha})",
+        "--body-file", str(body_file),
+        "--label", SELF_HEALING_LABEL,
+        "--head", fix_branch,
+        "--base", "main",
+    )
+    print(f"[self-healing] Created draft PR on branch {fix_branch}")
+
+
+def git_run(*args: str) -> None:
+    """Run a git command via subprocess."""
+    subprocess.run(args, check=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(data_dir: str) -> None:
+    data_path = Path(data_dir)
+    head_branch = os.environ.get("HEAD_BRANCH", "")
+    head_sha = os.environ.get("HEAD_SHA", "")
+    run_id = os.environ.get("RUN_ID", "")
+    provider = os.environ.get("AI_PROVIDER", "anthropic")
+    dry_run = os.environ.get("DRY_RUN", "").lower() == "true"
+
+    # Layer 1: Branch guard
+    if should_skip_branch(head_branch):
+        print(f"[self-healing] Skipping: self-healing branch ({head_branch})")
+        return
+
+    # Step 1: Find pre-computed selector fixes
+    fixes = find_selector_fixes(data_path)
+    fixes = filter_by_confidence(fixes)
+    fixes = deduplicate_fixes(fixes)
+
+    # Step 2: Fallback — check results.json for selector errors and call AI
+    if not fixes:
+        results_files = list(data_path.rglob("results.json"))
+        for results_file in results_files:
+            failed_tests = extract_failed_tests(results_file)
+            selector_failures = [t for t in failed_tests if is_selector_error(t.error_message)]
+            for test in selector_failures:
+                # Find corresponding dom.xhtml
+                test_dir = results_file.parent
+                dom_files = list(test_dir.rglob("dom.xhtml"))
+                if not dom_files:
+                    continue
+                dom_content = dom_files[0].read_text(encoding="utf-8", errors="replace")
+                fix = request_selector_fix_from_ai(test.error_message, dom_content, provider)
+                if fix:
+                    fixes.append(fix)
+        fixes = filter_by_confidence(fixes)
+        fixes = deduplicate_fixes(fixes)
+
+    if not fixes:
+        print("[self-healing] No actionable selector fixes found")
+        return
+
+    # Step 3: Determine output mode
+    pr_number = find_pr_for_branch(head_branch)
+
+    if pr_number:
+        # PR comment mode
+        # Layer 3: Max attempts
+        attempts = count_self_healing_comments(pr_number)
+        if attempts >= MAX_ATTEMPTS:
+            print(
+                f"[self-healing] Max attempts ({MAX_ATTEMPTS}) reached for PR #{pr_number}"
+            )
+            return
+        body = compose_comment(fixes, run_id)
+        post_comment(pr_number, body, dry_run=dry_run)
+    else:
+        # Draft PR mode
+        # Layer 4: Dedup
+        if has_existing_self_healing_pr():
+            print("[self-healing] A self-healing PR already exists, skipping")
+            return
+        create_draft_pr(fixes, head_sha, run_id, dry_run=dry_run)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <data-dir>", file=sys.stderr)
+        sys.exit(1)
+    main(sys.argv[1])

--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -332,14 +332,30 @@ def _call_gemini(api_key: str, user_content: str) -> str | None:
     return None
 
 
+_JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*\n(.*?)\n\s*```", re.DOTALL)
+
+
 def _parse_ai_response(text: str, broken_selector: str) -> SelectorFix | None:
-    """Parse JSON response from AI provider into a SelectorFix."""
-    cleaned = re.sub(r"^```(?:json)?\s*", "", text.strip())
-    cleaned = re.sub(r"\s*```$", "", cleaned).strip()
+    """Parse JSON response from AI provider into a SelectorFix.
+
+    Handles three response shapes: bare JSON, fenced JSON at the boundaries,
+    and JSON fenced somewhere in the middle of explanatory text.
+    """
+    stripped = text.strip()
+    # Try bare JSON first
+    candidate = re.sub(r"^```(?:json)?\s*", "", stripped)
+    candidate = re.sub(r"\s*```$", "", candidate).strip()
     try:
-        data = json.loads(cleaned)
+        data = json.loads(candidate)
     except json.JSONDecodeError:
-        return None
+        # Try extracting a fenced JSON block from anywhere in the response
+        m = _JSON_BLOCK_RE.search(stripped)
+        if not m:
+            return None
+        try:
+            data = json.loads(m.group(1).strip())
+        except json.JSONDecodeError:
+            return None
     conf = data.get("confidence", "")
     if conf not in ("high", "medium", "low"):
         return None
@@ -364,9 +380,9 @@ def request_selector_fix_from_ai(
     """Call AI provider to get a selector fix proposal (fallback path).
 
     When *error_context* is provided (the Playwright built-in error-context.md
-    attachment), it is used as the primary context because it bundles the
-    accessibility tree snapshot, test source, and error details in one document.
-    *dom_content* is still appended as a fallback DOM reference.
+    attachment), it replaces dom_content entirely — the accessibility tree
+    snapshot it contains is more useful for selector fixing than raw HTML,
+    and it also bundles the test source and error details.
     """
     broken = _extract_broken_selector(error_message)
     if not broken:
@@ -377,21 +393,25 @@ def request_selector_fix_from_ai(
     if not api_key:
         return None
 
-    dom_snippet = dom_content[:DOM_TRUNCATE_CHARS]
-    if len(dom_content) > DOM_TRUNCATE_CHARS:
-        dom_snippet += "\n...[truncated]"
-
     if error_context:
+        # error-context.md already contains the page snapshot (accessibility
+        # tree), test source, and error details — no need for dom.xhtml.
+        # Strip the "# Instructions" section to avoid conflicting with our
+        # system prompt (it tells the AI to "explain why", which causes it
+        # to add prose before the JSON we need).
+        ec_cleaned = re.sub(
+            r"^#\s*Instructions\b.*?(?=^#\s|\Z)", "", error_context,
+            count=1, flags=re.MULTILINE | re.DOTALL,
+        ).strip()
         user_content = "\n".join([
             f"Broken selector: {broken}",
             "",
-            "--- Playwright error context (includes test source and page snapshot) ---",
-            error_context[:DOM_TRUNCATE_CHARS],
-            "",
-            "--- DOM snapshot (may be truncated) ---",
-            dom_snippet,
+            ec_cleaned[:DOM_TRUNCATE_CHARS],
         ])
     else:
+        dom_snippet = dom_content[:DOM_TRUNCATE_CHARS]
+        if len(dom_content) > DOM_TRUNCATE_CHARS:
+            dom_snippet += "\n...[truncated]"
         user_content = "\n".join([
             f"Broken selector: {broken}",
             f"Errors:\n{error_message}",

--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -161,9 +161,13 @@ def filter_by_confidence(fixes: list[SelectorFix]) -> list[SelectorFix]:
 
 
 def deduplicate_fixes(fixes: list[SelectorFix]) -> list[SelectorFix]:
-    """Remove duplicate fixes (same broken_selector from multiple browsers)."""
+    """Remove duplicate fixes and no-op fixes (same broken_selector from multiple browsers,
+    or suggested_selector identical to broken_selector)."""
     seen: dict[str, SelectorFix] = {}
     for fix in fixes:
+        # Skip no-op fixes where the AI suggested the exact same selector
+        if fix.broken_selector == fix.suggested_selector:
+            continue
         if fix.broken_selector not in seen:
             seen[fix.broken_selector] = fix
         elif fix.confidence == "high" and seen[fix.broken_selector].confidence != "high":
@@ -355,8 +359,15 @@ def request_selector_fix_from_ai(
     error_message: str,
     dom_content: str,
     provider: str = "anthropic",
+    error_context: str | None = None,
 ) -> SelectorFix | None:
-    """Call AI provider to get a selector fix proposal (fallback path)."""
+    """Call AI provider to get a selector fix proposal (fallback path).
+
+    When *error_context* is provided (the Playwright built-in error-context.md
+    attachment), it is used as the primary context because it bundles the
+    accessibility tree snapshot, test source, and error details in one document.
+    *dom_content* is still appended as a fallback DOM reference.
+    """
     broken = _extract_broken_selector(error_message)
     if not broken:
         return None
@@ -370,13 +381,24 @@ def request_selector_fix_from_ai(
     if len(dom_content) > DOM_TRUNCATE_CHARS:
         dom_snippet += "\n...[truncated]"
 
-    user_content = "\n".join([
-        f"Broken selector: {broken}",
-        f"Errors:\n{error_message}",
-        "",
-        "--- DOM snapshot (may be truncated) ---",
-        dom_snippet,
-    ])
+    if error_context:
+        user_content = "\n".join([
+            f"Broken selector: {broken}",
+            "",
+            "--- Playwright error context (includes test source and page snapshot) ---",
+            error_context[:DOM_TRUNCATE_CHARS],
+            "",
+            "--- DOM snapshot (may be truncated) ---",
+            dom_snippet,
+        ])
+    else:
+        user_content = "\n".join([
+            f"Broken selector: {broken}",
+            f"Errors:\n{error_message}",
+            "",
+            "--- DOM snapshot (may be truncated) ---",
+            dom_snippet,
+        ])
 
     callers = {"anthropic": _call_anthropic, "gemini": _call_gemini}
     caller = callers.get(provider)
@@ -613,13 +635,21 @@ def main(data_dir: str) -> None:
             failed_tests = extract_failed_tests(results_file)
             selector_failures = [t for t in failed_tests if is_selector_error(t.error_message)]
             for test in selector_failures:
-                # Find corresponding dom.xhtml
                 test_dir = results_file.parent
+                # Prefer error-context.md (Playwright built-in: includes test source
+                # and accessibility tree) over raw dom.xhtml
+                error_context = None
+                ec_files = list(test_dir.rglob("error-context.md"))
+                if ec_files:
+                    error_context = ec_files[0].read_text(encoding="utf-8", errors="replace")
                 dom_files = list(test_dir.rglob("dom.xhtml"))
-                if not dom_files:
+                if not dom_files and not error_context:
                     continue
-                dom_content = dom_files[0].read_text(encoding="utf-8", errors="replace")
-                fix = request_selector_fix_from_ai(test.error_message, dom_content, provider)
+                dom_content = dom_files[0].read_text(encoding="utf-8", errors="replace") if dom_files else ""
+                fix = request_selector_fix_from_ai(
+                    test.error_message, dom_content, provider,
+                    error_context=error_context,
+                )
                 if fix:
                     fixes.append(fix)
         fixes = filter_by_confidence(fixes)

--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -307,6 +307,7 @@ def _call_anthropic(api_key: str, user_content: str) -> str | None:
 
 
 def _call_gemini(api_key: str, user_content: str) -> str | None:
+    # Same model as diagnosis.util.ts — chosen for its free-tier RPD quota (500 vs 20).
     model = "gemini-3.1-flash-lite-preview"
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     body = json.dumps({
@@ -463,7 +464,11 @@ def find_pr_for_branch(branch: str) -> int | None:
 
 
 def count_self_healing_comments(pr_number: int) -> int:
-    """Count comments on a PR that contain the self-healing marker."""
+    """Count comments on a PR that contain the self-healing marker.
+
+    ``gh api --paginate`` applies ``--jq`` per page, so the output is one
+    number per page (e.g. ``"1\\n0\\n"``).  We sum them to get the total.
+    """
     result = gh(
         "api",
         f"repos/{{owner}}/{{repo}}/issues/{pr_number}/comments",
@@ -473,10 +478,13 @@ def count_self_healing_comments(pr_number: int) -> int:
     )
     if result.returncode != 0:
         return 0
-    try:
-        return int(result.stdout.strip())
-    except ValueError:
-        return 0
+    total = 0
+    for line in result.stdout.strip().splitlines():
+        try:
+            total += int(line)
+        except ValueError:
+            continue
+    return total
 
 
 def has_existing_self_healing_pr(base_branch: str = "main") -> bool:

--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -50,6 +50,15 @@ SELECTOR_ERROR_PATTERN = re.compile(
 
 DOM_TRUNCATE_CHARS = 30_000
 
+
+def _run_url(run_id: str) -> str:
+    """Build a URL to the workflow run, absolute when GITHUB_REPOSITORY is set."""
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    if repo:
+        return f"https://github.com/{repo}/actions/runs/{run_id}"
+    return f"../actions/runs/{run_id}"
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
@@ -308,6 +317,7 @@ def _call_anthropic(api_key: str, user_content: str) -> str | None:
 
 def _call_gemini(api_key: str, user_content: str) -> str | None:
     # Same model as diagnosis.util.ts — chosen for its free-tier RPD quota (500 vs 20).
+    # Model override env vars are planned in #200 (AI_MODEL_FAST / AI_MODEL_STRONG).
     model = "gemini-3.1-flash-lite-preview"
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     body = json.dumps({
@@ -487,13 +497,17 @@ def count_self_healing_comments(pr_number: int) -> int:
     return total
 
 
-def has_existing_self_healing_pr(base_branch: str = "main") -> bool:
+def _default_branch() -> str:
+    return os.environ.get("GITHUB_DEFAULT_BRANCH", "main")
+
+
+def has_existing_self_healing_pr(base_branch: str | None = None) -> bool:
     """Check if an open draft PR with the self-healing label already exists."""
     result = gh(
         "pr", "list",
         "--label", SELF_HEALING_LABEL,
         "--state", "open",
-        "--base", base_branch,
+        "--base", base_branch or _default_branch(),
         "--json", "number",
         check=False,
     )
@@ -514,7 +528,7 @@ def compose_comment(fixes: list[SelectorFix], run_id: str) -> str:
         COMMENT_MARKER,
         "## Self-Healing: Selector Fix Proposal",
         "",
-        f"Workflow run: [{run_id}](../actions/runs/{run_id})",
+        f"Workflow run: [{run_id}]({_run_url(run_id)})",
         "",
     ]
     for i, fix in enumerate(fixes, 1):
@@ -623,7 +637,7 @@ def create_draft_pr(
         "--body-file", str(body_file),
         "--label", SELF_HEALING_LABEL,
         "--head", fix_branch,
-        "--base", "main",
+        "--base", _default_branch(),
     )
     print(f"[self-healing] Created draft PR on branch {fix_branch}")
 

--- a/scripts/test_self_healing.py
+++ b/scripts/test_self_healing.py
@@ -46,6 +46,45 @@ SAMPLE_SELECTOR_FIX = textwrap.dedent("""\
     ## Explanation
     The original selector used 'Strona glowna' (without Polish diacritics) but the actual link text is 'Strona główna'.""")
 
+SAMPLE_ERROR_CONTEXT = textwrap.dedent("""\
+    # Instructions
+
+    - Following Playwright test failed.
+    - Explain why, be concise, respect Playwright best practices.
+    - Provide a snippet of code with the fix, if possible.
+
+    # Test info
+
+    - Name: navigation.spec.ts >> navigation >> home page
+    - Location: tests/navigation.spec.ts:31:3
+
+    # Error details
+
+    ```
+    TimeoutError: locator.click: Timeout 15000ms exceeded.
+    Call log:
+      - waiting for locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })
+    ```
+
+    # Page snapshot
+
+    ```yaml
+    - list:
+        - listitem:
+            - link "Strona główna":
+                - /url: /
+    ```
+
+    # Test source
+
+    ```ts
+      31 |   test('home page', async ({ page }) => {
+      32 |     await page
+      33 |       .locator('#menubar')
+      34 |       .getByRole('link', { name: 'Strona glowna', exact: true })
+    > 35 |       .click();
+    ```""")
+
 SAMPLE_SELECTOR_FIX_LOW = SAMPLE_SELECTOR_FIX.replace(
     "**Confidence:** high", "**Confidence:** low"
 )
@@ -301,6 +340,12 @@ class TestDeduplication(unittest.TestCase):
         result = self_healing.deduplicate_fixes([fix1, fix2])
         self.assertEqual(len(result), 2)
 
+    def test_skips_noop_fix(self):
+        """AI suggested the exact same selector — must be filtered out."""
+        fix = self_healing.SelectorFix("high", "getByRole('link')", "getByRole('link')", "no change")
+        result = self_healing.deduplicate_fixes([fix])
+        self.assertEqual(len(result), 0)
+
     def test_empty_list(self):
         self.assertEqual(self_healing.deduplicate_fixes([]), [])
 
@@ -549,6 +594,65 @@ class TestParseAiResponse(unittest.TestCase):
             "explanation": "z",
         })
         self.assertIsNone(self_healing._parse_ai_response(text, "x"))
+
+
+# ===================================================================
+# Error-context.md support in AI fallback
+# ===================================================================
+
+
+class TestErrorContextSupport(unittest.TestCase):
+    @patch("self_healing._call_anthropic")
+    def test_includes_error_context_in_prompt(self, mock_call):
+        """When error-context.md is provided, it appears in the user_content."""
+        mock_call.return_value = json.dumps({
+            "confidence": "high",
+            "brokenSelector": "locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })",
+            "suggestedSelector": "locator('#menubar').getByRole('link', { name: 'Strona główna', exact: true })",
+            "explanation": "diacritic fix",
+        })
+        os.environ["ANTHROPIC_API_KEY"] = "test-key"
+        try:
+            fix = self_healing.request_selector_fix_from_ai(
+                "waiting for locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })",
+                "<html></html>",
+                "anthropic",
+                error_context=SAMPLE_ERROR_CONTEXT,
+            )
+            self.assertIsNotNone(fix)
+            # Verify error-context was included in the prompt sent to the AI
+            call_args = mock_call.call_args
+            user_content = call_args[0][1]  # second positional arg
+            self.assertIn("Playwright error context", user_content)
+            self.assertIn("Page snapshot", user_content)
+            self.assertIn("Test source", user_content)
+        finally:
+            del os.environ["ANTHROPIC_API_KEY"]
+
+    @patch("self_healing._call_anthropic")
+    def test_falls_back_to_dom_without_error_context(self, mock_call):
+        """When error_context is None, prompt uses the old format with DOM only."""
+        mock_call.return_value = json.dumps({
+            "confidence": "medium",
+            "brokenSelector": "locator('#foo')",
+            "suggestedSelector": "locator('#bar')",
+            "explanation": "changed",
+        })
+        os.environ["ANTHROPIC_API_KEY"] = "test-key"
+        try:
+            fix = self_healing.request_selector_fix_from_ai(
+                "waiting for locator('#foo')",
+                "<html><div id='bar'></div></html>",
+                "anthropic",
+                error_context=None,
+            )
+            self.assertIsNotNone(fix)
+            call_args = mock_call.call_args
+            user_content = call_args[0][1]
+            self.assertIn("DOM snapshot", user_content)
+            self.assertNotIn("Playwright error context", user_content)
+        finally:
+            del os.environ["ANTHROPIC_API_KEY"]
 
 
 # ===================================================================

--- a/scripts/test_self_healing.py
+++ b/scripts/test_self_healing.py
@@ -473,6 +473,14 @@ class TestMaxAttempts(unittest.TestCase):
         self.assertFalse(count >= self_healing.MAX_ATTEMPTS)
 
     @patch("self_healing.gh")
+    def test_sums_across_paginated_pages(self, mock_gh):
+        """--paginate applies --jq per page; output is one number per line."""
+        mock_gh.return_value = MagicMock(returncode=0, stdout="1\n1\n0\n")
+        count = self_healing.count_self_healing_comments(42)
+        self.assertEqual(count, 2)
+        self.assertTrue(count >= self_healing.MAX_ATTEMPTS)
+
+    @patch("self_healing.gh")
     def test_handles_api_failure(self, mock_gh):
         mock_gh.return_value = MagicMock(returncode=1, stdout="")
         count = self_healing.count_self_healing_comments(42)

--- a/scripts/test_self_healing.py
+++ b/scripts/test_self_healing.py
@@ -583,6 +583,23 @@ class TestParseAiResponse(unittest.TestCase):
         fix = self_healing._parse_ai_response(text, "x")
         self.assertIsNotNone(fix)
 
+    def test_extracts_json_after_prose(self):
+        """AI adds explanatory text before the fenced JSON block."""
+        text = (
+            "The selector failed because of a typo.\n\n"
+            "```json\n"
+            + json.dumps({
+                "confidence": "high",
+                "brokenSelector": "x",
+                "suggestedSelector": "y",
+                "explanation": "z",
+            })
+            + "\n```"
+        )
+        fix = self_healing._parse_ai_response(text, "x")
+        self.assertIsNotNone(fix)
+        self.assertEqual(fix.confidence, "high")
+
     def test_returns_none_for_invalid_json(self):
         self.assertIsNone(self_healing._parse_ai_response("not json", "x"))
 
@@ -604,7 +621,7 @@ class TestParseAiResponse(unittest.TestCase):
 class TestErrorContextSupport(unittest.TestCase):
     @patch("self_healing._call_anthropic")
     def test_includes_error_context_in_prompt(self, mock_call):
-        """When error-context.md is provided, it appears in the user_content."""
+        """When error-context.md is provided, it replaces dom.xhtml in the prompt."""
         mock_call.return_value = json.dumps({
             "confidence": "high",
             "brokenSelector": "locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })",
@@ -620,12 +637,16 @@ class TestErrorContextSupport(unittest.TestCase):
                 error_context=SAMPLE_ERROR_CONTEXT,
             )
             self.assertIsNotNone(fix)
-            # Verify error-context was included in the prompt sent to the AI
             call_args = mock_call.call_args
             user_content = call_args[0][1]  # second positional arg
-            self.assertIn("Playwright error context", user_content)
+            # Page snapshot and test source from error-context are included
             self.assertIn("Page snapshot", user_content)
             self.assertIn("Test source", user_content)
+            # Instructions section is stripped to avoid conflicting with system prompt
+            self.assertNotIn("# Instructions", user_content)
+            # dom.xhtml is NOT included — error-context replaces it
+            self.assertNotIn("DOM snapshot", user_content)
+            self.assertNotIn("<html></html>", user_content)
         finally:
             del os.environ["ANTHROPIC_API_KEY"]
 

--- a/scripts/test_self_healing.py
+++ b/scripts/test_self_healing.py
@@ -1,0 +1,587 @@
+"""Unit tests for scripts/self-healing.py.
+
+Covers all loop prevention scenarios, error classification, selector-fix
+parsing, confidence filtering, multi-browser deduplication, and YAML-level
+guard verification.
+
+Usage:
+    python3 scripts/test_self_healing.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Import self-healing.py (hyphenated filename requires importlib)
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "self_healing", Path(__file__).parent / "self-healing.py"
+)
+self_healing = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(self_healing)
+sys.modules["self_healing"] = self_healing  # allow @patch("self_healing.gh") to resolve
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "self-healing.yml"
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_SELECTOR_FIX = textwrap.dedent("""\
+    # Selector Fix Proposal
+
+    **Confidence:** high
+    **Broken selector:** `locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })`
+    **Suggested selector:** `locator('#menubar').getByRole('link', { name: 'Strona główna', exact: true })`
+
+    ## Explanation
+    The original selector used 'Strona glowna' (without Polish diacritics) but the actual link text is 'Strona główna'.""")
+
+SAMPLE_SELECTOR_FIX_LOW = SAMPLE_SELECTOR_FIX.replace(
+    "**Confidence:** high", "**Confidence:** low"
+)
+SAMPLE_SELECTOR_FIX_MEDIUM = SAMPLE_SELECTOR_FIX.replace(
+    "**Confidence:** high", "**Confidence:** medium"
+)
+
+SAMPLE_RESULTS_JSON_FAILED = {
+    "suites": [
+        {
+            "title": "navigation.spec.ts",
+            "file": "navigation.spec.ts",
+            "specs": [],
+            "suites": [
+                {
+                    "title": "navigation",
+                    "file": "navigation.spec.ts",
+                    "line": 26,
+                    "column": 6,
+                    "specs": [
+                        {
+                            "title": "home page",
+                            "ok": False,
+                            "tags": ["smoke"],
+                            "tests": [
+                                {
+                                    "timeout": 30000,
+                                    "expectedStatus": "passed",
+                                    "projectId": "Chromium",
+                                    "projectName": "Chromium",
+                                    "results": [
+                                        {
+                                            "status": "failed",
+                                            "errors": [
+                                                {
+                                                    "message": "TimeoutError: locator.click: Timeout 15000ms exceeded.\nCall log:\n  - waiting for locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })\n"
+                                                }
+                                            ],
+                                            "attachments": [],
+                                        }
+                                    ],
+                                    "status": "unexpected",
+                                }
+                            ],
+                            "file": "navigation.spec.ts",
+                            "line": 31,
+                            "column": 3,
+                        }
+                    ],
+                    "suites": [],
+                }
+            ],
+        }
+    ]
+}
+
+SAMPLE_RESULTS_JSON_PASSED = {
+    "suites": [
+        {
+            "title": "navigation.spec.ts",
+            "file": "navigation.spec.ts",
+            "specs": [
+                {
+                    "title": "/ has correct title",
+                    "ok": True,
+                    "tags": ["smoke"],
+                    "tests": [
+                        {
+                            "timeout": 30000,
+                            "expectedStatus": "passed",
+                            "projectId": "Chromium",
+                            "projectName": "Chromium",
+                            "results": [
+                                {
+                                    "status": "passed",
+                                    "errors": [],
+                                    "attachments": [],
+                                }
+                            ],
+                            "status": "expected",
+                        }
+                    ],
+                    "file": "navigation.spec.ts",
+                    "line": 13,
+                    "column": 3,
+                }
+            ],
+            "suites": [],
+        }
+    ]
+}
+
+
+def _write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ===================================================================
+# Branch guard tests
+# ===================================================================
+
+
+class TestBranchGuard(unittest.TestCase):
+    def test_blocks_self_healing_branch(self):
+        self.assertTrue(self_healing.should_skip_branch("fix/self-healing-abc123"))
+
+    def test_blocks_self_healing_branch_with_sha(self):
+        self.assertTrue(self_healing.should_skip_branch("fix/self-healing-d93137c"))
+
+    def test_allows_feature_branch(self):
+        self.assertFalse(self_healing.should_skip_branch("feature/123"))
+
+    def test_allows_main(self):
+        self.assertFalse(self_healing.should_skip_branch("main"))
+
+    def test_allows_bugfix_branch(self):
+        self.assertFalse(self_healing.should_skip_branch("bugfix/42"))
+
+    def test_allows_empty_string(self):
+        self.assertFalse(self_healing.should_skip_branch(""))
+
+
+# ===================================================================
+# Selector error classification tests
+# ===================================================================
+
+
+class TestClassification(unittest.TestCase):
+    def test_skips_non_selector_error(self):
+        self.assertFalse(
+            self_healing.is_selector_error('Expected "foo" to equal "bar"')
+        )
+
+    def test_skips_generic_timeout(self):
+        self.assertFalse(
+            self_healing.is_selector_error("Navigation timeout of 30000 ms exceeded")
+        )
+
+    def test_detects_selector_timeout(self):
+        self.assertTrue(
+            self_healing.is_selector_error("waiting for locator('#foo')")
+        )
+
+    def test_detects_strict_mode_violation(self):
+        self.assertTrue(
+            self_healing.is_selector_error(
+                "strict mode violation: getByRole('link') resolved to 3 elements"
+            )
+        )
+
+    def test_detects_getby_timeout(self):
+        self.assertTrue(
+            self_healing.is_selector_error(
+                "waiting for getByRole('link', { name: 'Home' })"
+            )
+        )
+
+    def test_detects_locator_method_timeout(self):
+        self.assertTrue(
+            self_healing.is_selector_error(
+                "locator.click: Timeout 15000ms exceeded"
+            )
+        )
+
+    def test_case_insensitive(self):
+        self.assertTrue(
+            self_healing.is_selector_error("STRICT MODE VIOLATION")
+        )
+
+
+# ===================================================================
+# Parse selector-fix.md tests
+# ===================================================================
+
+
+class TestParseSelectorFix(unittest.TestCase):
+    def test_extracts_all_fields(self):
+        fix = self_healing.parse_selector_fix(SAMPLE_SELECTOR_FIX)
+        self.assertIsNotNone(fix)
+        self.assertEqual(fix.confidence, "high")
+        self.assertEqual(
+            fix.broken_selector,
+            "locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })",
+        )
+        self.assertEqual(
+            fix.suggested_selector,
+            "locator('#menubar').getByRole('link', { name: 'Strona główna', exact: true })",
+        )
+        self.assertIn("diacritics", fix.explanation)
+
+    def test_returns_none_for_malformed(self):
+        self.assertIsNone(self_healing.parse_selector_fix("not a valid file"))
+
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(self_healing.parse_selector_fix(""))
+
+    def test_returns_none_for_missing_confidence(self):
+        content = SAMPLE_SELECTOR_FIX.replace("**Confidence:** high", "")
+        self.assertIsNone(self_healing.parse_selector_fix(content))
+
+    def test_returns_none_for_invalid_confidence(self):
+        content = SAMPLE_SELECTOR_FIX.replace("**Confidence:** high", "**Confidence:** extreme")
+        self.assertIsNone(self_healing.parse_selector_fix(content))
+
+
+# ===================================================================
+# Confidence filter tests
+# ===================================================================
+
+
+class TestConfidenceFilter(unittest.TestCase):
+    def _make_fix(self, confidence: str):
+        return self_healing.SelectorFix(confidence, "broken", "suggested", "why")
+
+    def test_skips_low(self):
+        fixes = [self._make_fix("low")]
+        self.assertEqual(self_healing.filter_by_confidence(fixes), [])
+
+    def test_includes_medium(self):
+        fixes = [self._make_fix("medium")]
+        self.assertEqual(len(self_healing.filter_by_confidence(fixes)), 1)
+
+    def test_includes_high(self):
+        fixes = [self._make_fix("high")]
+        self.assertEqual(len(self_healing.filter_by_confidence(fixes)), 1)
+
+    def test_mixed(self):
+        fixes = [self._make_fix("low"), self._make_fix("high"), self._make_fix("medium")]
+        result = self_healing.filter_by_confidence(fixes)
+        self.assertEqual(len(result), 2)
+        confidences = {f.confidence for f in result}
+        self.assertEqual(confidences, {"high", "medium"})
+
+
+# ===================================================================
+# Multi-browser dedup tests
+# ===================================================================
+
+
+class TestDeduplication(unittest.TestCase):
+    def test_deduplicates_same_selector(self):
+        fix1 = self_healing.SelectorFix("high", "getByRole('link')", "getByRole('button')", "reason")
+        fix2 = self_healing.SelectorFix("medium", "getByRole('link')", "getByRole('button')", "reason2")
+        result = self_healing.deduplicate_fixes([fix1, fix2])
+        self.assertEqual(len(result), 1)
+        # Should prefer high confidence
+        self.assertEqual(result[0].confidence, "high")
+
+    def test_keeps_different_selectors(self):
+        fix1 = self_healing.SelectorFix("high", "getByRole('link')", "fix1", "reason")
+        fix2 = self_healing.SelectorFix("high", "getByRole('button')", "fix2", "reason")
+        result = self_healing.deduplicate_fixes([fix1, fix2])
+        self.assertEqual(len(result), 2)
+
+    def test_empty_list(self):
+        self.assertEqual(self_healing.deduplicate_fixes([]), [])
+
+
+# ===================================================================
+# Extract failed tests from results.json
+# ===================================================================
+
+
+class TestExtractFailedTests(unittest.TestCase):
+    def test_extracts_failed_test(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(SAMPLE_RESULTS_JSON_FAILED, f)
+            f.flush()
+            try:
+                failed = self_healing.extract_failed_tests(Path(f.name))
+                self.assertEqual(len(failed), 1)
+                self.assertEqual(failed[0].title, "home page")
+                self.assertEqual(failed[0].project, "Chromium")
+                self.assertIn("waiting for locator", failed[0].error_message)
+            finally:
+                os.unlink(f.name)
+
+    def test_skips_passed_tests(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(SAMPLE_RESULTS_JSON_PASSED, f)
+            f.flush()
+            try:
+                failed = self_healing.extract_failed_tests(Path(f.name))
+                self.assertEqual(len(failed), 0)
+            finally:
+                os.unlink(f.name)
+
+    def test_strips_ansi_codes(self):
+        data = json.loads(json.dumps(SAMPLE_RESULTS_JSON_FAILED))
+        data["suites"][0]["suites"][0]["specs"][0]["tests"][0]["results"][0]["errors"][0][
+            "message"
+        ] = "\x1b[2mwaiting for locator('#foo')\x1b[22m"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+            try:
+                failed = self_healing.extract_failed_tests(Path(f.name))
+                self.assertEqual(len(failed), 1)
+                self.assertNotIn("\x1b", failed[0].error_message)
+            finally:
+                os.unlink(f.name)
+
+    def test_uses_last_retry(self):
+        """When a test has multiple retries, use the last result."""
+        data = json.loads(json.dumps(SAMPLE_RESULTS_JSON_FAILED))
+        # Add a first result that passed (simulating a retry)
+        test_obj = data["suites"][0]["suites"][0]["specs"][0]["tests"][0]
+        failed_result = test_obj["results"][0]
+        passed_result = {"status": "passed", "errors": [], "attachments": []}
+        test_obj["results"] = [passed_result, failed_result]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+            try:
+                failed = self_healing.extract_failed_tests(Path(f.name))
+                self.assertEqual(len(failed), 1)
+                self.assertIn("waiting for locator", failed[0].error_message)
+            finally:
+                os.unlink(f.name)
+
+
+# ===================================================================
+# Find selector fixes in artifact directory
+# ===================================================================
+
+
+class TestFindSelectorFixes(unittest.TestCase):
+    def test_finds_fixes_in_nested_dirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_file(
+                tmp_path / "test-results" / "nav-home-Chromium" / "selector-fix.md",
+                SAMPLE_SELECTOR_FIX,
+            )
+            fixes = self_healing.find_selector_fixes(tmp_path)
+            self.assertEqual(len(fixes), 1)
+
+    def test_skips_attachments_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_file(
+                tmp_path / "test-results" / "nav" / "attachments" / "selector-fix.md",
+                SAMPLE_SELECTOR_FIX,
+            )
+            fixes = self_healing.find_selector_fixes(tmp_path)
+            self.assertEqual(len(fixes), 0)
+
+    def test_returns_empty_for_no_fixes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixes = self_healing.find_selector_fixes(Path(tmp))
+            self.assertEqual(len(fixes), 0)
+
+
+# ===================================================================
+# Max attempts (comment counting)
+# ===================================================================
+
+
+class TestMaxAttempts(unittest.TestCase):
+    @patch("self_healing.gh")
+    def test_blocks_after_2_comments(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=0, stdout="2\n")
+        count = self_healing.count_self_healing_comments(42)
+        self.assertEqual(count, 2)
+        self.assertTrue(count >= self_healing.MAX_ATTEMPTS)
+
+    @patch("self_healing.gh")
+    def test_allows_first_comment(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=0, stdout="0\n")
+        count = self_healing.count_self_healing_comments(42)
+        self.assertEqual(count, 0)
+        self.assertFalse(count >= self_healing.MAX_ATTEMPTS)
+
+    @patch("self_healing.gh")
+    def test_allows_second_comment(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=0, stdout="1\n")
+        count = self_healing.count_self_healing_comments(42)
+        self.assertEqual(count, 1)
+        self.assertFalse(count >= self_healing.MAX_ATTEMPTS)
+
+    @patch("self_healing.gh")
+    def test_handles_api_failure(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=1, stdout="")
+        count = self_healing.count_self_healing_comments(42)
+        self.assertEqual(count, 0)
+
+
+# ===================================================================
+# Draft PR dedup
+# ===================================================================
+
+
+class TestDraftPrDedup(unittest.TestCase):
+    @patch("self_healing.gh")
+    def test_blocks_existing_pr(self, mock_gh):
+        mock_gh.return_value = MagicMock(
+            returncode=0, stdout=json.dumps([{"number": 99}])
+        )
+        self.assertTrue(self_healing.has_existing_self_healing_pr())
+
+    @patch("self_healing.gh")
+    def test_allows_when_no_existing_pr(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=0, stdout="[]")
+        self.assertFalse(self_healing.has_existing_self_healing_pr())
+
+
+# ===================================================================
+# Find PR for branch
+# ===================================================================
+
+
+class TestFindPrForBranch(unittest.TestCase):
+    @patch("self_healing.gh")
+    def test_returns_number(self, mock_gh):
+        mock_gh.return_value = MagicMock(
+            returncode=0, stdout=json.dumps([{"number": 42}])
+        )
+        self.assertEqual(self_healing.find_pr_for_branch("feature/123"), 42)
+
+    @patch("self_healing.gh")
+    def test_returns_none_for_no_pr(self, mock_gh):
+        mock_gh.return_value = MagicMock(returncode=0, stdout="[]")
+        self.assertIsNone(self_healing.find_pr_for_branch("main"))
+
+
+# ===================================================================
+# Compose comment
+# ===================================================================
+
+
+class TestComposeComment(unittest.TestCase):
+    def test_includes_marker(self):
+        fix = self_healing.SelectorFix("high", "broken", "suggested", "reason")
+        body = self_healing.compose_comment([fix], "12345")
+        self.assertIn(self_healing.COMMENT_MARKER, body)
+
+    def test_includes_all_fixes(self):
+        fix1 = self_healing.SelectorFix("high", "broken1", "suggested1", "reason1")
+        fix2 = self_healing.SelectorFix("medium", "broken2", "suggested2", "reason2")
+        body = self_healing.compose_comment([fix1, fix2], "12345")
+        self.assertIn("broken1", body)
+        self.assertIn("broken2", body)
+        self.assertIn("suggested1", body)
+        self.assertIn("suggested2", body)
+
+    def test_includes_run_link(self):
+        fix = self_healing.SelectorFix("high", "broken", "suggested", "reason")
+        body = self_healing.compose_comment([fix], "99999")
+        self.assertIn("99999", body)
+
+
+# ===================================================================
+# Dry run
+# ===================================================================
+
+
+class TestDryRun(unittest.TestCase):
+    @patch("self_healing.gh")
+    def test_dry_run_does_not_call_gh_for_comment(self, mock_gh):
+        self_healing.post_comment(42, "test body", dry_run=True)
+        mock_gh.assert_not_called()
+
+
+# ===================================================================
+# AI response parsing
+# ===================================================================
+
+
+class TestParseAiResponse(unittest.TestCase):
+    def test_parses_valid_json(self):
+        text = json.dumps({
+            "confidence": "high",
+            "brokenSelector": "getByRole('link')",
+            "suggestedSelector": "getByRole('button')",
+            "explanation": "Element changed",
+        })
+        fix = self_healing._parse_ai_response(text, "getByRole('link')")
+        self.assertIsNotNone(fix)
+        self.assertEqual(fix.confidence, "high")
+        self.assertEqual(fix.suggested_selector, "getByRole('button')")
+
+    def test_handles_markdown_fencing(self):
+        text = "```json\n" + json.dumps({
+            "confidence": "medium",
+            "brokenSelector": "x",
+            "suggestedSelector": "y",
+            "explanation": "z",
+        }) + "\n```"
+        fix = self_healing._parse_ai_response(text, "x")
+        self.assertIsNotNone(fix)
+
+    def test_returns_none_for_invalid_json(self):
+        self.assertIsNone(self_healing._parse_ai_response("not json", "x"))
+
+    def test_returns_none_for_invalid_confidence(self):
+        text = json.dumps({
+            "confidence": "extreme",
+            "brokenSelector": "x",
+            "suggestedSelector": "y",
+            "explanation": "z",
+        })
+        self.assertIsNone(self_healing._parse_ai_response(text, "x"))
+
+
+# ===================================================================
+# YAML-level guard verification (static analysis of workflow file)
+# ===================================================================
+
+
+@unittest.skipUnless(WORKFLOW_PATH.exists(), "self-healing.yml not yet created")
+class TestYamlGuards(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow_content = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_conclusion_check(self):
+        self.assertIn("conclusion == 'failure'", self.workflow_content)
+
+    def test_branch_guard(self):
+        self.assertIn("fix/self-healing-", self.workflow_content)
+        self.assertIn("startsWith", self.workflow_content)
+
+    def test_feature_flag(self):
+        self.assertIn("vars.SELF_HEALING", self.workflow_content)
+
+    def test_concurrency_group(self):
+        self.assertIn("concurrency:", self.workflow_content)
+        self.assertIn("cancel-in-progress: false", self.workflow_content)
+
+    def test_timeout(self):
+        self.assertIn("timeout-minutes:", self.workflow_content)
+
+    def test_repo_check(self):
+        self.assertIn("github.repository", self.workflow_content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #176

Adds a self-healing GitHub Actions workflow that automatically detects selector/locator failures in Playwright CI runs and proposes fixes by either commenting on the originating PR or creating a draft PR. Reuses pre-computed `selector-fix.md` attachments from `diagnosis.util.ts` when `AI_DIAGNOSIS` is enabled (saves API tokens), with a fallback path that calls Anthropic or Gemini directly via `urllib.request`.

The implementation is a Python stdlib-only script (`scripts/self-healing.py`) following the same pattern as `scripts/generate-quality-metrics.py`.

### Loop prevention — six independent layers

| # | Layer | What it prevents |
|---|-------|------------------|
| 1 | Branch name guard (`fix/self-healing-*`) | Self-healing PR fails → blocked |
| 2 | Existing PR approval gate | Draft PRs have no approval → tests don't auto-run |
| 3 | Max 2 comments per PR (HTML marker count) | Repeated failures don't flood comments |
| 4 | Draft PR dedup (label check) | Duplicate draft PRs |
| 5 | Per-branch concurrency group | Parallel `workflow_run` events racing |
| 6 | `conclusion == 'failure'` check | Triggering on success/skipped/cancelled |

### AI fallback optimization (Scenario 4)

When `AI_DIAGNOSIS` is disabled and the fallback path calls the AI directly, the prompt now uses Playwright's built-in `error-context.md` (accessibility tree + test source) instead of raw `dom.xhtml`. Benchmarked across 5 runs × 2 providers:

| Metric | DOM only (S1) | error-context only (S4) |
|---|---|---|
| Anthropic input tokens | 6,136 | **4,674 (-24%)** |
| Anthropic avg latency | 6.24s | **4.22s** |
| Gemini reliability | 3/5 | 3/5 |
| Correct fixes | 100% | 100% |

The `# Instructions` section is stripped from `error-context.md` to prevent it from overriding the system prompt. The JSON parser was hardened to handle AI responses that include prose before the fenced JSON block. No-op fixes (AI suggests the same selector) are filtered out.

### Files

| File | Change |
|---|---|
| `.github/workflows/self-healing.yml` | New — `workflow_run` trigger, all six guards in the job-level `if` |
| `.github/workflows/playwright-typescript.yml` | Uploads `selector-fix.md` / `dom.xhtml` / `error-context.md` / `results.json` as `self-healing-data-<id>` artifact on failure |
| `scripts/self-healing.py` | New — main script (stdlib only, 58 tests) |
| `scripts/test_self_healing.py` | New — 58 unit tests covering all loop scenarios, classification, parsing, dedup, YAML guards |
| `.vars.example`, `README.md` | Documentation for `SELF_HEALING` variable |

## Test plan

- [x] All 58 unit tests pass (`python3 scripts/test_self_healing.py`)
- [x] Branch guard blocks `fix/self-healing-*` (6 tests)
- [x] Selector error classification matches `diagnosis.util.ts` regex (7 tests)
- [x] `selector-fix.md` parsing extracts all fields and rejects malformed input (5 tests)
- [x] Confidence filter keeps medium/high, drops low (4 tests)
- [x] Multi-browser dedup + no-op fix filtering (4 tests)
- [x] Max attempts blocks after 2 comments (4 tests)
- [x] Draft PR dedup blocks when open `self-healing` PR exists (2 tests)
- [x] AI response parser handles bare JSON, fenced JSON, and JSON-after-prose (5 tests)
- [x] error-context.md replaces dom.xhtml in prompt; Instructions section stripped; graceful fallback when missing (2 tests)
- [x] YAML guard tests verify `self-healing.yml` contains all 6 safety checks (6 tests)
- [x] Playwright config still parses (96 smoke tests listed across 5 browsers)
- [x] Prettier + TypeScript compilation pass
- [x] Benchmark: Scenario 4 produces correct fixes with 24% fewer tokens (5 runs, both providers)
- [ ] CI smoke test: enable `SELF_HEALING=true`, break a selector, observe self-healing comment
- [ ] CI loop test: push to `fix/self-healing-test`, force failure, verify no self-healing trigger
