### PR TITLE
#211 Add blob-report/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bruno/environments/.env
 bruno/test-results/
 playwright/typescript/data/
 playwright/typescript/index.html
+playwright/typescript/blob-report/
 playwright/typescript/playwright-report-ci/
 playwright/typescript/trace/
 test-results/


### PR DESCRIPTION
## Summary

Adds `playwright/typescript/blob-report/` to the root `.gitignore`.

The `['blob']` reporter is unconditionally enabled in `playwright/typescript/playwright.config.ts:31`, so running tests locally writes to `playwright/typescript/blob-report/`. Without this gitignore entry the directory appears as untracked and could be accidentally committed with `git add -A`.

Closes #211.

## Test plan

- [x] Added entry to root `.gitignore` adjacent to existing Playwright entries
- [x] Verified `git status` does not show `playwright/typescript/blob-report/` as untracked after creating a test directory
- [x] Reviewer confirms the entry remains in place and no blob-report directory appears in PR diff
