### PR TITLE
#232 Reword signature instruction to fix literal \n\n on non-Anthropic models

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -89,8 +89,9 @@ jobs:
                  findings and must be under 2000 characters. Every claim must be verifiable
                  in the diff — do not invent issues.
 
-            Append this as the final line of the review body, verbatim:
-            `_Reviewed by ${{ vars.ANTHROPIC_BASE_URL != '' && 'proxy' || 'native Anthropic' }}/${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL || 'claude-sonnet-4-6' }}_`
+            At the end of the review body, append one blank line followed by this exact line:
+
+            _Reviewed by ${{ vars.ANTHROPIC_BASE_URL != '' && 'proxy' || 'native Anthropic' }}/${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL || 'claude-sonnet-4-6' }}_
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

Rewords the reviewer's signature-line instruction in `.github/workflows/claude-code-review.yml` so the blank-line separator between review body and signature is expressed semantically ("append one blank line followed by this exact line") rather than embedded in the instruction as an implied literal. Eliminates the `\n\n` escape-sequence rendering seen on `openai/gpt-5.3-chat` and `qwen/qwen3-coder-plus` (single-tier) during yesterday's five-model smoke on PR #231.

Closes #232.

## Before / after

**Before:**

```
Append this as the final line of the review body, verbatim:
`_Reviewed by …_`
```

**After:**

```
At the end of the review body, append one blank line followed by this exact line:

_Reviewed by …_
```

Two changes:
- Drop the outer backticks around the template (models were interpreting "verbatim" to include the surrounding backticks on some runs).
- Replace "Append this as the final line ... verbatim" with explicit "append one blank line followed by this exact line" — tells the model semantically what we want, rather than relying on the one-line-after-the-instruction layout being picked up as the newline source.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"` exits 0).
- [x] Diff scope limited to the signature-instruction block (3 lines inserted, 2 removed).
- [x] `/security-review` — no findings (prompt string only; no env/secret surface).
- [x] `/code-review` — all CI-workflow checks pass: `timeout-minutes` intact, actions pinned, no new secret refs, no new inputs.
- [x] Expected-failure pattern confirmed: `review` failed with workflow-tamper guard (same as #224 / #230); `check-approval` passed; `Report reviewer configuration` ran despite the failure and emitted `provider=proxy base_url=https://openrouter.ai/api sonnet=openai/gpt-5.3-chat haiku=openai/gpt-4o-mini` — `if: always()` guard intact.
- [ ] Post-merge smoke on a throwaway branch — iterate `ANTHROPIC_DEFAULT_SONNET_MODEL` across the five combos used on #231:
  - `openai/gpt-5.3-chat` + `openai/gpt-4o-mini` (the primary fix target)
  - `qwen/qwen3-coder-plus` + `qwen/qwen3-coder-flash`
  - `qwen/qwen3-coder-plus` on both tiers (the other fix target)
  - `anthropic/claude-sonnet-4.6` + `anthropic/claude-haiku-4.5` (regression check)
  - native Anthropic with all three `vars.ANTHROPIC_*` empty (regression check)
  For each, fetch the review body via `gh pr view <n> --json reviews -q '.reviews[-1].body'` and confirm no `\n` / `\\n` escape sequence in the output — the signature should appear on its own line after a genuine blank line. `grep -F '\n\n' <body>` must return no matches.

## Known limitation

Same `anthropics/claude-code-action@v1` workflow-tamper caveat as #224 / #230: the reviewer step on this PR will fail with *"Workflow validation failed…"* because the branch's copy of `claude-code-review.yml` differs from `main`. Expected. Real verification happens on the post-merge smoke pass described above.
