### PR TITLE
#200 Remove CLAUDE_DIAGNOSIS fallback and add AI_MODEL_FAST/AI_MODEL_STRONG overrides

### DIFF
--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -144,7 +144,8 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           AI_PROVIDER: ${{ vars.AI_PROVIDER }}
           AI_DIAGNOSIS: ${{ vars.AI_DIAGNOSIS }}
-          CLAUDE_DIAGNOSIS: ${{ vars.CLAUDE_DIAGNOSIS }}
+          AI_MODEL_FAST: ${{ vars.AI_MODEL_FAST }}
+          AI_MODEL_STRONG: ${{ vars.AI_MODEL_STRONG }}
       - name: Upload updated baselines
         if: ${{ github.event.inputs.update_visual_baselines == 'true' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -53,6 +53,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           AI_PROVIDER: ${{ vars.AI_PROVIDER }}
+          AI_MODEL_STRONG: ${{ vars.AI_MODEL_STRONG }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.vars.example
+++ b/.vars.example
@@ -10,8 +10,12 @@ QUALITY_METRICS=
 AI_DIAGNOSIS=
 # AI provider for test failure diagnosis. Accepted values: anthropic (default), gemini.
 AI_PROVIDER=
-# Deprecated: still works as a fallback for AI_DIAGNOSIS. Prefer AI_DIAGNOSIS above.
-CLAUDE_DIAGNOSIS=
+# Override the fast-tier model used for diagnosis. Leave empty to use the provider default.
+# Defaults: anthropic -> claude-haiku-4-5, gemini -> gemini-3.1-flash-lite-preview.
+AI_MODEL_FAST=
+# Override the strong-tier model used for selector-fix proposals. Leave empty to use the provider default.
+# Defaults: anthropic -> claude-sonnet-4-6, gemini -> gemini-3.1-flash-lite-preview.
+AI_MODEL_STRONG=
 # Self-healing selector fix workflow. Set to "true" to enable automatic draft PRs / PR comments
 # when Playwright tests fail due to locator/selector errors. Uses the same AI_PROVIDER setting
 # and API key (ANTHROPIC_API_KEY or GEMINI_API_KEY) as AI_DIAGNOSIS for the fallback path

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Four project-scoped skills are available in Claude Code (stored in `.claude/skil
 .env                        # credentials (git-ignored); see .env.example
 .env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, GEMINI_API_KEY
 .vars                       # CI repository variables (git-ignored); see .vars.example
-.vars.example               # template: CLAUDE_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, AI_DIAGNOSIS, AI_PROVIDER, CLAUDE_DIAGNOSIS, SELF_HEALING
+.vars.example               # template: CLAUDE_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, AI_DIAGNOSIS, AI_PROVIDER, AI_MODEL_FAST, AI_MODEL_STRONG, SELF_HEALING
 .mcp.json                   # MCP server definitions (MCP_DOCKER, playwright, playwright-report-mcp) — loaded by Claude Code and other MCP-compatible AI assistants
 .github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
@@ -74,7 +74,8 @@ The following variables are set in **GitHub → Settings → Variables → Actio
 | ----------------------- | -------------------------------------------- | -------------------------------------------------------------------------- |
 | `AI_DIAGNOSIS`          | AI-powered test failure diagnosis attachment | Every Playwright run (local and CI)                                        |
 | `AI_PROVIDER`           | AI provider for diagnosis (`anthropic` or `gemini`; default: `anthropic`) | Every Playwright run (local and CI)           |
-| `CLAUDE_DIAGNOSIS`      | Deprecated alias for `AI_DIAGNOSIS` (still works as fallback) | Every Playwright run (local and CI)                          |
+| `AI_MODEL_FAST`         | Override fast-tier model (diagnosis); empty = provider default            | Every Playwright run (local and CI)           |
+| `AI_MODEL_STRONG`       | Override strong-tier model (selector fix); empty = provider default       | Every Playwright run (local and CI)           |
 | `CLAUDE_REVIEW`         | `claude-code-review.yml`                     | PR events (opened, synchronize, ready_for_review, reopened)                |
 | `PLAYWRIGHT_TYPESCRIPT` | `playwright-typescript.yml`                  | PR events, push to main, Sunday 03:00 UTC schedule, `workflow_dispatch`    |
 | `BRUNO`                 | `bruno.yml`                                  | PR events, push to main, `workflow_dispatch`                               |
@@ -324,7 +325,7 @@ Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tes
 - `utils/string.util.ts` — `expectHeadings()` helper: asserts visibility of multiple headings on a page
 - `utils/validation.util.ts` — `expectValidXhtml(request, xhtml)` POSTs raw markup to the classic W3C Markup Validation Service (`validator.w3.org/check`) and asserts no errors (correct for XHTML 1.0 Strict; Nu is HTML5-only and gives false positives); `expectValidCss(request, cssUrl)` queries W3C CSS validator by URI and asserts zero errors
 - `utils/env.util.ts` — `loadEnv(importMetaUrl, levelsUp)` loads `.env` relative to the calling file; `requireCredentials()` validates and returns `ORWELLSTAT_USER`/`ORWELLSTAT_PASSWORD`, throwing a descriptive error if either is missing
-- `utils/diagnosis.util.ts` — `attachAiDiagnosis(testInfo, logs, domContent)`: calls the configured AI provider (Anthropic or Gemini, selected by `AI_PROVIDER`) to produce a diagnosis and optional selector-fix attachment on test failure; no-ops when `AI_DIAGNOSIS=true` is absent or the provider's API key is missing; errors are caught and warned so diagnosis never fails a test
+- `utils/diagnosis.util.ts` — `attachAiDiagnosis(testInfo, logs, domContent)`: calls the configured AI provider (Anthropic or Gemini, selected by `AI_PROVIDER`) to produce a diagnosis and optional selector-fix attachment on test failure; model names default to a per-provider map but can be overridden via `AI_MODEL_FAST` (diagnosis) and `AI_MODEL_STRONG` (selector fix); no-ops when `AI_DIAGNOSIS=true` is absent or the provider's API key is missing; errors are caught and warned so diagnosis never fails a test
 - `types/` — Shared TypeScript interfaces; exported via path alias `@types-local/*`
   - `svg-analysis.ts` — `SvgAnalysis` interface: shape of the object returned by `page.evaluate()` in `statistics.spec.ts`
   - `statistics-row.ts` — `StatisticsRow` interface: shape of each data row returned by the bulk `page.evaluate()` in `statistics.spec.ts`

--- a/playwright/typescript/utils/diagnosis.util.ts
+++ b/playwright/typescript/utils/diagnosis.util.ts
@@ -231,8 +231,8 @@ export async function attachAiDiagnosis(
   try {
     const complete = await PROVIDER_FACTORY[provider](apiKey);
     const models = {
-      fast: process.env.AI_MODEL_FAST ?? MODEL_MAP[provider].fast,
-      strong: process.env.AI_MODEL_STRONG ?? MODEL_MAP[provider].strong,
+      fast: process.env.AI_MODEL_FAST || MODEL_MAP[provider].fast,
+      strong: process.env.AI_MODEL_STRONG || MODEL_MAP[provider].strong,
     };
 
     const domSnippet =

--- a/playwright/typescript/utils/diagnosis.util.ts
+++ b/playwright/typescript/utils/diagnosis.util.ts
@@ -32,6 +32,11 @@ const MODEL_MAP = {
 
 type AiProvider = keyof typeof MODEL_MAP;
 
+interface Models {
+  fast: string;
+  strong: string;
+}
+
 function isAiProvider(value: string): value is AiProvider {
   return value in MODEL_MAP;
 }
@@ -84,7 +89,7 @@ function extractBrokenSelector(errorMessages: string): string | null {
 
 async function requestDiagnosis(
   complete: AiCompletionFn,
-  models: (typeof MODEL_MAP)[AiProvider],
+  models: Models,
   testInfo: TestInfo,
   logs: string[],
   errorMessages: string,
@@ -112,7 +117,7 @@ async function requestDiagnosis(
 
 async function requestSelectorFix(
   complete: AiCompletionFn,
-  models: (typeof MODEL_MAP)[AiProvider],
+  models: Models,
   brokenSelector: string,
   errorMessages: string,
   domSnippet: string
@@ -171,7 +176,7 @@ Confidence guidelines:
 
 async function attachSelectorFix(
   complete: AiCompletionFn,
-  models: (typeof MODEL_MAP)[AiProvider],
+  models: Models,
   testInfo: TestInfo,
   errorMessages: string,
   domSnippet: string
@@ -212,9 +217,7 @@ export async function attachAiDiagnosis(
   logs: string[],
   domContent: string
 ): Promise<void> {
-  const diagnosisEnabled =
-    process.env.AI_DIAGNOSIS === 'true' || process.env.CLAUDE_DIAGNOSIS === 'true';
-  if (!diagnosisEnabled) return;
+  if (process.env.AI_DIAGNOSIS !== 'true') return;
 
   const provider = process.env.AI_PROVIDER ?? 'anthropic';
   if (!isAiProvider(provider)) {
@@ -227,7 +230,10 @@ export async function attachAiDiagnosis(
 
   try {
     const complete = await PROVIDER_FACTORY[provider](apiKey);
-    const models = MODEL_MAP[provider];
+    const models = {
+      fast: process.env.AI_MODEL_FAST ?? MODEL_MAP[provider].fast,
+      strong: process.env.AI_MODEL_STRONG ?? MODEL_MAP[provider].strong,
+    };
 
     const domSnippet =
       domContent.length > DOM_TRUNCATE_CHARS

--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -317,7 +317,6 @@ def _call_anthropic(api_key: str, user_content: str) -> str | None:
 
 def _call_gemini(api_key: str, user_content: str) -> str | None:
     # Same model as diagnosis.util.ts — chosen for its free-tier RPD quota (500 vs 20).
-    # Model override env vars are planned in #200 (AI_MODEL_FAST / AI_MODEL_STRONG).
     model = "gemini-3.1-flash-lite-preview"
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     body = json.dumps({

--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -18,6 +18,7 @@ Environment variables:
     ANTHROPIC_API_KEY — Anthropic API key (fallback path)
     GEMINI_API_KEY    — Gemini API key (fallback path)
     AI_PROVIDER       — "anthropic" (default) or "gemini"
+    AI_MODEL_STRONG   — override the selector-fix model (strong tier); defaults match diagnosis.util.ts
     DRY_RUN           — set to "true" to print actions without executing
 """
 
@@ -289,8 +290,9 @@ def _extract_broken_selector(error_message: str) -> str | None:
 
 
 def _call_anthropic(api_key: str, user_content: str) -> str | None:
+    model = os.environ.get("AI_MODEL_STRONG") or "claude-sonnet-4-6"
     body = json.dumps({
-        "model": "claude-sonnet-4-6",
+        "model": model,
         "max_tokens": 1024,
         "system": _SELECTOR_FIX_SYSTEM_PROMPT,
         "messages": [{"role": "user", "content": user_content}],
@@ -316,8 +318,8 @@ def _call_anthropic(api_key: str, user_content: str) -> str | None:
 
 
 def _call_gemini(api_key: str, user_content: str) -> str | None:
-    # Same model as diagnosis.util.ts — chosen for its free-tier RPD quota (500 vs 20).
-    model = "gemini-3.1-flash-lite-preview"
+    # Default matches diagnosis.util.ts — chosen for its free-tier RPD quota (500 vs 20).
+    model = os.environ.get("AI_MODEL_STRONG") or "gemini-3.1-flash-lite-preview"
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     body = json.dumps({
         "systemInstruction": {"parts": [{"text": _SELECTOR_FIX_SYSTEM_PROMPT}]},


### PR DESCRIPTION
## Summary

- Remove the deprecated `CLAUDE_DIAGNOSIS` env-var fallback for `AI_DIAGNOSIS` (migration window from #198 is over).
- Add `AI_MODEL_FAST` and `AI_MODEL_STRONG` env vars that override the hardcoded per-provider model names in `MODEL_MAP`, so testers can swap models without editing source.
- Keep the existing defaults (`claude-haiku-4-5` / `claude-sonnet-4-6`, `gemini-3.1-flash-lite-preview`) when the overrides are unset or empty.
- Update `.vars.example`, the Playwright CI workflow, and `README.md` to match.

Closes #200

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run format:check` passes
- [x] Scenario 1 (full override): both env vars set → passed to provider as `model` (verified by reading the fallback at `diagnosis.util.ts:233-236`)
- [x] Scenario 2 (no override): defaults apply — `||` falls back on both `undefined` and empty string (the GitHub Actions shape when the repo variable is unset)
- [x] Scenario 3 (partial): only `AI_MODEL_STRONG` set → strong overridden, fast defaults (independent `||` per tier)
- [x] Scenario 4: `CLAUDE_DIAGNOSIS=true` alone → diagnosis NOT enabled (guard at `diagnosis.util.ts:220` checks only `AI_DIAGNOSIS`)
- [x] `.vars.example` documents `AI_MODEL_FAST` / `AI_MODEL_STRONG` with default model names in comments; `CLAUDE_DIAGNOSIS` removed
- [x] CI workflow (`playwright-typescript.yml`) passes both new vars into the test step; `CLAUDE_DIAGNOSIS` removed
- [x] `README.md` structure listing, CI variables table, and `utils/diagnosis.util.ts` description all reference the new vars
- [x] Live end-to-end smoke: run a failing test locally with `AI_DIAGNOSIS=true`, `AI_PROVIDER=gemini`, `AI_MODEL_STRONG=gemini-2.5-flash`, confirm the resulting `diagnosis.md` / `selector-fix.md` attachments come from the override models (requires an API key; reviewer to verify) _(Verified 2026-04-15 against a throwaway failing spec with `AI_MODEL_FAST=gemini-2.5-flash-lite`, `AI_MODEL_STRONG=gemini-2.5-flash`: a temporary `console.log` inside `attachAiDiagnosis` printed `fast=gemini-2.5-flash-lite strong=gemini-2.5-flash` — confirming the overrides resolved — and Gemini returned a coherent `AI diagnosis` attachment. Log + spec reverted after.)_
- [x] CI: one full `playwright-typescript` matrix run on this branch with `AI_MODEL_FAST` / `AI_MODEL_STRONG` unset, to confirm Scenario 2 behavior on the actual runner (reviewer / CI to verify) _(PR #213's `test` matrix jobs concluded SUCCESS in `gh pr view 213 --json statusCheckRollup`.)_


