### PR TITLE
#223 Require binary reviewer verdict — --comment reserved for drafts only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -58,10 +58,18 @@ jobs:
             as a message.
 
             MANDATORY final action — invoke `gh pr review ${{ github.event.pull_request.number }}`
-            exactly once, with one of:
-              - `--approve -b "..."`          if the PR is acceptable as-is
-              - `--request-changes -b "..."`  if changes are required
-              - `--comment -b "..."`          if you have observations but no verdict
+            exactly once with a BINARY verdict:
+              - `--approve -b "..."`          default — pick this when the PR meets the
+                                              criteria. Minor nits do not block approval.
+              - `--request-changes -b "..."`  pick this ONLY when the PR has a concrete
+                                              blocking issue that must be fixed before merge.
+              - `--comment -b "..."`          reserved for drafts / WIP PRs or PRs where the
+                                              diff is structurally unreviewable (mass renames,
+                                              generated files). Do not use as a fallback.
+
+            You are the reviewer; produce a verdict. Do not add disclaimers like
+            "As an AI, I cannot approve" — your role is to evaluate code quality
+            against the criteria, not defer to human judgment.
 
             Task completion is measured by whether that call succeeds. If the final
             `gh pr review` is not invoked, the task has failed.


### PR DESCRIPTION
## Summary

Follow-up to #224 (closed #223). The sharpened prompt now produces real reviews, but qwen3-coder-plus consistently picks `--comment` over `--approve` — hedging with *"As an AI, I cannot approve this PR"*. `COMMENTED` reviews don't satisfy the `check-approval` gate in `playwright-typescript.yml:94` or `bruno.yml:38` (both filter for `.state == "APPROVED"`), so the heavier CI jobs skip.

## Changes

Tightens the MANDATORY-verdict block in `.github/workflows/claude-code-review.yml` to push toward a binary `--approve` / `--request-changes` decision:

- **`--approve` marked as the default.** *"Minor nits do not block approval."*
- **`--request-changes` scoped to "ONLY when the PR has a concrete blocking issue."** Stops Qwen from retreating there to avoid approving.
- **`--comment` scoped to "drafts / WIP PRs or PRs where the diff is structurally unreviewable (mass renames, generated files). Do not use as a fallback."**
- **Explicit anti-hedge:** *"You are the reviewer; produce a verdict. Do not add disclaimers like 'As an AI, I cannot approve' — your role is to evaluate code quality against the criteria, not defer to human judgment."*

## Test plan

- [x] YAML parses (`yaml.safe_load`). Prompt length now 2055 chars.
- [x] **Post-merge**: re-run reviewer on PR #219 with `qwen/qwen3-coder-plus`. Expect `.reviews[].state` to be `APPROVED` (or `CHANGES_REQUESTED` if Qwen flags something real), not `COMMENTED`. `check-approval` job should then unlock downstream CI. _(Run 24412848507 on commit a0041928 — verdict `APPROVED`. `check-approval` on PR #219 concluded SUCCESS.)_
- [x] No "As an AI" disclaimer in the review body. _(`gh pr view 219 --json reviews` — neither review body contains the disclaimer.)_
- [x] **Post-merge**: flip `ANTHROPIC_BASE_URL` to empty, confirm native Anthropic path unaffected by the prompt change. _(Verified 2026-04-15 on throwaway PR #231 — native Anthropic reviewer produced an `APPROVED` verdict, no "As an AI" hedge. Binary-verdict prompt changes from this PR work identically on the native path.)_

## Previous run for comparison

- Run [24412334990](https://github.com/hubertgajewski/orwellstat/actions/runs/24412334990) — qwen3-coder-plus with #223 prompt — posted `COMMENTED` review with "As an AI, I cannot approve this PR" disclaimer. Technically successful (18 turns, $1.19, clean body, no hallucinations) but the wrong verdict state for CI purposes.


