### PR TITLE
#227 Log AI diagnosis provider + models on failure

### DIFF
--- a/playwright/typescript/utils/diagnosis.util.ts
+++ b/playwright/typescript/utils/diagnosis.util.ts
@@ -234,6 +234,7 @@ export async function attachAiDiagnosis(
       fast: process.env.AI_MODEL_FAST || MODEL_MAP[provider].fast,
       strong: process.env.AI_MODEL_STRONG || MODEL_MAP[provider].strong,
     };
+    console.log(`[AI diagnosis] provider=${provider} fast=${models.fast} strong=${models.strong}`);
 
     const domSnippet =
       domContent.length > DOM_TRUNCATE_CHARS


### PR DESCRIPTION
## Summary

Adds a single `console.log` inside `attachAiDiagnosis` that surfaces the resolved provider and both model slugs to stdout whenever the fixture runs against a failing test. Makes local verification of `AI_MODEL_FAST` / `AI_MODEL_STRONG` overrides a zero-effort read of the test output, instead of a throwaway edit + revert.

Closes #227.

## Diff (1 line)

```typescript
const models = {
  fast: process.env.AI_MODEL_FAST || MODEL_MAP[provider].fast,
  strong: process.env.AI_MODEL_STRONG || MODEL_MAP[provider].strong,
};
console.log(`[AI diagnosis] provider=${provider} fast=${models.fast} strong=${models.strong}`);
```

The existing guards at `diagnosis.util.ts:220` (`AI_DIAGNOSIS !== 'true'`), `:224` (invalid provider), and `:229` (missing API key) all short-circuit before this line, so green runs and diagnosis-disabled runs produce no new output. The `[AI diagnosis]` prefix matches the existing `console.warn('[AI diagnosis] skipped: …')` style at lines 224 and 268.

## Test plan

- [x] `npx tsc --noEmit` passes (from `playwright/typescript/`)
- [x] `npm run format:check` passes (from `playwright/typescript/`)
- [x] Manual smoke: failing test with `AI_DIAGNOSIS=true AI_PROVIDER=gemini AI_MODEL_FAST=gemini-2.5-flash-lite AI_MODEL_STRONG=gemini-2.5-flash` prints `[AI diagnosis] provider=gemini fast=gemini-2.5-flash-lite strong=gemini-2.5-flash` exactly once, then produces the expected `AI diagnosis` attachment on the failed test
- [x] `/security-review` — no findings (the line logs provider + model slugs only; no keys, PII, or credentials)
- [x] `/simplify` — nothing to simplify; existing `console.warn` at line 268 is the closest related call and intentionally different (warn path, different message)
- [x] CI green on branch _(`test` pass 19s, `review` pass 40s (Qwen verdict: APPROVED), `check-approval` pass)_
