### PR TITLE
#235 Disable action tag mode (track_progress: false) and revert #233's signature rewording

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,7 +50,7 @@ jobs:
           ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.ANTHROPIC_DEFAULT_HAIKU_MODEL }}
         with:
           anthropic_api_key: ${{ (vars.ANTHROPIC_BASE_URL != '' && secrets.OPENROUTER_API_KEY) || (vars.ANTHROPIC_BASE_URL == '' && secrets.ANTHROPIC_API_KEY) || '' }}
-          track_progress: true
+          track_progress: false
           prompt: |
             You are executing a code review of pull request #${{ github.event.pull_request.number }}
             in ${{ github.repository }}. This is an autonomous task: complete it using tool calls
@@ -89,9 +89,8 @@ jobs:
                  findings and must be under 2000 characters. Every claim must be verifiable
                  in the diff — do not invent issues.
 
-            At the end of the review body, append one blank line followed by this exact line:
-
-            _Reviewed by ${{ vars.ANTHROPIC_BASE_URL != '' && 'proxy' || 'native Anthropic' }}/${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL || 'claude-sonnet-4-6' }}_
+            Append this as the final line of the review body, verbatim:
+            `_Reviewed by ${{ vars.ANTHROPIC_BASE_URL != '' && 'proxy' || 'native Anthropic' }}/${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL || 'claude-sonnet-4-6' }}_`
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

Two surgical edits to `.github/workflows/claude-code-review.yml`:

1. **`track_progress: true` → `false`** (line 53). Switches `anthropics/claude-code-action@v1` from "tag mode" to "agent mode" per the action's documented `track_progress` input. Stops the action from auto-creating an issue comment per reviewer run, stops it from injecting `mcp__github_comment__update_claude_comment`, and stops the "PR CRITICAL: you MUST post via comment" framing into Claude's prompt. Result: each reviewer run posts exactly one artefact to the PR — the formal `gh pr review` verdict.
2. **Revert PR #233's signature rewording** (lines 92–93). Restores the pre-#233 single-line `Append this as the final line of the review body, verbatim: \`...\`` form. The rewording made `qwen/qwen3-coder-plus` drop the signature entirely without fixing the `\n\n` issue on `openai/gpt-5.3-chat`. With the dual-post pipeline removed, the simpler "verbatim" instruction works for everyone.

Closes #235. Closes #232 (the `\n\n` literal-newline glitch is expected to resolve as a side-effect of removing the dual-post pipeline; if it persists for any model, follow-up issue).

## Why this fixes the issue

The auto-comment + comment-update tool that `track_progress: true` enables is what produced six dead `I'll analyze this and get back to you.` placeholders on PR #234, and is the most plausible source of pressure that made non-Anthropic models construct their `gh pr review -b` shell argument with literal `\n\n` instead of real newlines (Claude was juggling two posting paths and confusing the bash quoting). The action's own `action.yml` defaults `track_progress` to `false`; we'd opted into `true` back in #218 without registering the dual-post implications.

Verified the action's behaviour by reading `action.yml` and `src/modes/detector.ts` from `anthropics/claude-code-action@v1`:

- `action.yml`: *"Force tag mode with tracking comments for pull_request and issue events. Default: false."*
- `src/modes/detector.ts`: `if (context.inputs.trackProgress && isEntityContext(context)) { … force tag mode }` — false → agent mode → no auto-comment, no `update_claude_comment` injection.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"` exits 0).
- [x] Diff scope: 1 boolean flip + 2-line revert. No other workflow content touched.
- [x] `/security-review` — no findings (no new secret refs or shell surfaces).
- [x] `/code-review` — workflow checks pass: `timeout-minutes` intact, action `@v1` pinning intact, no new env/secret refs.
- [x] Expected-failure pattern confirmed: `review` failed with workflow-tamper guard (same as #224 / #230 / #233); `check-approval` passed; `Report reviewer configuration` ran despite the failure and emitted `provider=proxy base_url=https://openrouter.ai/api sonnet=openai/gpt-5.3-chat haiku=openai/gpt-4o-mini` — `if: always()` guard intact. (Note: no auto-comment was created on this PR either, but that's because the tamper guard fires before the action reaches the comment-creation step — same on PR #233 which had `track_progress: true`. Real verification of comment suppression happens post-merge.)
- [ ] Post-merge smoke on a throwaway draft PR. Iterate `ANTHROPIC_DEFAULT_SONNET_MODEL` / `ANTHROPIC_DEFAULT_HAIKU_MODEL` across the same 6 combos used on #234:
  - `openai/gpt-5.3-chat` + `openai/gpt-4o-mini` (current production; primary fix target)
  - `qwen/qwen3-coder-plus` + `qwen/qwen3-coder-flash`
  - `qwen/qwen3-coder-plus` on both tiers
  - `anthropic/claude-sonnet-4.6` + `anthropic/claude-haiku-4.5`
  - native Anthropic (all three `vars.ANTHROPIC_*` deleted)
  - `@preset/qwen3-6-no-thinking` on both tiers

  For each iteration, two checks:
  1. `gh pr view <n> --json comments -q '[.comments[] | select(.author.login == "claude")] | length'` does **not** grow with each new commit (no new "Claude finished" comments per run).
  2. `gh pr view <n> --json reviews -q '.reviews[-1].body'` ends with the templated signature line and `grep -F '\n\n' body` returns no matches.

## Known limitation

Same `anthropics/claude-code-action@v1` workflow-tamper caveat as #224 / #230 / #233: the reviewer step on this PR will fail with *"Workflow validation failed…"* because the branch's copy of `claude-code-review.yml` differs from `main`. Expected. Real verification happens on the post-merge smoke pass described above.
