### PR TITLE
#203 Checkout default branch so self-healing script is always up to date

### DIFF
--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -32,6 +32,9 @@ jobs:
           # Checkout the default branch to get the latest self-healing script.
           # The script creates its own branch from HEAD_SHA for applying fixes.
           fetch-depth: 0
+      - name: Fetch failing branch
+        run: git fetch origin ${{ github.event.workflow_run.head_sha }}
+        # head_sha may live on a non-merged branch that fetch-depth: 0 didn't cover.
 
       - name: Download self-healing data
         uses: actions/download-artifact@v8

--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -29,8 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          # Fetch full history so we can create and push a new branch from head_sha.
+          # Checkout the default branch to get the latest self-healing script.
+          # The script creates its own branch from HEAD_SHA for applying fixes.
           fetch-depth: 0
 
       - name: Download self-healing data

--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -33,7 +33,7 @@ jobs:
           # The script creates its own branch from HEAD_SHA for applying fixes.
           fetch-depth: 0
       - name: Fetch failing branch
-        run: git fetch origin ${{ github.event.workflow_run.head_sha }}
+        run: git fetch origin ${{ github.event.workflow_run.head_branch }}
         # head_sha may live on a non-merged branch that fetch-depth: 0 didn't cover.
 
       - name: Download self-healing data


### PR DESCRIPTION
## Summary

Follow-up to #203. The workflow checked out `head_sha` (the failing branch's commit), which meant `self-healing.py` ran from that old commit — not the latest version on main. For branches that predate the self-healing code, the script wouldn't even exist.

Fix: remove the `ref:` parameter so `actions/checkout` uses the default branch. The script already calls `git checkout -b fix/self-healing-<sha> <head_sha>` internally when creating draft PRs, so the failing commit's code is still accessible for applying fixes. `fetch-depth: 0` ensures full history is available.

## Test plan

- [x] 70/70 unit tests pass
- [x] Comment path: reads from `self-healing-data/` artifacts, never touches repo files — unaffected
- [x] Draft PR path: `git checkout -b` in the script switches to head_sha before reading test files — correct behavior preserved
- [x] `self-healing-data/` is untracked — survives `git checkout` in the script
- [ ] CI smoke test: re-trigger on `test/self-healing-smoke` after merge, verify draft PR is created
