### PR TITLE
#203 Fix multi-line chained selector matching in draft PR path

### DIFF
--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -573,6 +573,14 @@ def post_comment(pr_number: int, body: str, *, dry_run: bool = False) -> None:
     print(f"[self-healing] Posted comment on PR #{pr_number}")
 
 
+_PW_METHODS = (
+    "locator", "getByRole", "getByText", "getByLabel", "getByTestId",
+    "getByPlaceholder", "getByAltText", "getByTitle", "filter", "nth",
+    "first", "last",
+)
+_PW_SPLIT_PATTERN = r"\.(?=" + "|".join(_PW_METHODS) + r")"
+
+
 def _apply_selector_fix(content: str, fix: SelectorFix) -> str | None:
     """Replace a broken selector in source code, handling multi-line chains.
 
@@ -587,12 +595,7 @@ def _apply_selector_fix(content: str, fix: SelectorFix) -> str | None:
 
     # Split on dots before known Playwright method names (not arbitrary alpha
     # chars, which would break on dots inside string args like 'example.com').
-    _PW_METHODS = (
-        "locator", "getByRole", "getByText", "getByLabel", "getByTestId",
-        "getByPlaceholder", "getByAltText", "getByTitle", "filter", "nth",
-        "first", "last",
-    )
-    split_pattern = r"\.(?=" + "|".join(_PW_METHODS) + r")"
+    split_pattern = _PW_SPLIT_PATTERN
     parts = re.split(split_pattern, fix.broken_selector)
     if len(parts) < 2:
         return None

--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -573,6 +573,36 @@ def post_comment(pr_number: int, body: str, *, dry_run: bool = False) -> None:
     print(f"[self-healing] Posted comment on PR #{pr_number}")
 
 
+def _apply_selector_fix(content: str, fix: SelectorFix) -> str | None:
+    """Replace a broken selector in source code, handling multi-line chains.
+
+    Playwright chained calls like ``locator('#x').getByRole(...)`` appear on
+    separate lines in source but as a single line in error messages.  When a
+    direct ``str.replace`` misses, we build a regex that allows optional
+    whitespace and dot-chaining between method calls.
+    """
+    # Fast path: exact substring match
+    if fix.broken_selector in content:
+        return content.replace(fix.broken_selector, fix.suggested_selector, 1)
+
+    # Split on dots before known Playwright method names (not arbitrary alpha
+    # chars, which would break on dots inside string args like 'example.com').
+    _PW_METHODS = (
+        "locator", "getByRole", "getByText", "getByLabel", "getByTestId",
+        "getByPlaceholder", "getByAltText", "getByTitle", "filter", "nth",
+        "first", "last",
+    )
+    split_pattern = r"\.(?=" + "|".join(_PW_METHODS) + r")"
+    parts = re.split(split_pattern, fix.broken_selector)
+    if len(parts) < 2:
+        return None
+    pattern = r"\s*\.?\s*".join(re.escape(p) for p in parts)
+    m = re.search(pattern, content)
+    if not m:
+        return None
+    return content[: m.start()] + fix.suggested_selector + content[m.end() :]
+
+
 def create_draft_pr(
     fixes: list[SelectorFix],
     head_sha: str,
@@ -609,10 +639,8 @@ def create_draft_pr(
     for fix in fixes:
         for ts_file in pw_dir.rglob("*.spec.ts"):
             content = ts_file.read_text(encoding="utf-8")
-            if fix.broken_selector in content:
-                new_content = content.replace(
-                    fix.broken_selector, fix.suggested_selector, 1
-                )
+            new_content = _apply_selector_fix(content, fix)
+            if new_content and new_content != content:
                 ts_file.write_text(new_content, encoding="utf-8")
                 git_run("git", "add", str(ts_file))
                 applied += 1

--- a/scripts/test_self_healing.py
+++ b/scripts/test_self_healing.py
@@ -554,6 +554,183 @@ class TestComposeComment(unittest.TestCase):
 # ===================================================================
 # Dry run
 # ===================================================================
+# Apply selector fix (multi-line matching)
+# ===================================================================
+
+
+class TestApplySelectorFix(unittest.TestCase):
+    MULTILINE_SOURCE = textwrap.dedent("""\
+        test('home page', async ({ page }) => {
+          await page
+            .locator('#menubar')
+            .getByRole('link', { name: 'Strona glowna', exact: true })
+            .click();
+        });""")
+
+    SINGLE_LINE_SOURCE = textwrap.dedent("""\
+        test('about', async ({ page }) => {
+          await page.locator('#menubar').getByRole('link', { name: 'O systemie', exact: true }).click();
+        });""")
+
+    def test_exact_match_single_line(self):
+        fix = self_healing.SelectorFix(
+            "high",
+            "locator('#menubar').getByRole('link', { name: 'O systemie', exact: true })",
+            "locator('#menubar').getByRole('link', { name: 'About', exact: true })",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(self.SINGLE_LINE_SOURCE, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("About", result)
+        self.assertNotIn("O systemie", result)
+
+    def test_multiline_chained_selector(self):
+        fix = self_healing.SelectorFix(
+            "high",
+            "locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })",
+            "locator('#menubar').getByRole('link', { name: 'Strona główna', exact: true })",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(self.MULTILINE_SOURCE, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("Strona główna", result)
+        self.assertNotIn("Strona glowna", result)
+
+    def test_multiline_shorter_replacement(self):
+        """Gemini-style fix: drops locator('#menubar') scoping entirely."""
+        fix = self_healing.SelectorFix(
+            "high",
+            "locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })",
+            "getByRole('link', { name: 'Strona główna', exact: true })",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(self.MULTILINE_SOURCE, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("Strona główna", result)
+        self.assertNotIn("locator('#menubar')", result)
+        # The leading dot should chain page to getByRole
+        self.assertIn(".getByRole", result)
+        self.assertIn(".click()", result)
+
+    def test_three_part_chain_multiline(self):
+        """Three-part chain: locator.getByRole.getByText across three lines."""
+        source = textwrap.dedent("""\
+            await page
+              .locator('#sidebar')
+              .getByRole('listitem')
+              .getByText('Home')""")
+        fix = self_healing.SelectorFix(
+            "high",
+            "locator('#sidebar').getByRole('listitem').getByText('Home')",
+            "locator('#sidebar').getByRole('listitem').getByText('Dashboard')",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(source, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("Dashboard", result)
+        self.assertNotIn("Home", result)
+
+    def test_filter_chain_multiline(self):
+        """Chain with .filter() across multiple lines."""
+        source = textwrap.dedent("""\
+            await page
+              .getByRole('listitem')
+              .filter({ hasText: 'Active' })
+              .getByRole('link')""")
+        fix = self_healing.SelectorFix(
+            "high",
+            "getByRole('listitem').filter({ hasText: 'Active' }).getByRole('link')",
+            "getByRole('listitem').filter({ hasText: 'Enabled' }).getByRole('link')",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(source, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("Enabled", result)
+        self.assertNotIn("Active", result)
+
+    def test_nth_chain_multiline(self):
+        """Chain with .nth() across lines."""
+        source = textwrap.dedent("""\
+            await page
+              .getByRole('link')
+              .nth(0)""")
+        fix = self_healing.SelectorFix(
+            "high",
+            "getByRole('link').nth(0)",
+            "getByRole('link').nth(1)",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(source, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("nth(1)", result)
+
+    def test_dot_in_string_arg_not_split(self):
+        """Dots inside string arguments (e.g. 'example.com') must not be split."""
+        source = "  await page.getByRole('link', { name: 'example.com' }).click();"
+        fix = self_healing.SelectorFix(
+            "high",
+            "getByRole('link', { name: 'example.com' })",
+            "getByRole('link', { name: 'example.org' })",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(source, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("example.org", result)
+
+    def test_dot_in_string_arg_multiline_fallback(self):
+        """Dot in arg + multi-line chain: split must not break on string dots."""
+        source = textwrap.dedent("""\
+            await page
+              .locator('#nav')
+              .getByRole('link', { name: 'example.com' })""")
+        fix = self_healing.SelectorFix(
+            "high",
+            "locator('#nav').getByRole('link', { name: 'example.com' })",
+            "locator('#nav').getByRole('link', { name: 'example.org' })",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(source, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("example.org", result)
+
+    def test_getbytext_with_version_dot(self):
+        """getByText('v2.0') — dot followed by digit, not a method name."""
+        source = "  await page.getByText('v2.0').click();"
+        fix = self_healing.SelectorFix(
+            "high",
+            "getByText('v2.0')",
+            "getByText('v3.0')",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(source, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("v3.0", result)
+
+    def test_no_match_returns_none(self):
+        fix = self_healing.SelectorFix(
+            "high",
+            "getByRole('button', { name: 'nonexistent' })",
+            "getByRole('button', { name: 'fixed' })",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(self.MULTILINE_SOURCE, fix)
+        self.assertIsNone(result)
+
+    def test_single_part_selector_no_chain(self):
+        """Single method call — no dot splitting needed."""
+        source = "  await page.getByRole('link', { name: 'foo' }).click();"
+        fix = self_healing.SelectorFix(
+            "high",
+            "getByRole('link', { name: 'foo' })",
+            "getByRole('link', { name: 'bar' })",
+            "reason",
+        )
+        result = self_healing._apply_selector_fix(source, fix)
+        self.assertIsNotNone(result)
+        self.assertIn("bar", result)
+
+
+# ===================================================================
 
 
 class TestDryRun(unittest.TestCase):


### PR DESCRIPTION
## Summary

Closes #203

The draft PR path in `create_draft_pr` used `str.replace()` to apply selector fixes, which requires an exact substring match. Playwright chained selectors span multiple lines in source (`.locator('#menubar')\n  .getByRole(...)`) but appear as a single line in error messages and `selector-fix.md`. The replacement silently no-oped, logging "No fixes could be applied to source files."

Adds `_apply_selector_fix()` with a two-step approach:
1. **Fast path:** exact `str.replace` (single-line selectors)
2. **Fallback:** split the broken selector on dots before known Playwright method names (`locator`, `getByRole`, `filter`, `nth`, etc.), build a regex allowing whitespace between parts, and `re.search` the source

The split uses a whitelist of Playwright methods (not arbitrary alpha chars) to avoid breaking on dots inside string arguments like `'example.com'`.

## Test plan

- [x] 70/70 unit tests pass
- [x] `test_exact_match_single_line` — single-line selector (fast path)
- [x] `test_multiline_chained_selector` — 2-part chain across lines (Anthropic-style)
- [x] `test_multiline_shorter_replacement` — shorter fix drops scoping (Gemini-style)
- [x] `test_three_part_chain_multiline` — 3-part chain across lines
- [x] `test_filter_chain_multiline` — `.filter()` chain
- [x] `test_nth_chain_multiline` — `.nth()` chain
- [x] `test_dot_in_string_arg_not_split` — `'example.com'` not split (exact match)
- [x] `test_dot_in_string_arg_multiline_fallback` — `'example.com'` + multi-line chain
- [x] `test_getbytext_with_version_dot` — `'v2.0'` not split (digit after dot)
- [ ] CI smoke test: trigger draft PR creation on a branch with no open PR, verify fix is applied
