### PR TITLE
#228 Log AI reviewer provider + models in claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -89,5 +89,22 @@ jobs:
                  findings and must be under 2000 characters. Every claim must be verifiable
                  in the diff — do not invent issues.
 
+            Append this as the final line of the review body, verbatim:
+            `_Reviewed by ${{ vars.ANTHROPIC_BASE_URL != '' && 'proxy' || 'native Anthropic' }}/${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL || 'claude-sonnet-4-6' }}_`
+
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      - name: Report reviewer configuration
+        if: always()
+        env:
+          BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+          SONNET: ${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL }}
+          HAIKU: ${{ vars.ANTHROPIC_DEFAULT_HAIKU_MODEL }}
+        run: |
+          if [ -z "$BASE_URL" ]; then
+            provider="native Anthropic"; url="<native>"
+          else
+            provider="proxy"; url="$BASE_URL"
+          fi
+          echo "provider=$provider base_url=$url sonnet=${SONNET:-<default>} haiku=${HAIKU:-<default>}"


### PR DESCRIPTION
## Summary

Surfaces the AI reviewer's configuration (provider + both model slugs) in two places so confirming a given review came from the expected path no longer requires grepping the action's internal logs:

1. **Signature line in the posted review body** — added to the reviewer prompt. GitHub Actions templating resolves `ANTHROPIC_BASE_URL` / `ANTHROPIC_DEFAULT_SONNET_MODEL` at job-run time so the model just echoes a pre-formed string.
2. **Trailing `Report reviewer configuration` step** with `if: always()` — echoes `provider=<native Anthropic|proxy> base_url=<url|<native>> sonnet=<slug|<default>> haiku=<slug|<default>>` to stdout. Survives action failures.

Closes #228.

## Why now

The unchecked "native-Anthropic path regression" DoD on #221, #222, #223, #224, and #225 has been pending specifically because there was no clean signal on a merged PR showing which path produced a given review. Once this lands, flipping `vars.ANTHROPIC_BASE_URL` to empty on a throwaway branch yields `provider=native Anthropic` in the job log and `_Reviewed by native Anthropic/claude-sonnet-4-6_` as the final line of the review — satisfying all five of those regression items in a single future run.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"` exits 0).
- [x] Env-var indirection (`BASE_URL` / `SONNET` / `HAIKU` passed via `env:` then referenced as `$VAR`) mirrors the existing `Validate reviewer configuration` step at line 24 — no inline shell injection surface.
- [x] `/security-review` — no findings (logged values are non-secret repo Variables; no secrets referenced in the new step or signature line).
- [x] `/code-review` — 9 Pass / 9 N/A / 0 Fail; workflow-file checks (timeout-minutes, action pinning, secret scoping, `if:` on context-specific steps) all pass.
- [x] `Report reviewer configuration` step executes on this PR despite the expected action failure (`if: always()` guard works). Log line verified: `provider=proxy base_url=https://openrouter.ai/api sonnet=openai/gpt-5.3-chat haiku=openai/gpt-4o-mini` in run [24440439527](https://github.com/hubertgajewski/orwellstat/actions/runs/24440439527).
- [ ] CI green on branch — `review` job fails on this PR by design (workflow-tamper guard, see "Known limitation"). `check-approval` passes. Signature-line half of the feature can only be verified post-merge.
- [ ] Post-merge: on a follow-up PR, the `_Reviewed by …_` signature appears as the final line of the posted review body via `gh pr view <n> --json reviews`.
- [ ] Post-merge: flipping `vars.ANTHROPIC_BASE_URL` to empty on a throwaway branch produces `provider=native Anthropic base_url=<native>` in the log and a `_Reviewed by native Anthropic/claude-sonnet-4-6_` signature — closes the pending regression item on #221, #222, #223, #224, #225.

## Known limitation

`anthropics/claude-code-action@v1` has a workflow-tamper guard that refuses to issue an app token when the workflow file on the PR branch differs from `main`. The reviewer step on this PR will therefore fail with *"Workflow validation failed…"* and that is expected — the real behaviour change can only be observed on a PR opened **after** this one merges. Same flow as #224.
