### PR TITLE
#203 Log gh stderr on failure and retry gh pr create

### DIFF
--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -449,13 +449,21 @@ def request_selector_fix_from_ai(
 
 
 def gh(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
-    """Run a gh CLI command and return the result."""
-    return subprocess.run(
+    """Run a gh CLI command and return the result.
+
+    When *check* is True and the command fails, stderr is printed before
+    re-raising so the CI log always shows why.
+    """
+    result = subprocess.run(
         ["gh", *args],
         capture_output=True,
         text=True,
-        check=check,
     )
+    if check and result.returncode != 0:
+        print(f"[self-healing] gh {args[0]} failed (exit {result.returncode}): "
+              f"{result.stderr.strip()}", file=sys.stderr)
+        result.check_returncode()
+    return result
 
 
 def find_pr_for_branch(branch: str) -> int | None:
@@ -661,7 +669,7 @@ def create_draft_pr(
 
     body_file = Path("/tmp/self-healing-pr-body.md")
     body_file.write_text(comment_body, encoding="utf-8")
-    gh(
+    pr_args = (
         "pr", "create",
         "--draft",
         "--title", f"fix: self-healing selector repair ({short_sha})",
@@ -670,6 +678,13 @@ def create_draft_pr(
         "--head", fix_branch,
         "--base", _default_branch(),
     )
+    result = gh(*pr_args, check=False)
+    if result.returncode != 0:
+        import time
+        print(f"[self-healing] gh pr create failed, retrying in 5s: {result.stderr.strip()}",
+              file=sys.stderr)
+        time.sleep(5)
+        gh(*pr_args)  # check=True — fail loudly on second attempt
     print(f"[self-healing] Created draft PR on branch {fix_branch}")
 
 


### PR DESCRIPTION
## Summary

Follow-up to #203. The `gh pr create` call in the draft PR path failed in CI with a transient API error, but the error was invisible because `gh()` used `capture_output=True` with `check=True` — stderr was swallowed.

Two fixes:
1. **`gh()` now logs stderr before re-raising** — every `gh` call failure will show the actual error message in CI logs
2. **`gh pr create` retries once after 5s** — handles transient GitHub API errors that are common in `workflow_run` contexts

## Test plan

- [x] 70/70 unit tests pass
- [x] `gh()` with `check=True`: prints stderr, then raises `CalledProcessError`
- [x] `gh()` with `check=False`: returns result without printing (unchanged)
- [x] Retry: if first `gh pr create` fails, error is logged, waits 5s, retries with `check=True`
- [x] No duplicate PR risk: `gh pr create` rejects if a PR for the head branch already exists
- [ ] CI: re-trigger draft PR test on `test/self-healing-smoke` after merge
