### PR TITLE
#220 Pass proxy key via anthropic_api_key to satisfy action pre-flight

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,11 +32,16 @@ jobs:
             exit 1
           fi
 
-      # Auth convention: when ANTHROPIC_BASE_URL is set we're proxying through an
-      # Anthropic-compat provider (e.g. OpenRouter) which expects Bearer auth via
-      # ANTHROPIC_AUTH_TOKEN; when empty we use Anthropic's native API with x-api-key
-      # auth via the anthropic_api_key input. The two conditions below are inverse
-      # by design — exactly one path ever carries a credential.
+      # Auth convention:
+      # - Native Anthropic (ANTHROPIC_BASE_URL empty): anthropic_api_key input carries
+      #   ANTHROPIC_API_KEY (x-api-key header). ANTHROPIC_AUTH_TOKEN left empty.
+      # - Proxy (ANTHROPIC_BASE_URL set, e.g. OpenRouter): ANTHROPIC_AUTH_TOKEN carries
+      #   the proxy key (Bearer header, per OpenRouter docs). anthropic_api_key input
+      #   ALSO carries the same proxy key — required to satisfy claude-code-action@v1's
+      #   own pre-flight env validator which hard-requires a non-empty ANTHROPIC_API_KEY.
+      #   The Anthropic SDK sends both headers with the proxy key; OpenRouter accepts
+      #   either. No cross-provider leak: the Anthropic key is only ever emitted when
+      #   ANTHROPIC_BASE_URL is empty.
       - uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
@@ -44,7 +49,7 @@ jobs:
           ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL }}
           ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.ANTHROPIC_DEFAULT_HAIKU_MODEL }}
         with:
-          anthropic_api_key: ${{ vars.ANTHROPIC_BASE_URL == '' && secrets.ANTHROPIC_API_KEY || '' }}
+          anthropic_api_key: ${{ (vars.ANTHROPIC_BASE_URL != '' && secrets.OPENROUTER_API_KEY) || (vars.ANTHROPIC_BASE_URL == '' && secrets.ANTHROPIC_API_KEY) || '' }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Follow-up to #221 (which closed #220). The reviewer still fails on PR #219's run with:

> Environment variable validation failed: Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.

Root cause: `anthropics/claude-code-action@v1` has its own pre-flight env validator — one level above the Claude Code SDK — that hard-requires `ANTHROPIC_API_KEY` (or `CLAUDE_CODE_OAUTH_TOKEN`) to be non-empty. `ANTHROPIC_AUTH_TOKEN` alone (which the SDK accepts for Bearer auth) is not accepted by the action's validator. #221 passed `anthropic_api_key: ''` when proxying, tripping this validator.

**Fix:** pass the OpenRouter key via `anthropic_api_key` input when proxying, in addition to `ANTHROPIC_AUTH_TOKEN` env. The Anthropic SDK then sends both `x-api-key` and `Authorization: Bearer` headers with the same key; OpenRouter accepts Bearer and ignores (or also accepts) the x-api-key header.

Run that failed: https://github.com/hubertgajewski/orwellstat/actions/runs/24408010412 — env wiring was correct (`ANTHROPIC_BASE_URL`, both tier-model vars, `ANTHROPIC_AUTH_TOKEN` all set), but `ANTHROPIC_API_KEY: ` was empty.

## Ternary safety

New `anthropic_api_key` input:

```yaml
anthropic_api_key: ${{ (vars.ANTHROPIC_BASE_URL != '' && secrets.OPENROUTER_API_KEY) || (vars.ANTHROPIC_BASE_URL == '' && secrets.ANTHROPIC_API_KEY) || '' }}
```

Walk-through of all four (BASE_URL set/empty) × (relevant-secret set/empty) cases:

| BASE_URL | Target secret | Result | Leak? |
|---|---|---|---|
| set (proxy) | OPENROUTER_API_KEY set | OPENROUTER_API_KEY | ✅ no |
| set (proxy) | OPENROUTER_API_KEY empty | `''` | ✅ no — empty, not Anthropic key |
| empty (native) | ANTHROPIC_API_KEY set | ANTHROPIC_API_KEY | ✅ no |
| empty (native) | ANTHROPIC_API_KEY empty | `''` | ✅ no |

Cross-provider leak is structurally impossible: when `BASE_URL != ''`, the second `&&` evaluates to `false` and the ANTHROPIC_API_KEY branch is unreachable.

## Test plan

- [x] YAML parses (`yaml.safe_load`).
- [x] After merge → merge main into PR #219 again → reviewer runs, `ANTHROPIC_API_KEY` (in env, via input) is now non-empty, action's pre-flight passes, OpenRouter logs show a request for `qwen/qwen3.6-plus`, Qwen posts a `gh pr review` verdict. _(Verdict posted on PR #219 — first as `COMMENTED` (commit 944cccfb, run 24412334990), then as `APPROVED` after #225 tightened the verdict framing (commit a0041928, run 24412848507). Pre-flight passed.)_
- [x] Native Anthropic path unchanged: flip `ANTHROPIC_BASE_URL` to empty in repo Variables, confirm reviewer still works with `ANTHROPIC_API_KEY`. _(Verified 2026-04-15 on throwaway PR #231 — with all three `vars.ANTHROPIC_*` temporarily deleted, `anthropic_api_key: secrets.ANTHROPIC_API_KEY` branch of the ternary was exercised, pre-flight passed, reviewer posted `APPROVED` verdict via native Anthropic path.)_


