### PR TITLE
Smoke: preset Qwen 3.6 retry + Minimax M2.5 comparison

### DIFF
--- a/.vars.example
+++ b/.vars.example
@@ -17,7 +17,7 @@ AI_MODEL_FAST=
 # Defaults: anthropic -> claude-sonnet-4-6, gemini -> gemini-3.1-flash-lite-preview.
 AI_MODEL_STRONG=
 # Base URL for the PR code review action (claude-code-review.yml).
-# Leave empty to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
+# Leave empty (or unset) to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
 # Set to an Anthropic-compatible proxy like https://openrouter.ai/api to route through it
 # (requires OPENROUTER_API_KEY secret, Bearer auth). When set, both
 # ANTHROPIC_DEFAULT_SONNET_MODEL and ANTHROPIC_DEFAULT_HAIKU_MODEL must also be set.


### PR DESCRIPTION
## Throwaway smoke — preset Qwen 3.6 retry + Minimax comparison

Three iterations on this branch:
1. `@preset/qwen3-6-no-thinking` (both tiers) — retry after the PR #237 iter-6 compliance miss.
2. `@preset/minimax/minimax-m2.5-no-thinking` (both tiers) — Minimax M2.5 via the no-thinking preset.
3. `minimax/minimax-m2.5` (both tiers, raw) — check whether the preset wrapper is needed or if the raw slug works without emitting thinking blocks.

Per iteration, capture: auto-comment count (should stay 0), `gh pr review` posted, signature present, `\n\n` in body, verdict state, cost.

Vars restored to production (openai) at the end. Not for merge.
