### PR TITLE
#174 Add /generate-test skill for per-page test scaffolding

### DIFF
--- a/.claude/skills/generate-test/SKILL.md
+++ b/.claude/skills/generate-test/SKILL.md
@@ -84,14 +84,14 @@ For each target file:
 
 All scaffolds are `test.fixme()` so unfinished scaffolds do not run in CI. The user replaces `fixme` with `test` once the assertions are filled in.
 
-**Content scaffold** — appended to or created in the content target file. Test title: `{page-name} page - content`, where `{page-name}` is the class name with `Page` stripped and converted to kebab-case (`RegisterPage` → `register`, `PasswordResetPage` → `password-reset`, `ServiceStatisticsPage` → `service-statistics`).
+**Content scaffold** — appended to or created in the content target file. Test title: `{pageName} page - content`, where `{pageName}` is the class name with `Page` stripped and split from camelCase into lowercase space-separated words (`RegisterPage` → `register`, `PasswordResetPage` → `password reset`, `ServiceStatisticsPage` → `service statistics`). This matches the title format produced by `/generate-stubs` so the Step 6 duplicate guard catches stubs planted by either skill.
 
 New file template:
 ```typescript
 import { test, expect } from '@fixtures/base.fixture';
 import { {ClassName} } from '{importPath}';
 
-test.fixme('{page-name} page - content', { tag: '@regression' }, async ({ page }) => {
+test.fixme('{pageName} page - content', { tag: '@regression' }, async ({ page }) => {
   await page.goto({ClassName}.url);
   const pageObject = new {ClassName}(page);
   await expect(pageObject.heading).toBeVisible();
@@ -102,7 +102,7 @@ test.fixme('{page-name} page - content', { tag: '@regression' }, async ({ page }
 Append to existing file (import added separately if missing):
 ```typescript
 
-test.fixme('{page-name} page - content', { tag: '@regression' }, async ({ page }) => {
+test.fixme('{pageName} page - content', { tag: '@regression' }, async ({ page }) => {
   await page.goto({ClassName}.url);
   const pageObject = new {ClassName}(page);
   await expect(pageObject.heading).toBeVisible();
@@ -124,11 +124,11 @@ test.fixme('{page-name} page - content', { tag: '@regression' }, async ({ page }
 
 Add the page-class import at the top of `accessibility.spec.ts` if missing.
 
-**Visual regression scaffold** — appended at the bottom of `visual.spec.ts`. Test title: `{page-name} page visual regression`.
+**Visual regression scaffold** — appended at the bottom of `visual.spec.ts`. Test title: `{pageName} page visual regression`, using the same `{pageName}` derivation as the content scaffold.
 
 ```typescript
 
-test.fixme('{page-name} page visual regression', { tag: '@regression' }, async ({ page }) => {
+test.fixme('{pageName} page visual regression', { tag: '@regression' }, async ({ page }) => {
   await page.goto({ClassName}.url);
   // TODO: Add a toHaveScreenshot() assertion. Mask any dynamic content (live data tables,
   // SVG charts, #statsbar lists) so the baseline is deterministic.

--- a/.claude/skills/generate-test/SKILL.md
+++ b/.claude/skills/generate-test/SKILL.md
@@ -1,0 +1,174 @@
+---
+description: Scaffold Playwright tests for one page based on its class and coverage-matrix gaps.
+---
+
+Page identifier: $ARGUMENTS
+
+Generate Playwright test scaffolds for a single page, driven by the gaps recorded in `playwright/typescript/coverage-matrix.json`. The scaffolds are real `test.fixme()` blocks with imports, navigation, and a TODO marker so that CI does not run an unfilled test, but the user only needs to write the actual assertions. Existing spec files are **appended to**, never overwritten; new files are only created when the target does not exist.
+
+This skill is the targeted, per-page counterpart to `/generate-stubs` (which sweeps the whole matrix at once). Use it when you want to drop fresh scaffolding into one page's spec file after flipping new values to `false` in the matrix.
+
+**Step 1 — Resolve the page identifier**
+
+The user may pass any of: URL (`/register/`), class name (`RegisterPage`, case-insensitive), page-file stem (`register`, `register.page`). Match `$ARGUMENTS` against this table; the match must be unambiguous.
+
+| URL | Class | Import | File stem |
+|---|---|---|---|
+| `/` | `HomePage` | `@pages/public` | `home` |
+| `/about/` | `AboutSystemPage` | `@pages/public` | `about-system` |
+| `/statistics/` | `ServiceStatisticsPage` | `@pages/public` | `service-statistics` |
+| `/contact/` | `ContactPage` | `@pages/public` | `contact` |
+| `/register/` | `RegisterPage` | `@pages/public` | `register` |
+| `/2/` | `PreviouslyAddedPage` | `@pages/public/previously-added.page` | `previously-added` |
+| `/password_reset/` | `PasswordResetPage` | `@pages/public` | `password-reset` |
+| `/zone/` | `InformationPage` | `@pages/authenticated` | `information` |
+| `/zone/stats/` | `StatsPage` | `@pages/authenticated` | `stats` |
+| `/zone/hits/` | `HitsPage` | `@pages/authenticated` | `hits` |
+| `/zone/scripts/` | `ScriptsPage` | `@pages/authenticated` | `scripts` |
+| `/zone/admin/` | `AdminPage` | `@pages/authenticated` | `admin` |
+
+If `$ARGUMENTS` is empty, matches nothing, or matches more than one row, stop and ask the user to pick from the list.
+
+**Step 2 — Read the coverage matrix**
+
+Read `playwright/typescript/coverage-matrix.json`. Locate the entry under `pages` whose key equals the resolved URL. If the URL is not present, stop and ask the user whether to add it to the matrix first — do not invent an entry.
+
+**Step 3 — Identify gaps**
+
+Check the page's `content`, `accessibility`, and `visualRegression` values. Skip `title` and `api` — those are covered by the data-driven loops in `navigation.spec.ts` and `api.spec.ts`. Record each `false` value as a gap. If none are `false`, print "No content/accessibility/visual gaps for `{url}` in `coverage-matrix.json` — nothing to scaffold." and stop.
+
+**Step 4 — Data-driven accessibility conflict check**
+
+If accessibility is a gap, read `playwright/typescript/pages/public/index.ts` and `playwright/typescript/pages/authenticated/index.ts` and check whether the page class is in `PUBLIC_PAGE_CLASSES` or `AUTHENTICATED_PAGE_CLASSES`.
+
+If it **is** in the array, the data-driven loop in `accessibility.spec.ts` already covers it. Do not scaffold an accessibility test; instead warn:
+
+> Page `{url}` (`{ClassName}`) is in `{PUBLIC|AUTHENTICATED}_PAGE_CLASSES`, so `accessibility.spec.ts` already covers it via the data-driven loop. Flip `accessibility` to `true` in `coverage-matrix.json` instead of adding a standalone test.
+
+Continue with the remaining gaps.
+
+**Special case:** `PreviouslyAddedPage` (`/2/`) is deliberately excluded from `PUBLIC_PAGE_CLASSES`. For this page, proceed with a standalone accessibility scaffold but flag to the user that adding it to the array would cover title, accessibility, and API at once via existing loops.
+
+**Step 5 — Map each gap to a target file**
+
+| Gap | Target file | Action when file exists |
+|---|---|---|
+| `content` | see content-file mapping below | append |
+| `accessibility` | `playwright/typescript/tests/accessibility.spec.ts` | append inside the existing `test.describe('accessibility', ...)` block, after the two `for` loops |
+| `visualRegression` | `playwright/typescript/tests/visual.spec.ts` | append at the bottom of the file |
+
+Content-file mapping:
+
+- `/` → `home.spec.ts`
+- `/about/` → `about-system.spec.ts`
+- `/statistics/` → `statistics.spec.ts`
+- `/contact/` → `contact.spec.ts`
+- `/register/` → `register.spec.ts` (new)
+- `/2/` → `previously-added.spec.ts` (new)
+- `/password_reset/` → `password-reset.spec.ts` (new)
+- `/zone/` → `zone-information.spec.ts` (new)
+- `/zone/stats/` → `zone-stats.spec.ts` (new)
+- `/zone/hits/` → `zone-hits.spec.ts` (new)
+- `/zone/scripts/` → `zone-scripts.spec.ts` (new)
+- `/zone/admin/` → `zone-admin.spec.ts` (new)
+
+**Step 6 — Preflight: never overwrite, never duplicate**
+
+For each target file:
+
+1. Check whether the file exists. If it does **not**, you will create it with the Write tool in Step 7. Use Write only after confirming non-existence — Write silently overwrites.
+2. If the file **does** exist, read it. Search for the exact test title string the scaffold will use (see Step 7). If already present, skip that scaffold and warn: `Skipping {category} scaffold for {url} — '{test title}' already exists in {file}.`
+3. If the file exists but the page class import is missing, add the import near the top of the file (alongside the existing imports) using Edit. Do not rewrite unrelated imports.
+
+**Step 7 — Generate scaffolds**
+
+All scaffolds are `test.fixme()` so unfinished scaffolds do not run in CI. The user replaces `fixme` with `test` once the assertions are filled in.
+
+**Content scaffold** — appended to or created in the content target file. Test title: `{page-name} page - content`, where `{page-name}` is the class name with `Page` stripped and converted to kebab-case (`RegisterPage` → `register`, `PasswordResetPage` → `password-reset`, `ServiceStatisticsPage` → `service-statistics`).
+
+New file template:
+```typescript
+import { test, expect } from '@fixtures/base.fixture';
+import { {ClassName} } from '{importPath}';
+
+test.fixme('{page-name} page - content', { tag: '@regression' }, async ({ page }) => {
+  await page.goto({ClassName}.url);
+  const pageObject = new {ClassName}(page);
+  await expect(pageObject.heading).toBeVisible();
+  // TODO: Assert page content — additional headings, sections, links, tables, form fields.
+});
+```
+
+Append to existing file (import added separately if missing):
+```typescript
+
+test.fixme('{page-name} page - content', { tag: '@regression' }, async ({ page }) => {
+  await page.goto({ClassName}.url);
+  const pageObject = new {ClassName}(page);
+  await expect(pageObject.heading).toBeVisible();
+  // TODO: Assert page content — additional headings, sections, links, tables, form fields.
+});
+```
+
+**Accessibility scaffold** — appended inside the existing `test.describe('accessibility', ...)` block in `accessibility.spec.ts`, after both `for` loops. Only emit this when Step 4 did not flag the page as already covered.
+
+```typescript
+
+  test.fixme('{url}', async ({ page }) => {
+    await page.goto({ClassName}.url);
+    await expectNoAccessibilityViolations(page);
+    // TODO: Add {ClassName} to {PUBLIC|AUTHENTICATED}_PAGE_CLASSES to replace this standalone
+    // test with the data-driven loop above, or remove this comment once the test is finalised.
+  });
+```
+
+Add the page-class import at the top of `accessibility.spec.ts` if missing.
+
+**Visual regression scaffold** — appended at the bottom of `visual.spec.ts`. Test title: `{page-name} page visual regression`.
+
+```typescript
+
+test.fixme('{page-name} page visual regression', { tag: '@regression' }, async ({ page }) => {
+  await page.goto({ClassName}.url);
+  // TODO: Add a toHaveScreenshot() assertion. Mask any dynamic content (live data tables,
+  // SVG charts, #statsbar lists) so the baseline is deterministic.
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});
+```
+
+Add the page-class import at the top of `visual.spec.ts` if missing.
+
+**Step 8 — Update README.md for new spec files**
+
+If Step 7 **created** any new spec files, update `README.md`:
+
+1. Add the file to the "Single test file" run list under "Running tests".
+2. Add an entry to the spec file description list under "Architecture → Directory structure → `tests/`".
+3. Add the file to the "Test tags" table under `@regression`.
+
+If no new files were created, do not touch `README.md`.
+
+**Step 9 — Do not flip the coverage matrix**
+
+Do **not** edit `coverage-matrix.json`. Scaffolds are unfinished tests; the matrix should only flip to `true` once the scaffold is replaced with real, passing assertions.
+
+**Step 10 — Summary**
+
+Print a summary in this shape:
+
+```
+Scaffolded for {url} ({ClassName}):
+- content: {created|appended|skipped} → tests/{file}
+- accessibility: {appended|skipped-data-driven|skipped-already-exists} → tests/accessibility.spec.ts
+- visualRegression: {appended|skipped} → tests/visual.spec.ts
+
+Warnings:
+- (any data-driven conflict from Step 4)
+- (any PreviouslyAddedPage flag)
+- (any duplicate-skip message from Step 6)
+
+Next steps:
+- Replace each test.fixme() with test() once assertions are filled in.
+- Flip the corresponding value in coverage-matrix.json to true in the same commit that adds real assertions.
+- Run `npx playwright test tests/{file}` to verify.
+```

--- a/.claude/skills/generate-test/SKILL.md
+++ b/.claude/skills/generate-test/SKILL.md
@@ -84,14 +84,14 @@ For each target file:
 
 All scaffolds are `test.fixme()` so unfinished scaffolds do not run in CI. The user replaces `fixme` with `test` once the assertions are filled in.
 
-**Content scaffold** — appended to or created in the content target file. Test title: `{pageName} page - content`, where `{pageName}` is the class name with `Page` stripped and split from camelCase into lowercase space-separated words (`RegisterPage` → `register`, `PasswordResetPage` → `password reset`, `ServiceStatisticsPage` → `service statistics`). This matches the title format produced by `/generate-stubs` so the Step 6 duplicate guard catches stubs planted by either skill.
+**Content scaffold** — appended to or created in the content target file. Test title: `{pageName} - content`, where `{pageName}` is a human-readable name derived from the class — strip `Page`, split from camelCase into lowercase space-separated words, and append `page` (`RegisterPage` → `register page`, `PasswordResetPage` → `password reset page`, `ServiceStatisticsPage` → `service statistics page`). Template and derivation both match `/generate-stubs` exactly so the Step 6 duplicate guard catches stubs planted by either skill.
 
 New file template:
 ```typescript
 import { test, expect } from '@fixtures/base.fixture';
 import { {ClassName} } from '{importPath}';
 
-test.fixme('{pageName} page - content', { tag: '@regression' }, async ({ page }) => {
+test.fixme('{pageName} - content', { tag: '@regression' }, async ({ page }) => {
   await page.goto({ClassName}.url);
   const pageObject = new {ClassName}(page);
   await expect(pageObject.heading).toBeVisible();
@@ -102,7 +102,7 @@ test.fixme('{pageName} page - content', { tag: '@regression' }, async ({ page })
 Append to existing file (import added separately if missing):
 ```typescript
 
-test.fixme('{pageName} page - content', { tag: '@regression' }, async ({ page }) => {
+test.fixme('{pageName} - content', { tag: '@regression' }, async ({ page }) => {
   await page.goto({ClassName}.url);
   const pageObject = new {ClassName}(page);
   await expect(pageObject.heading).toBeVisible();
@@ -124,11 +124,11 @@ test.fixme('{pageName} page - content', { tag: '@regression' }, async ({ page })
 
 Add the page-class import at the top of `accessibility.spec.ts` if missing.
 
-**Visual regression scaffold** — appended at the bottom of `visual.spec.ts`. Test title: `{pageName} page visual regression`, using the same `{pageName}` derivation as the content scaffold.
+**Visual regression scaffold** — appended at the bottom of `visual.spec.ts`. Test title: `{pageName} visual regression`, using the same `{pageName}` derivation as the content scaffold (so `RegisterPage` → `register page visual regression`).
 
 ```typescript
 
-test.fixme('{pageName} page visual regression', { tag: '@regression' }, async ({ page }) => {
+test.fixme('{pageName} visual regression', { tag: '@regression' }, async ({ page }) => {
   await page.goto({ClassName}.url);
   // TODO: Add a toHaveScreenshot() assertion. Mask any dynamic content (live data tables,
   // SVG charts, #statsbar lists) so the baseline is deterministic.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Multi-language, multi-framework end-to-end test suite for [Orwell Stat](https://
 
 ## Claude skills
 
-Four project-scoped skills are available in Claude Code (stored in `.claude/skills/`) and appear in the VSCode extension `/` menu:
+Five project-scoped skills are available in Claude Code (stored in `.claude/skills/`) and appear in the VSCode extension `/` menu:
 
 | Skill              | Usage                         | What it does                                                                                                                                                                                                       |
 | ------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -12,6 +12,7 @@ Four project-scoped skills are available in Claude Code (stored in `.claude/skil
 | `/create-issue`    | `/create-issue <description>` | Scaffolds a GitHub issue in the documented format (User Story / Context / AC / Implementation Hint / DoD / milestone) and creates it via `gh issue create`                                                         |
 | `/code-review`     | `/code-review`                | Works through every item on the code review checklist from `.claude/skills/code-review/SKILL.md`, applies general diff checks and CI workflow checks, and explicitly states a finding (pass / fail / N/A) for each item |
 | `/generate-stubs`  | `/generate-stubs`             | Reads `coverage-matrix.json`, finds uncovered page-category combinations (excluding `title` and `api`), and generates `test.fixme()` stubs in the appropriate spec files                                           |
+| `/generate-test`   | `/generate-test <page>`       | Scaffolds `test.fixme()` blocks for one page's content / accessibility / visual-regression gaps in `coverage-matrix.json`, appending to existing spec files (never overwriting) or creating new ones                |
 
 ## Repository structure
 


### PR DESCRIPTION
Closes #174

## Summary

Adds a new project-scoped skill `/generate-test <page>` that scaffolds Playwright `test.fixme()` blocks for a single page's content / accessibility / visual-regression gaps recorded in `playwright/typescript/coverage-matrix.json`.

Complements `/generate-stubs` (which sweeps the whole matrix) by targeting one page at a time with richer scaffolding: imports, navigation to the page's `url`, a placeholder assertion on the page object's `heading` getter, and a TODO comment guiding the user to the real assertions.

The skill never overwrites existing files — it appends to existing spec files (with a duplicate-test guard) and only creates new files when the target does not exist. Data-driven accessibility coverage is respected: if the page is already in `PUBLIC_PAGE_CLASSES` or `AUTHENTICATED_PAGE_CLASSES`, the skill skips the accessibility scaffold and warns the user to flip the matrix value instead. `coverage-matrix.json` is intentionally not modified by the skill — values should only flip to `true` once the scaffold is replaced with real passing assertions.

## Changes

- `.claude/skills/generate-test/SKILL.md` — new skill (10 steps: resolve identifier, read matrix, identify gaps, accessibility conflict check, target-file mapping, preflight guard against overwrite/duplicate, generate scaffolds, README update for new files, no-flip rule, summary output)
- `README.md` — add the skill to the Claude skills table, update the count from "Four" to "Five"

## Test plan

- [x] `.claude/skills/generate-test/SKILL.md` file exists and carries a valid frontmatter `description`
- [x] Skill is discoverable by the Claude Code loader (appears in the loaded-skills listing as `generate-test`)
- [x] `README.md` Claude skills table includes a row for `/generate-test`
- [x] Skill prose instructs that existing files are appended to, never overwritten, with an existence check before any Write call
- [x] Skill prose instructs never to flip values in `coverage-matrix.json`
- [x] Templates in the skill use project-correct imports (`@fixtures/base.fixture`, `@pages/public`, `@pages/authenticated`), valid Playwright API calls (`test.fixme`, `expect`, `page.goto`, `toBeVisible`, `toHaveScreenshot`), and the `@regression` tag
- [x] Skill respects data-driven accessibility coverage (warns when the page is in `PUBLIC_PAGE_CLASSES`/`AUTHENTICATED_PAGE_CLASSES`)
- [ ] Reviewer invokes `/generate-test register` in a scratch checkout and confirms: scaffolds are generated for `content` and `visualRegression`, no accessibility scaffold is written (accessibility is already `true` in the matrix), and `register.spec.ts` is created rather than overwriting anything
- [ ] Reviewer invokes `/generate-test home` (all gaps already closed) and confirms the skill exits with "No content/accessibility/visual gaps — nothing to scaffold."
- [ ] Reviewer invokes `/generate-test zone-admin` (all three categories are gaps and page is in `AUTHENTICATED_PAGE_CLASSES`) and confirms the accessibility scaffold is skipped with the data-driven warning, while content and visual scaffolds are emitted
