### PR TITLE
#242 Gate test workflows on latest decisional review state

### DIFF
--- a/.github/workflows/bruno.yml
+++ b/.github/workflows/bruno.yml
@@ -34,9 +34,19 @@ jobs:
             echo "approved=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          COUNT=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.state == "APPROVED")] | length')
-          if [ "$COUNT" -gt 0 ]; then
+          # Reviews are append-only history. A user's latest decisional review
+          # (APPROVED/CHANGES_REQUESTED/DISMISSED) is authoritative; COMMENTED is ignored.
+          # Gate opens only if ≥1 user's latest is APPROVED and no user's latest is CHANGES_REQUESTED.
+          # `gh api --paginate` merges pages into a single array; `--jq` is not passed because
+          # it would apply per-page and break the group_by across page boundaries.
+          RESULT=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" \
+            | jq '
+              [.[] | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")]
+              | group_by(.user.login)
+              | map(max_by(.submitted_at) | .state)
+              | (any(. == "APPROVED")) and (all(. != "CHANGES_REQUESTED"))
+            ')
+          if [ "$RESULT" = "true" ]; then
             echo "approved=true" >> "$GITHUB_OUTPUT"
           else
             echo "approved=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -90,9 +90,19 @@ jobs:
             echo "approved=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          COUNT=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.state == "APPROVED")] | length')
-          if [ "$COUNT" -gt 0 ]; then
+          # Reviews are append-only history. A user's latest decisional review
+          # (APPROVED/CHANGES_REQUESTED/DISMISSED) is authoritative; COMMENTED is ignored.
+          # Gate opens only if ≥1 user's latest is APPROVED and no user's latest is CHANGES_REQUESTED.
+          # `gh api --paginate` merges pages into a single array; `--jq` is not passed because
+          # it would apply per-page and break the group_by across page boundaries.
+          RESULT=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" \
+            | jq '
+              [.[] | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")]
+              | group_by(.user.login)
+              | map(max_by(.submitted_at) | .state)
+              | (any(. == "APPROVED")) and (all(. != "CHANGES_REQUESTED"))
+            ')
+          if [ "$RESULT" = "true" ]; then
             echo "approved=true" >> "$GITHUB_OUTPUT"
           else
             echo "approved=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #242

## Summary
Replaces the count-based PR approval check in `bruno.yml` and `playwright-typescript.yml` with latest-per-user decisional-review logic, so a CHANGES_REQUESTED review actually blocks the test job (the previous logic counted every historical APPROVED, including ones superseded by later CHANGES_REQUESTED).

The fix:
- Filters reviews to APPROVED / CHANGES_REQUESTED / DISMISSED (COMMENTED ignored)
- Groups by `user.login`, takes each user's latest by `submitted_at`
- Opens the gate only if ≥1 user's latest is APPROVED and no user's latest is CHANGES_REQUESTED
- Uses `gh api --paginate ... | jq` so the group_by sees the full review history (`gh --jq` runs per-page and would break the grouping)

## Test plan
- [x] jq verified against PR #241's full review history → returns `true` (current HEAD has APPROVED as the latest review)
- [x] jq verified against PR #241 snapshot at 12:47:06Z (the buggy run) → returns `false` (CHANGES_REQUESTED was the latest review at that moment)
- [x] Synthetic case: only COMMENTED reviews → `false`
- [x] Synthetic case: empty reviews → `false`
- [x] Synthetic case: two approvers + one CHANGES_REQUESTED from a third user → `false`
- [x] Synthetic case: same user APPROVED then COMMENTED → `true`
- [x] Synthetic case: same user APPROVED then DISMISSED → `false`
- [x] `gh api --paginate ... | jq 'length'` returns the full count (7 on PR #241, vs `--jq 'length'` which returns per-page counts)
- [x] `--paginate` with `per_page=100` requires only one API call for typical PRs
- [x] **Live:** this PR's first `pull_request` run (13:20:18Z) found 0 reviews → `check-approval` returned false → Bruno `test` job **SKIPPED** (confirms the gate is now properly closed by default — previously it would have run with stale APPROVEDs from any prior PR pattern)
- [x] **Live:** after Claude approved at 13:21:11Z, the `pull_request_review` re-trigger ran `check-approval` → returned true → Bruno `test` job **SUCCESS**
- [ ] Live: CHANGES_REQUESTED scenario isn't naturally exercised on this PR — verified by jq scenario above plus historical PR #241 snapshot
