### PR TITLE
#223 Sharpen PR reviewer prompt — imperative framing for autonomous agents

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,23 +52,34 @@ jobs:
           anthropic_api_key: ${{ (vars.ANTHROPIC_BASE_URL != '' && secrets.OPENROUTER_API_KEY) || (vars.ANTHROPIC_BASE_URL == '' && secrets.ANTHROPIC_API_KEY) || '' }}
           track_progress: true
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            You are executing a code review of pull request #${{ github.event.pull_request.number }}
+            in ${{ github.repository }}. This is an autonomous task: complete it using tool calls
+            only. Do not reply in prose. Do not say "I will analyze". Do not output review text
+            as a message.
 
-            Please review this pull request. The repo is a multi-framework E2E test suite for OrwellStat.
-            Focus on:
-            - Playwright test correctness (selectors, assertions, fixture usage)
-            - Page Object Model conventions (extending AbstractPage, static url/title/accessKey)
-            - TypeScript quality (types, imports, path aliases)
-            - Potential bugs or flaky test patterns
-            - Consistency with existing patterns in the codebase
+            MANDATORY final action — invoke `gh pr review ${{ github.event.pull_request.number }}`
+            exactly once, with one of:
+              - `--approve -b "..."`          if the PR is acceptable as-is
+              - `--request-changes -b "..."`  if changes are required
+              - `--comment -b "..."`          if you have observations but no verdict
 
-            Always finish by submitting a formal GitHub review using `gh pr review` — this is mandatory regardless of what other tools you used:
-            - `gh pr review <number> --approve -b "..."` if the PR looks good
-            - `gh pr review <number> --request-changes -b "..."` if changes are needed
-            - `gh pr review <number> --comment -b "..."` if you have feedback but no verdict
-            You may also use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues, but it does not replace the required `gh pr review` call.
-            Only post GitHub review/comments - don't submit review text as messages.
+            Task completion is measured by whether that call succeeds. If the final
+            `gh pr review` is not invoked, the task has failed.
+
+            Steps:
+              1. Fetch the diff with `gh pr diff ${{ github.event.pull_request.number }}`.
+              2. Read the diff and identify issues against these criteria:
+                 - Playwright test correctness (selectors, assertions, fixture usage)
+                 - Page Object Model conventions (extending AbstractPage, static
+                   url/title/accessKey)
+                 - TypeScript quality (types, imports, path aliases)
+                 - Potential bugs or flaky test patterns
+                 - Consistency with existing patterns in the codebase
+              3. (Optional) attach line-anchored comments via
+                 `mcp__github_inline_comment__create_inline_comment`.
+              4. Call `gh pr review` per the mandate above. The review body must summarise
+                 findings and must be under 2000 characters. Every claim must be verifiable
+                 in the diff — do not invent issues.
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

Closes #223. Rewrites the reviewer `prompt:` in `.github/workflows/claude-code-review.yml` to frame the work as an autonomous agentic task instead of a polite advisory request. Two distinct failure modes observed with Qwen models on PR #219 motivated this:

- **`qwen/qwen3-coder-plus`** (run [24411572539](https://github.com/hubertgajewski/orwellstat/actions/runs/24411572539)): 1 turn, no tool calls, responded *"I'll analyze this and get back to you."* and stopped.
- **`qwen/qwen3-coder`** (run [24411178668](https://github.com/hubertgajewski/orwellstat/actions/runs/24411178668)): 20 turns, hallucinated 2 false issues, no `gh pr review` verdict.

Root cause: *"Please review this pull request"* reads as conversational to non-Claude models, and the mandatory `gh pr review` action was buried 10+ lines into the prompt.

## Changes

Prompt rewrite moves the mandatory final action to the top and adds explicit guardrails:

- **Line 1:** "This is an autonomous task: complete it using tool calls only. Do not reply in prose."
- **Line 2 block:** `MANDATORY final action — invoke gh pr review ... exactly once` (the one thing the reviewer must do).
- **Line 3:** "Task completion is measured by whether that call succeeds. If the final `gh pr review` is not invoked, the task has failed."
- **Numbered steps follow**, with the 4th step reiterating the `gh pr review` mandate and adding: "The review body must be under 2000 characters. Every claim must be verifiable in the diff — do not invent issues."

Scope limited to the prompt block — no other workflow changes.

## Test plan

- [x] `yaml.safe_load` — parses cleanly, 3 steps preserved.
- [x] Prompt length 1498 chars (under the 2000-char model output cap this request instructs).
- [x] **Post-merge**: re-run the reviewer on PR #219 (branch `feature/145`) with `qwen/qwen3-coder-plus` — confirm `num_turns > 1`, a formal `gh pr review` verdict appears in `gh pr view 219 --json reviews`, and the review body contains no fabricated findings. _(Run 24412334990 — 18 turns, `COMMENTED` verdict, clean body. Verdict state was later tightened by #225.)_
- [x] **Post-merge**: flip `ANTHROPIC_BASE_URL` to empty on a test branch — confirm native Anthropic path still behaves as before (no regression). _(Verified 2026-04-15 on throwaway PR #231 — native-Anthropic reviewer posted a 352-char `APPROVED` verdict on `claude-sonnet-4-6` with the sharpened prompt, cleanest review in the cross-model comparison.)_
- [x] **Post-merge**: `grep 'Please review' .github/workflows/claude-code-review.yml` returns no matches.

## Known limitation

Same workflow-tamper guard as #218/#221/#222 — `anthropics/claude-code-action@v1` refuses to exchange OIDC for an app token when the workflow file on the PR branch differs from `main`. The reviewer's own check on this PR will fail with *"Workflow validation failed…"* and that's expected. Real verification happens on the first PR after merge.


