### PR TITLE
#239 Swap openai/gpt-5.3-chat for Minimax M2.7 preset in sonnet examples

### DIFF
--- a/.vars.example
+++ b/.vars.example
@@ -28,7 +28,7 @@ ANTHROPIC_BASE_URL=
 # Leave empty to use Claude Code's default (claude-sonnet-4-6).
 # Use a non-thinking model slug — models that emit reasoning/thinking content blocks
 # (e.g. qwen/qwen3.6-plus, any qwen3.5-*) break Claude Code SDK's response parser.
-# Examples that work: openai/gpt-5.3-chat, qwen/qwen3-coder-plus.
+# Examples that work: @preset/minimax-minimax-m2-7-no-thinking, qwen/qwen3-coder-plus.
 ANTHROPIC_DEFAULT_SONNET_MODEL=
 # Override the haiku-tier model used by the PR reviewer (Claude Code invokes Haiku internally
 # for summarization and quick calls). Required when ANTHROPIC_BASE_URL is set.


### PR DESCRIPTION
## Summary

One-line change to `.vars.example:31` — the sonnet-tier "Examples that work" line now lists `@preset/minimax-minimax-m2-7-no-thinking` as the primary recommendation (was `openai/gpt-5.3-chat`). `qwen/qwen3-coder-plus` stays as the secondary example. Closes #239 and #232 (as a side-effect — openai's `\n\n` bug is sidestepped rather than patched).

## Why swap

Today's five-iteration cross-model sweep on #238 tested six configurations including all mentioned in `.vars.example`. Results:

| Config | `\n\n`? | Signature | Markdown | Verdict routing |
|---|---|---|---|---|
| `openai/gpt-5.3-chat` (removed) | **yes** | plain | basic | correct |
| `qwen/qwen3-coder-plus` (kept) | no | italic | plain | correct |
| `@preset/minimax-minimax-m2-7-no-thinking` (new primary) | no | italic | **headings + bullets** | correct |

`openai/gpt-5.3-chat` emits literal `\n\n` before the signature (the #232 bug, not fixed by #233's revert or #235's `track_progress: false`). The Minimax M2.7 no-thinking preset is the only model tested today that produces fully-formatted markdown reviews (headings, bullet lists, labelled criteria assessment) while satisfying every correctness property.

## Rollout

After merge, update the repo Variable manually in GitHub → Settings → Variables → Actions:

- `ANTHROPIC_DEFAULT_SONNET_MODEL`: `openai/gpt-5.3-chat` → `@preset/minimax-minimax-m2-7-no-thinking`
- `ANTHROPIC_DEFAULT_HAIKU_MODEL`: unchanged (`openai/gpt-4o-mini`) — haiku-tier calls are internal Claude Code summarisation, not user-visible, and `openai/gpt-4o-mini` has shown no issues + it's cheap

After the Variable flip, the next PR's review body should end with `_Reviewed by proxy/@preset/minimax-minimax-m2-7-no-thinking_` and the `Report reviewer configuration` step will log the new slug.

## Test plan

- [x] `git diff` — one line changed in `.vars.example`, comment only. No functional code.
- [x] Production behaviour verified empirically on smoke PR #238 iter 5 — preset posted a clean review, no `\n\n`, signature present, best markdown of any model tested.
- [x] `/security-review` — N/A (template file, comment edit, no env / secret surface).
- [x] `/code-review` — N/A items apply; no workflow, test, or code change.
- [x] CI green on branch. `review`, `test`, `check-approval` all pass. Reviewer (still on `openai/gpt-5.3-chat`) posted APPROVED verdict. 0 auto-comments confirms `track_progress: false` still working for non-workflow-touching PRs.
- [x] Repo Variable `ANTHROPIC_DEFAULT_SONNET_MODEL` set to `@preset/minimax-minimax-m2-7-no-thinking` (flipped ahead of merge to verify on this PR itself).
- [x] Rollout verified on this PR: empty-commit re-triggered the reviewer under the new config. `Report reviewer configuration` logged `sonnet=@preset/minimax-minimax-m2-7-no-thinking haiku=openai/gpt-4o-mini`; review body is APPROVED with `_Reviewed by proxy/@preset/minimax-minimax-m2-7-no-thinking_` signature, clean markdown (headings + summary), no `\n\n`, 0 auto-comments.

## Related issues closed

- Closes #239 (this issue).
- Closes #232 — the `\n\n` bug on openai/gpt-5.3-chat is resolved by moving off openai; we will not patch the prompt further.
