### PR TITLE
Smoke: #235 post-merge verification sweep

### DIFF
--- a/.vars.example
+++ b/.vars.example
@@ -17,7 +17,7 @@ AI_MODEL_FAST=
 # Defaults: anthropic -> claude-sonnet-4-6, gemini -> gemini-3.1-flash-lite-preview.
 AI_MODEL_STRONG=
 # Base URL for the PR code review action (claude-code-review.yml).
-# Leave empty to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
+# Leave empty (or unset) to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
 # Set to an Anthropic-compatible proxy like https://openrouter.ai/api to route through it
 # (requires OPENROUTER_API_KEY secret, Bearer auth). When set, both
 # ANTHROPIC_DEFAULT_SONNET_MODEL and ANTHROPIC_DEFAULT_HAIKU_MODEL must also be set.


### PR DESCRIPTION
## Throwaway smoke test — will be closed after the 6-config sweep

Post-merge verification of #235 / PR #236 — `track_progress: false` + revert of #233 signature wording. Iterates the same six combos from PR #234 and checks two things per iteration:

1. Comment count from `claude` does NOT grow with each new commit (auto-comment suppression).
2. Review body ends with templated signature, no `\n` / `\\n` escape (#232 fix as side-effect).

Sweep order:
1. `openai/gpt-5.3-chat` + `openai/gpt-4o-mini` (production)
2. `qwen/qwen3-coder-plus` + `qwen/qwen3-coder-flash`
3. `qwen/qwen3-coder-plus` on both tiers
4. `anthropic/claude-sonnet-4.6` + `anthropic/claude-haiku-4.5`
5. native Anthropic — all three `vars.ANTHROPIC_*` deleted
6. `@preset/qwen3-6-no-thinking` on both tiers

Vars restored to production at the end. Not for merge.
