### PR TITLE
#217 Make PR reviewer provider-switchable (OpenRouter/Qwen default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,5 @@ BASIC_AUTH_PASSWORD=
 # Set AI_PROVIDER in .vars to choose which provider to use (default: anthropic).
 ANTHROPIC_API_KEY=
 GEMINI_API_KEY=
+# Required when AI_REVIEW_PROVIDER=openrouter. Get one at https://openrouter.ai/keys.
+OPENROUTER_API_KEY=

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   review:
-    if: github.actor != 'dependabot[bot]' && vars.CLAUDE_REVIEW == 'true'
+    if: github.actor != 'dependabot[bot]' && vars.AI_REVIEW == 'true'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:
@@ -21,9 +21,49 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Resolve reviewer provider settings
+        id: reviewer
+        env:
+          AI_REVIEW_PROVIDER: ${{ vars.AI_REVIEW_PROVIDER }}
+          AI_REVIEW_MODEL: ${{ vars.AI_REVIEW_MODEL }}
+          HAS_OPENROUTER_KEY: ${{ secrets.OPENROUTER_API_KEY != '' }}
+          HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: |
+          provider="${AI_REVIEW_PROVIDER:-openrouter}"
+          case "$provider" in
+            openrouter)
+              if [ "$HAS_OPENROUTER_KEY" != "true" ]; then
+                echo "::error::AI_REVIEW_PROVIDER=openrouter but OPENROUTER_API_KEY secret is not set"
+                exit 1
+              fi
+              default_model="qwen/qwen3.6-plus"
+              base_url="https://openrouter.ai/api/v1"
+              ;;
+            anthropic)
+              if [ "$HAS_ANTHROPIC_KEY" != "true" ]; then
+                echo "::error::AI_REVIEW_PROVIDER=anthropic but ANTHROPIC_API_KEY secret is not set"
+                exit 1
+              fi
+              default_model="claude-sonnet-4-6"
+              base_url=""
+              ;;
+            *)
+              echo "::error::Unknown AI_REVIEW_PROVIDER '$provider' (expected: openrouter | anthropic)"
+              exit 1
+              ;;
+          esac
+          model="${AI_REVIEW_MODEL:-$default_model}"
+          {
+            echo "provider=$provider"
+            echo "model=$model"
+            echo "base_url=$base_url"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ steps.reviewer.outputs.base_url }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ steps.reviewer.outputs.provider == 'openrouter' && secrets.OPENROUTER_API_KEY || secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
@@ -45,4 +85,4 @@ jobs:
             Only post GitHub review/comments - don't submit review text as messages.
 
           claude_args: |
-            --model claude-sonnet-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model ${{ steps.reviewer.outputs.model }} --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.vars.example
+++ b/.vars.example
@@ -2,7 +2,7 @@
 # In real GitHub Actions these are set under Settings → Variables → Actions.
 # Copy to .vars and set each variable to "true" to enable the corresponding workflow or feature.
 # When absent or any other value the workflow job or feature is skipped.
-CLAUDE_REVIEW=
+AI_REVIEW=
 PLAYWRIGHT_TYPESCRIPT=
 BRUNO=
 QUALITY_METRICS=
@@ -16,6 +16,13 @@ AI_MODEL_FAST=
 # Override the strong-tier model used for selector-fix proposals. Leave empty to use the provider default.
 # Defaults: anthropic -> claude-sonnet-4-6, gemini -> gemini-3.1-flash-lite-preview.
 AI_MODEL_STRONG=
+# Provider for the PR code review action (claude-code-review.yml).
+# Accepted values: openrouter (default), anthropic.
+# openrouter requires OPENROUTER_API_KEY secret; anthropic requires ANTHROPIC_API_KEY secret.
+AI_REVIEW_PROVIDER=
+# Override the model used by the PR reviewer. Leave empty to use the provider default.
+# Defaults: openrouter -> qwen/qwen3.6-plus, anthropic -> claude-sonnet-4-6.
+AI_REVIEW_MODEL=
 # Self-healing selector fix workflow. Set to "true" to enable automatic draft PRs / PR comments
 # when Playwright tests fail due to locator/selector errors. Uses the same AI_PROVIDER setting
 # and API key (ANTHROPIC_API_KEY or GEMINI_API_KEY) as AI_DIAGNOSIS for the fallback path

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Four project-scoped skills are available in Claude Code (stored in `.claude/skil
 
 ```
 .env                        # credentials (git-ignored); see .env.example
-.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, GEMINI_API_KEY
+.env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY
 .vars                       # CI repository variables (git-ignored); see .vars.example
-.vars.example               # template: CLAUDE_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, AI_DIAGNOSIS, AI_PROVIDER, AI_MODEL_FAST, AI_MODEL_STRONG, SELF_HEALING
+.vars.example               # template: AI_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, AI_DIAGNOSIS, AI_PROVIDER, AI_MODEL_FAST, AI_MODEL_STRONG, AI_REVIEW_PROVIDER, AI_REVIEW_MODEL, SELF_HEALING
 .mcp.json                   # MCP server definitions (MCP_DOCKER, playwright, playwright-report-mcp) — loaded by Claude Code and other MCP-compatible AI assistants
 .github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
@@ -62,9 +62,10 @@ BASIC_AUTH_USER=<staging basic auth user>
 BASIC_AUTH_PASSWORD=<staging basic auth password>
 ANTHROPIC_API_KEY=<Anthropic API key>
 GEMINI_API_KEY=<Gemini API key>
+OPENROUTER_API_KEY=<OpenRouter API key (required when AI_REVIEW_PROVIDER=openrouter)>
 ```
 
-`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` and `GEMINI_API_KEY` are optional — when the active provider's key is present alongside `AI_DIAGNOSIS=true` in `.vars`, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. Set `AI_PROVIDER` in `.vars` to choose the provider (`anthropic` by default, or `gemini`). In CI, secrets are injected as GitHub Actions secrets and variables via GitHub Actions variables. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env` and `../../.vars`).
+`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` and `GEMINI_API_KEY` are optional — when the active provider's key is present alongside `AI_DIAGNOSIS=true` in `.vars`, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. Set `AI_PROVIDER` in `.vars` to choose the provider (`anthropic` by default, or `gemini`). `OPENROUTER_API_KEY` is required when `AI_REVIEW_PROVIDER=openrouter` (the default for the PR reviewer); get one at https://openrouter.ai/keys. In CI, secrets are injected as GitHub Actions secrets and variables via GitHub Actions variables. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env` and `../../.vars`).
 
 ### CI repository variables
 
@@ -76,7 +77,9 @@ The following variables are set in **GitHub → Settings → Variables → Actio
 | `AI_PROVIDER`           | AI provider for diagnosis (`anthropic` or `gemini`; default: `anthropic`) | Every Playwright run (local and CI)           |
 | `AI_MODEL_FAST`         | Override fast-tier model (diagnosis); empty = provider default            | Every Playwright run (local and CI)           |
 | `AI_MODEL_STRONG`       | Override strong-tier model (selector fix); empty = provider default       | Every Playwright run (local and CI)           |
-| `CLAUDE_REVIEW`         | `claude-code-review.yml`                     | PR events (opened, synchronize, ready_for_review, reopened)                |
+| `AI_REVIEW_PROVIDER`    | Provider for PR reviewer (`openrouter` default or `anthropic`)            | PR events via `claude-code-review.yml`                                     |
+| `AI_REVIEW_MODEL`       | Override reviewer model; empty = provider default (openrouter: `qwen/qwen3.6-plus`, anthropic: `claude-sonnet-4-6`) | PR events via `claude-code-review.yml`                                     |
+| `AI_REVIEW`             | `claude-code-review.yml`                     | PR events (opened, synchronize, ready_for_review, reopened)                |
 | `PLAYWRIGHT_TYPESCRIPT` | `playwright-typescript.yml`                  | PR events, push to main, Sunday 03:00 UTC schedule, `workflow_dispatch`    |
 | `BRUNO`                 | `bruno.yml`                                  | PR events, push to main, `workflow_dispatch`                               |
 | `QUALITY_METRICS`       | `quality-metrics.yml`                        | 1st of every month 06:00 UTC schedule, `workflow_dispatch`                 |


### PR DESCRIPTION
## Summary

Closes #217. Replaces the hardcoded Claude Sonnet reviewer with a provider-switchable setup. Defaults to **Qwen3.6 Plus via OpenRouter** (Anthropic-compatible `/v1/messages` endpoint); flip `AI_REVIEW_PROVIDER=anthropic` in repo Variables to revert.

- New repo variables: `AI_REVIEW_PROVIDER` (`openrouter` default | `anthropic`), `AI_REVIEW_MODEL` (optional model override per provider).
- Renames the enable-gate `CLAUDE_REVIEW` → `AI_REVIEW` so the name is vendor-neutral.
- Resolver step in `claude-code-review.yml` validates that the required secret is non-empty before the action runs — prevents the Anthropic key from being sent to `openrouter.ai` if `OPENROUTER_API_KEY` is missing.
- New secret requirement: `OPENROUTER_API_KEY` (documented in `.env.example` and `README.md`).

## Changes

- `.vars.example` — rename `CLAUDE_REVIEW` → `AI_REVIEW`; add `AI_REVIEW_PROVIDER`, `AI_REVIEW_MODEL`.
- `.env.example` — add `OPENROUTER_API_KEY` placeholder.
- `.github/workflows/claude-code-review.yml` — resolver step branches on provider, sets `ANTHROPIC_BASE_URL`, picks the right secret, and passes the right `--model`.
- `README.md` — rename gate in catalog + table, add rows for the two new variables, document `OPENROUTER_API_KEY`.

## Rollout prerequisites (done before merge)

- `OPENROUTER_API_KEY` secret created
- `AI_REVIEW=true` repo variable created; `CLAUDE_REVIEW` deleted
- `AI_REVIEW_PROVIDER=openrouter` and `AI_REVIEW_MODEL=qwen/qwen3.6-plus` set

## Test plan

> **Design superseded by #220.** The `qwen/qwen3.6-plus` path failed pre-flight (Claude Code SDK client-side slug validation) on the first live run. Follow-up #220 / #221 / #222 replaced `AI_REVIEW_PROVIDER` + `AI_REVIEW_MODEL` with direct `ANTHROPIC_BASE_URL` + `ANTHROPIC_DEFAULT_{SONNET,HAIKU}_MODEL` pass-through. Most of this test plan is moot — the vars it references no longer exist.

- [x] This PR itself triggers `claude-code-review.yml` with the new defaults — confirm the `Resolve reviewer provider settings` step outputs `provider=openrouter`, `model=qwen/qwen3.6-plus`, `base_url=https://openrouter.ai/api/v1`
- [ ] ~~`anthropics/claude-code-action@v1` step completes without a 401/404~~ _(Failed pre-flight on run 24405785979; root cause addressed in #220/#221/#222.)_
- [ ] ~~A formal `gh pr review` verdict is posted on this PR by the Qwen-backed reviewer~~ _(Not on this PR. First Qwen verdict on PR #219 came after the #220/#221/#222/#224/#225 chain.)_
- [ ] ~~Temporarily flip `AI_REVIEW_PROVIDER=anthropic`, push a trivial commit, confirm `model=claude-sonnet-4-6`, `base_url=` (empty), review still works~~ _(Var removed by #220.)_
- [ ] ~~Temporarily set `AI_REVIEW_MODEL=qwen/qwen3-coder`, confirm resolver honors the override~~ _(Var removed by #220.)_
- [ ] ~~Restore production settings (`AI_REVIEW_PROVIDER=openrouter`, `AI_REVIEW_MODEL` empty or `qwen/qwen3.6-plus`)~~ _(Vars removed by #220.)_
- [x] `grep -rn CLAUDE_REVIEW` (excluding `.claude/worktrees/`) returns no hits

## Assumptions flagged for verification

1. `anthropics/claude-code-action@v1` forwards the `ANTHROPIC_BASE_URL` env var into the Claude Code runtime.
2. OpenRouter's `/v1/messages` endpoint accepts `qwen/qwen3.6-plus` (Anthropic-compatible routing).
3. Qwen via OpenRouter supports Anthropic-style tool use (required for `mcp__github_inline_comment__create_inline_comment` and `Bash(gh pr review:*)`).

If any of these fail during the Test plan checks, the fallback is a custom Python script (`scripts/pr-review.py`) following the `self-healing.py` dispatch pattern.

