### PR TITLE
Smoke: #232 signature-fix verification sweep

### DIFF
--- a/.vars.example
+++ b/.vars.example
@@ -17,7 +17,7 @@ AI_MODEL_FAST=
 # Defaults: anthropic -> claude-sonnet-4-6, gemini -> gemini-3.1-flash-lite-preview.
 AI_MODEL_STRONG=
 # Base URL for the PR code review action (claude-code-review.yml).
-# Leave empty to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
+# Leave empty (or unset) to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
 # Set to an Anthropic-compatible proxy like https://openrouter.ai/api to route through it
 # (requires OPENROUTER_API_KEY secret, Bearer auth). When set, both
 # ANTHROPIC_DEFAULT_SONNET_MODEL and ANTHROPIC_DEFAULT_HAIKU_MODEL must also be set.


### PR DESCRIPTION
## Throwaway smoke test — will be closed after the 5-config sweep

Post-merge verification of #232 / PR #233 — the signature-line rewrite. Iterates the same five model combos used on #231 and greps each review body for `\n` / `\\n` to confirm the literal-newline glitch is gone on `openai/gpt-5.3-chat` and `qwen/qwen3-coder-plus`.

Sweep order (each is one empty-commit on this branch):
1. `openai/gpt-5.3-chat` + `openai/gpt-4o-mini` (production; primary fix target)
2. `qwen/qwen3-coder-plus` + `qwen/qwen3-coder-flash`
3. `qwen/qwen3-coder-plus` on both tiers (other fix target)
4. `anthropic/claude-sonnet-4.6` + `anthropic/claude-haiku-4.5` (regression check)
5. native Anthropic — all three `vars.ANTHROPIC_*` deleted (regression check)

Vars are restored to production (#1) at the end.

Not for merge.
