### PR TITLE
#220 Fix openrouter URL in .vars.example and steer away from thinking-mode models

### DIFF
--- a/.vars.example
+++ b/.vars.example
@@ -18,16 +18,23 @@ AI_MODEL_FAST=
 AI_MODEL_STRONG=
 # Base URL for the PR code review action (claude-code-review.yml).
 # Leave empty to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
-# Set to an Anthropic-compatible proxy like https://openrouter.ai/api/v1 to route through it
+# Set to an Anthropic-compatible proxy like https://openrouter.ai/api to route through it
 # (requires OPENROUTER_API_KEY secret, Bearer auth). When set, both
 # ANTHROPIC_DEFAULT_SONNET_MODEL and ANTHROPIC_DEFAULT_HAIKU_MODEL must also be set.
+# Note: OpenRouter's Anthropic-compat endpoint lives at /api (not /api/v1 — the Anthropic SDK
+# appends /v1/messages internally).
 ANTHROPIC_BASE_URL=
 # Override the sonnet-tier model used by the PR reviewer. Required when ANTHROPIC_BASE_URL is set.
-# Leave empty to use Claude Code's default (claude-sonnet-4-6). Example: qwen/qwen3.6-plus.
+# Leave empty to use Claude Code's default (claude-sonnet-4-6).
+# Use a non-thinking model slug — models that emit reasoning/thinking content blocks
+# (e.g. qwen/qwen3.6-plus, any qwen3.5-*) break Claude Code SDK's response parser.
+# Examples that work: openai/gpt-5.3-chat, qwen/qwen3-coder-plus.
 ANTHROPIC_DEFAULT_SONNET_MODEL=
 # Override the haiku-tier model used by the PR reviewer (Claude Code invokes Haiku internally
 # for summarization and quick calls). Required when ANTHROPIC_BASE_URL is set.
-# Leave empty to use Claude Code's default (claude-haiku-4-5). Example: qwen/qwen3.6-plus.
+# Leave empty to use Claude Code's default (claude-haiku-4-5).
+# Pick a cheaper non-thinking model here; a flagship is overkill for quick calls.
+# Examples that work: openai/gpt-4o-mini, qwen/qwen3-coder-flash.
 ANTHROPIC_DEFAULT_HAIKU_MODEL=
 # Self-healing selector fix workflow. Set to "true" to enable automatic draft PRs / PR comments
 # when Playwright tests fail due to locator/selector errors. Uses the same AI_PROVIDER setting


### PR DESCRIPTION
## Summary

Docs-only cleanup on `.vars.example` — three issues found while operating the reviewer:

1. **Wrong OpenRouter URL in the comment.** The example said `https://openrouter.ai/api/v1`; correct value is `https://openrouter.ai/api` (the Anthropic SDK appends `/v1/messages` internally, so `/api/v1` produces a double-`v1` 404). Added a note explaining why.
2. **Stale model examples** pointed to `qwen/qwen3.6-plus` (lines 26 and 30). That slug is confirmed to break Claude Code SDK — it always emits `thinking` / `redacted_thinking` content blocks the SDK parser can't handle, and `reasoning.enabled=false` is silently ignored. Replaced with empirically-probed working examples.
3. **No guidance on avoiding thinking-mode models.** Added a one-line warning plus two working examples per tier (`openai/gpt-5.3-chat`, `qwen/qwen3-coder-plus` for sonnet; `openai/gpt-4o-mini`, `qwen/qwen3-coder-flash` for haiku).

No functional changes — `.vars.example` is a template, not runtime code.

## Test plan

- [x] `grep qwen3.6-plus .vars.example` returns no matches.
- [x] `grep 'openrouter.ai/api/v1' .vars.example` returns no matches.
- [ ] Post-merge: a future operator reading `.vars.example` can pick a working model on first try without our thread of debugging.
