### PR TITLE
Smoke: native Anthropic reviewer regression test

### DIFF
--- a/.vars.example
+++ b/.vars.example
@@ -17,7 +17,7 @@ AI_MODEL_FAST=
 # Defaults: anthropic -> claude-sonnet-4-6, gemini -> gemini-3.1-flash-lite-preview.
 AI_MODEL_STRONG=
 # Base URL for the PR code review action (claude-code-review.yml).
-# Leave empty to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
+# Leave empty (or unset) to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
 # Set to an Anthropic-compatible proxy like https://openrouter.ai/api to route through it
 # (requires OPENROUTER_API_KEY secret, Bearer auth). When set, both
 # ANTHROPIC_DEFAULT_SONNET_MODEL and ANTHROPIC_DEFAULT_HAIKU_MODEL must also be set.


### PR DESCRIPTION
## Throwaway smoke test — will be closed after the reviewer run

Native-Anthropic regression check for the DoD items still pending on #221, #222, #223, #224, #225. `ANTHROPIC_BASE_URL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL` have been **temporarily deleted** from repo Variables for this run; they will be restored to their OpenRouter/GPT-5.3 values immediately after.

The reviewer on this PR should:
- Take the native-Anthropic path (`anthropic_api_key: ANTHROPIC_API_KEY`, x-api-key auth, Claude models)
- Log `provider=native Anthropic base_url=<native> sonnet=<default> haiku=<default>` in the `Report reviewer configuration` step
- Post a verdict ending with `_Reviewed by native Anthropic/claude-sonnet-4-6_`

Not for merge.
