### PR TITLE
#220 Fix PR reviewer — ANTHROPIC_DEFAULT_*_MODEL + Bearer auth via direct vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,6 @@ BASIC_AUTH_PASSWORD=
 # Set AI_PROVIDER in .vars to choose which provider to use (default: anthropic).
 ANTHROPIC_API_KEY=
 GEMINI_API_KEY=
-# Required when AI_REVIEW_PROVIDER=openrouter. Get one at https://openrouter.ai/keys.
+# Required when ANTHROPIC_BASE_URL points to OpenRouter (or any Anthropic-compat proxy).
+# Used as the Bearer auth token for the PR reviewer. Get one at https://openrouter.ai/keys.
 OPENROUTER_API_KEY=

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,49 +21,30 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Resolve reviewer provider settings
-        id: reviewer
+      - name: Validate reviewer configuration
         env:
-          AI_REVIEW_PROVIDER: ${{ vars.AI_REVIEW_PROVIDER }}
-          AI_REVIEW_MODEL: ${{ vars.AI_REVIEW_MODEL }}
-          HAS_OPENROUTER_KEY: ${{ secrets.OPENROUTER_API_KEY != '' }}
-          HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+          BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+          SONNET: ${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL }}
+          HAIKU: ${{ vars.ANTHROPIC_DEFAULT_HAIKU_MODEL }}
         run: |
-          provider="${AI_REVIEW_PROVIDER:-openrouter}"
-          case "$provider" in
-            openrouter)
-              if [ "$HAS_OPENROUTER_KEY" != "true" ]; then
-                echo "::error::AI_REVIEW_PROVIDER=openrouter but OPENROUTER_API_KEY secret is not set"
-                exit 1
-              fi
-              default_model="qwen/qwen3.6-plus"
-              base_url="https://openrouter.ai/api/v1"
-              ;;
-            anthropic)
-              if [ "$HAS_ANTHROPIC_KEY" != "true" ]; then
-                echo "::error::AI_REVIEW_PROVIDER=anthropic but ANTHROPIC_API_KEY secret is not set"
-                exit 1
-              fi
-              default_model="claude-sonnet-4-6"
-              base_url=""
-              ;;
-            *)
-              echo "::error::Unknown AI_REVIEW_PROVIDER '$provider' (expected: openrouter | anthropic)"
-              exit 1
-              ;;
-          esac
-          model="${AI_REVIEW_MODEL:-$default_model}"
-          {
-            echo "provider=$provider"
-            echo "model=$model"
-            echo "base_url=$base_url"
-          } >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_URL" ] && { [ -z "$SONNET" ] || [ -z "$HAIKU" ]; }; then
+            echo "::error::ANTHROPIC_BASE_URL is set, so both ANTHROPIC_DEFAULT_SONNET_MODEL and ANTHROPIC_DEFAULT_HAIKU_MODEL must also be set. Claude Code's defaults (claude-sonnet-4-6, claude-haiku-4-5) don't exist on proxies like OpenRouter."
+            exit 1
+          fi
 
+      # Auth convention: when ANTHROPIC_BASE_URL is set we're proxying through an
+      # Anthropic-compat provider (e.g. OpenRouter) which expects Bearer auth via
+      # ANTHROPIC_AUTH_TOKEN; when empty we use Anthropic's native API with x-api-key
+      # auth via the anthropic_api_key input. The two conditions below are inverse
+      # by design — exactly one path ever carries a credential.
       - uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_BASE_URL: ${{ steps.reviewer.outputs.base_url }}
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_AUTH_TOKEN: ${{ vars.ANTHROPIC_BASE_URL != '' && secrets.OPENROUTER_API_KEY || '' }}
+          ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL }}
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.ANTHROPIC_DEFAULT_HAIKU_MODEL }}
         with:
-          anthropic_api_key: ${{ steps.reviewer.outputs.provider == 'openrouter' && secrets.OPENROUTER_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ vars.ANTHROPIC_BASE_URL == '' && secrets.ANTHROPIC_API_KEY || '' }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
@@ -85,4 +66,4 @@ jobs:
             Only post GitHub review/comments - don't submit review text as messages.
 
           claude_args: |
-            --model ${{ steps.reviewer.outputs.model }} --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.vars.example
+++ b/.vars.example
@@ -16,13 +16,19 @@ AI_MODEL_FAST=
 # Override the strong-tier model used for selector-fix proposals. Leave empty to use the provider default.
 # Defaults: anthropic -> claude-sonnet-4-6, gemini -> gemini-3.1-flash-lite-preview.
 AI_MODEL_STRONG=
-# Provider for the PR code review action (claude-code-review.yml).
-# Accepted values: openrouter (default), anthropic.
-# openrouter requires OPENROUTER_API_KEY secret; anthropic requires ANTHROPIC_API_KEY secret.
-AI_REVIEW_PROVIDER=
-# Override the model used by the PR reviewer. Leave empty to use the provider default.
-# Defaults: openrouter -> qwen/qwen3.6-plus, anthropic -> claude-sonnet-4-6.
-AI_REVIEW_MODEL=
+# Base URL for the PR code review action (claude-code-review.yml).
+# Leave empty to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
+# Set to an Anthropic-compatible proxy like https://openrouter.ai/api/v1 to route through it
+# (requires OPENROUTER_API_KEY secret, Bearer auth). When set, both
+# ANTHROPIC_DEFAULT_SONNET_MODEL and ANTHROPIC_DEFAULT_HAIKU_MODEL must also be set.
+ANTHROPIC_BASE_URL=
+# Override the sonnet-tier model used by the PR reviewer. Required when ANTHROPIC_BASE_URL is set.
+# Leave empty to use Claude Code's default (claude-sonnet-4-6). Example: qwen/qwen3.6-plus.
+ANTHROPIC_DEFAULT_SONNET_MODEL=
+# Override the haiku-tier model used by the PR reviewer (Claude Code invokes Haiku internally
+# for summarization and quick calls). Required when ANTHROPIC_BASE_URL is set.
+# Leave empty to use Claude Code's default (claude-haiku-4-5). Example: qwen/qwen3.6-plus.
+ANTHROPIC_DEFAULT_HAIKU_MODEL=
 # Self-healing selector fix workflow. Set to "true" to enable automatic draft PRs / PR comments
 # when Playwright tests fail due to locator/selector errors. Uses the same AI_PROVIDER setting
 # and API key (ANTHROPIC_API_KEY or GEMINI_API_KEY) as AI_DIAGNOSIS for the fallback path

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Four project-scoped skills are available in Claude Code (stored in `.claude/skil
 .env                        # credentials (git-ignored); see .env.example
 .env.example                # template: ORWELLSTAT_USER, ORWELLSTAT_PASSWORD, ENV, BASIC_AUTH_USER, BASIC_AUTH_PASSWORD, ANTHROPIC_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY
 .vars                       # CI repository variables (git-ignored); see .vars.example
-.vars.example               # template: AI_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, AI_DIAGNOSIS, AI_PROVIDER, AI_MODEL_FAST, AI_MODEL_STRONG, AI_REVIEW_PROVIDER, AI_REVIEW_MODEL, SELF_HEALING
+.vars.example               # template: AI_REVIEW, PLAYWRIGHT_TYPESCRIPT, BRUNO, QUALITY_METRICS, AI_DIAGNOSIS, AI_PROVIDER, AI_MODEL_FAST, AI_MODEL_STRONG, ANTHROPIC_BASE_URL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_DEFAULT_HAIKU_MODEL, SELF_HEALING
 .mcp.json                   # MCP server definitions (MCP_DOCKER, playwright, playwright-report-mcp) — loaded by Claude Code and other MCP-compatible AI assistants
 .github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
@@ -62,10 +62,10 @@ BASIC_AUTH_USER=<staging basic auth user>
 BASIC_AUTH_PASSWORD=<staging basic auth password>
 ANTHROPIC_API_KEY=<Anthropic API key>
 GEMINI_API_KEY=<Gemini API key>
-OPENROUTER_API_KEY=<OpenRouter API key (required when AI_REVIEW_PROVIDER=openrouter)>
+OPENROUTER_API_KEY=<OpenRouter API key (required when ANTHROPIC_BASE_URL points to OpenRouter)>
 ```
 
-`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` and `GEMINI_API_KEY` are optional — when the active provider's key is present alongside `AI_DIAGNOSIS=true` in `.vars`, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. Set `AI_PROVIDER` in `.vars` to choose the provider (`anthropic` by default, or `gemini`). `OPENROUTER_API_KEY` is required when `AI_REVIEW_PROVIDER=openrouter` (the default for the PR reviewer); get one at https://openrouter.ai/keys. In CI, secrets are injected as GitHub Actions secrets and variables via GitHub Actions variables. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env` and `../../.vars`).
+`ORWELLSTAT_USER` and `ORWELLSTAT_PASSWORD` are required for all environments. `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` are only needed when running against staging — Playwright passes them automatically as HTTP Basic Auth credentials when set. `ANTHROPIC_API_KEY` and `GEMINI_API_KEY` are optional — when the active provider's key is present alongside `AI_DIAGNOSIS=true` in `.vars`, failed tests receive an `AI diagnosis` attachment in the Playwright report; when either is absent the fixture behaves identically to without them. Set `AI_PROVIDER` in `.vars` to choose the provider (`anthropic` by default, or `gemini`). `OPENROUTER_API_KEY` is required when `ANTHROPIC_BASE_URL` in `.vars` points to OpenRouter (or any Anthropic-compat proxy); the PR reviewer uses it as the Bearer auth token. Get one at https://openrouter.ai/keys. In CI, secrets are injected as GitHub Actions secrets and variables via GitHub Actions variables. Sub-projects load them via `dotenv` with a path pointing two levels up (`../../.env` and `../../.vars`).
 
 ### CI repository variables
 
@@ -77,8 +77,9 @@ The following variables are set in **GitHub → Settings → Variables → Actio
 | `AI_PROVIDER`           | AI provider for diagnosis (`anthropic` or `gemini`; default: `anthropic`) | Every Playwright run (local and CI)           |
 | `AI_MODEL_FAST`         | Override fast-tier model (diagnosis); empty = provider default            | Every Playwright run (local and CI)           |
 | `AI_MODEL_STRONG`       | Override strong-tier model (selector fix); empty = provider default       | Every Playwright run (local and CI)           |
-| `AI_REVIEW_PROVIDER`    | Provider for PR reviewer (`openrouter` default or `anthropic`)            | PR events via `claude-code-review.yml`                                     |
-| `AI_REVIEW_MODEL`       | Override reviewer model; empty = provider default (openrouter: `qwen/qwen3.6-plus`, anthropic: `claude-sonnet-4-6`) | PR events via `claude-code-review.yml`                                     |
+| `ANTHROPIC_BASE_URL`    | Base URL for PR reviewer; empty = native Anthropic, `https://openrouter.ai/api/v1` = OpenRouter | PR events via `claude-code-review.yml`                                     |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | Sonnet-tier model slug for PR reviewer; required when `ANTHROPIC_BASE_URL` is set | PR events via `claude-code-review.yml`                                     |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL`  | Haiku-tier model slug for PR reviewer; required when `ANTHROPIC_BASE_URL` is set | PR events via `claude-code-review.yml`                                     |
 | `AI_REVIEW`             | `claude-code-review.yml`                     | PR events (opened, synchronize, ready_for_review, reopened)                |
 | `PLAYWRIGHT_TYPESCRIPT` | `playwright-typescript.yml`                  | PR events, push to main, Sunday 03:00 UTC schedule, `workflow_dispatch`    |
 | `BRUNO`                 | `bruno.yml`                                  | PR events, push to main, `workflow_dispatch`                               |


### PR DESCRIPTION
## Summary

Closes #220. Fixes the reviewer from #218, which failed pre-flight with `qwen/qwen3.6-plus` — Claude Code's SDK validates model slugs client-side and rejects non-Anthropic ones before any HTTP call reaches OpenRouter.

Two root causes, one combined fix:

1. **`--model` doesn't work for non-Anthropic slugs.** Replaced with the SDK's documented env-var override: `ANTHROPIC_DEFAULT_SONNET_MODEL` + `ANTHROPIC_DEFAULT_HAIKU_MODEL` (Haiku also overridden because Claude Code invokes it internally for summarization).
2. **Wrong auth header.** OpenRouter expects `Authorization: Bearer` (→ `ANTHROPIC_AUTH_TOKEN` env). The old workflow passed the OpenRouter key via the `anthropic_api_key` action input, which sets `ANTHROPIC_API_KEY` (x-api-key). Now split: Bearer via env when proxying, x-api-key via input when native.

### Design change — direct pass-through

Per "`.env` for secrets, `.vars` for non-secret variables", the translator layer is gone. The workflow reads GH repo Variables straight through to Claude Code SDK env vars; the resolver shell step is deleted.

| Layer | Name | Purpose |
|---|---|---|
| Secret | `ANTHROPIC_API_KEY` | Native Anthropic auth (x-api-key). |
| Secret | `OPENROUTER_API_KEY` | Proxy auth (Bearer). |
| Variable | `AI_REVIEW` | Enable gate (unchanged). |
| Variable | `ANTHROPIC_BASE_URL` | Empty = native Anthropic. Set = proxy. |
| Variable | `ANTHROPIC_DEFAULT_SONNET_MODEL` | Sonnet-tier slug. Required when base URL is set. |
| Variable | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | Haiku-tier slug. Required when base URL is set. |

Removed: `AI_REVIEW_PROVIDER`, `AI_REVIEW_MODEL` (both deleted from GH Variables as part of rollout).

Auth convention via inverse ternaries on `vars.ANTHROPIC_BASE_URL`:
- Empty → `anthropic_api_key: secrets.ANTHROPIC_API_KEY`, no Bearer.
- Non-empty → `ANTHROPIC_AUTH_TOKEN: secrets.OPENROUTER_API_KEY` env, `anthropic_api_key: ''`.

A preflight validation step aborts the job loudly if `ANTHROPIC_BASE_URL` is set without both model overrides — otherwise Claude Code's defaults (`claude-sonnet-4-6` / `claude-haiku-4-5`) would hit the proxy and either silently re-route or 4xx.

## Rollout prerequisites (done)

- `ANTHROPIC_BASE_URL` = `https://openrouter.ai/api/v1` set
- `ANTHROPIC_DEFAULT_SONNET_MODEL` = `qwen/qwen3.6-plus` set
- `ANTHROPIC_DEFAULT_HAIKU_MODEL` = `qwen/qwen3.6-plus` set
- `AI_REVIEW_PROVIDER` and `AI_REVIEW_MODEL` deleted

## Test plan

- [x] Validation guard smoke-tested locally (`/tmp/validate_test.sh`) — 6/6 branches behave correctly: native (no models), native (sonnet-only override), proxy (both set), proxy (sonnet missing → error), proxy (haiku missing → error), proxy (both missing → error).
- [x] `/security-review` — zero findings. Cross-provider key leak traced impossible across all 4 (BASE_URL set/unset) × (secret present/empty) combinations for both ternaries.
- [x] `/simplify` — one fix applied (polarity-explaining comment above ternaries). Other suggestions (inline validation, README trim, hardcode defaults) triaged as judgment calls and skipped.
- [x] Workflow YAML parses (`yaml.safe_load`).
- [x] `git grep AI_REVIEW_PROVIDER\|AI_REVIEW_MODEL` outside `.claude/worktrees/` returns no matches.
- [x] After merge: the next incoming PR triggers the reviewer, OpenRouter logs show a request for `qwen/qwen3.6-plus`, and a formal `gh pr review` verdict is posted. _(Achieved on PR #219 after the #222/#224/#225 follow-up chain fixed the action pre-flight validator + prompt + verdict-framing issues — run 24412848507 succeeded with `APPROVED` verdict, commit a0041928.)_
- [x] After merge: manually flip `ANTHROPIC_BASE_URL` to empty, confirm native Anthropic path still works with `ANTHROPIC_API_KEY`. _(Verified 2026-04-15 on throwaway PR #231 — with all three `vars.ANTHROPIC_*` temporarily deleted, reviewer ran on native Anthropic via `ANTHROPIC_API_KEY`, posted `APPROVED` verdict ending with `_Reviewed by native Anthropic/claude-sonnet-4-6_`. Assumption above confirmed: empty env vars fall back to Claude Code's built-in defaults.)_

## Assumption

Claude Code SDK treats `ANTHROPIC_DEFAULT_SONNET_MODEL=""` (empty env) as equivalent to unset — falling back to the built-in default. `self-healing.yml` already relies on this pattern for `AI_MODEL_FAST` / `AI_MODEL_STRONG` without issue, so the precedent is solid. If the native-Anthropic path breaks post-merge with an "empty model" error, the follow-up is to conditionally set explicit defaults (`claude-sonnet-4-6` / `claude-haiku-4-5`) in the workflow.


