### PR TITLE
#259 Backfill missing reviewer signature line via workflow post-step

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,6 +16,11 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+    env:
+      # Single source of truth — referenced by the reviewer prompt mandate
+      # and by the Backfill review signature step. They must stay byte-identical
+      # or the post-step's string compare silently no-ops.
+      SIGNATURE: "_Reviewed by ${{ vars.ANTHROPIC_BASE_URL != '' && 'proxy' || 'native Anthropic' }}/${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL || 'claude-sonnet-4-6' }}_"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -90,10 +95,53 @@ jobs:
                  in the diff — do not invent issues.
 
             Append this as the final line of the review body, verbatim:
-            `_Reviewed by ${{ vars.ANTHROPIC_BASE_URL != '' && 'proxy' || 'native Anthropic' }}/${{ vars.ANTHROPIC_DEFAULT_SONNET_MODEL || 'claude-sonnet-4-6' }}_`
+            `${{ env.SIGNATURE }}`
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # Backfills the signature line mandated by the prompt above (line ~93)
+      # when the model fails to append it. See issue #259.
+      - name: Backfill review signature
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.REVIEW_GUARD_PAT || secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          # SIGNATURE inherited from job-level env (single source of truth)
+        run: |
+          set -u
+          reviews_json=$(gh api \
+            "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" \
+            --jq "[.[] | select(.user.login==\"claude[bot]\" and .commit_id==\"${HEAD_SHA}\")] | sort_by(.submitted_at) | reverse")
+          count=$(jq 'length' <<<"$reviews_json")
+          if [ "$count" = "0" ]; then
+            echo "No claude[bot] reviews at ${HEAD_SHA}; nothing to guard."
+            exit 0
+          fi
+          target=$(jq -c 'map(select(.body|length>0)) | .[0] // empty' <<<"$reviews_json")
+          if [ -z "$target" ]; then
+            echo "::warning::No non-empty claude[bot] review at ${HEAD_SHA}; skipping."
+            exit 0
+          fi
+          target_id=$(jq -r '.id' <<<"$target")
+          target_body=$(jq -r '.body' <<<"$target")
+          last_line=$(printf '%s' "$target_body" | awk 'NF{line=$0} END{print line}')
+          if [ "$last_line" = "$SIGNATURE" ]; then
+            echo "Signature present on review ${target_id}; no-op."
+            exit 0
+          fi
+          echo "::warning::Review ${target_id} missing signature; backfilling."
+          new_body="${target_body}"$'\n\n'"${SIGNATURE}"
+          if ! jq -n --arg b "$new_body" '{body:$b}' | gh api \
+              --method PUT \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${target_id}" \
+              --input - >/dev/null; then
+            echo "::error::PUT /reviews/${target_id} failed — GITHUB_TOKEN likely lacks cross-App edit rights. Create a fine-grained PAT with Pull requests: read & write, store as secret REVIEW_GUARD_PAT."
+          fi
 
       - name: Report reviewer configuration
         if: always()


### PR DESCRIPTION
## Summary

Adds a deterministic post-step to `.github/workflows/claude-code-review.yml` that backfills the mandated `_Reviewed by <provider>/<model>_` signature line when the reviewer model fails to append it. Same model, same prompt, two runs on PR #258 produced one review with the signature and one without — this guard makes the signature presence guaranteed regardless of model compliance.

The signature expression has also been hoisted to a job-level `env: SIGNATURE` so the reviewer prompt mandate (line ~98) and the backfill string compare reference one source. They must stay byte-identical or the comparison silently no-ops.

Closes #259

## Test plan

- [x] `/security-review` — clean across two runs (initial + post-simplify), no findings.
- [x] `/simplify` — converged after one round (SIGNATURE hoist applied; "drop count check" deferred to preserve AC-distinct messages; "extract to script" deferred under threshold).
- [x] Code review checklist — every applicable item passes; CI workflow checks (`timeout-minutes`, `actions/*` pinning, secret scoping, no echoed tokens) all pass.
- [x] Acceptance criteria — all 5 implemented and one verified live (see below).
- [x] Local `act` smoke test — N/A. README:740 documents this workflow as not supported for `act` (requires real GitHub PR context).
- [x] **Live verification on this PR's own workflow run (run [24475262532](https://github.com/hubertgajewski/orwellstat/actions/runs/24475262532)):**
  - `Backfill review signature` step conclusion: ✅ success.
  - Job-level `env.SIGNATURE` resolved correctly: `_Reviewed by proxy/@preset/minimax-minimax-m2-7-no-thinking_`.
  - `GH_TOKEN` masked as `***` in logs, never echoed.
  - **AC #3 verified live**: action posted no review (see "Caveat" below); the post-step took the no-data branch and logged `"No claude[bot] reviews at 48cc6c6...; nothing to guard."` then exited 0.
- [ ] **Post-merge verification (cannot be done on this PR — see Caveat)**: on the next unrelated PR after merge, observe whether the model includes the signature → expect log `"Signature present on review <id>; no-op."` with no PUT; or omits it → expect `::warning::` + successful PUT under `secrets.GITHUB_TOKEN`. If the PUT 403s, the step emits `::error::` and the job remains green (`continue-on-error: true`); follow-up: create `REVIEW_GUARD_PAT` fine-grained PAT (Pull requests: read & write) and re-trigger.
- [ ] **Idempotency post-merge**: re-trigger the workflow on the same SHA of an unrelated PR; expect `"Signature present; no-op."` on the second run regardless of which path the first run took.

## Caveat — why the live signature paths can't be verified on this PR

When this PR's own `claude-code-review.yml` workflow ran (run [24475262532](https://github.com/hubertgajewski/orwellstat/actions/runs/24475262532)), the `anthropics/claude-code-action@v1` step failed with HTTP 401:

> `Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch. If you're seeing this on a PR when you first add a code review workflow file to your repository, this is normal and you should ignore this error.`

This is a known sandbox protection by the Anthropic Claude App: any PR that modifies the reviewer workflow file itself is refused execution by the App until the change is on `main`. The signature-present and signature-missing paths therefore can only be exercised post-merge, on subsequent unrelated PRs. AC #3 (no-reviews branch) was reachable because the action's failure left zero reviews on the PR — this validated the only AC that doesn't require the action to actually post a review.

## Notes

- v1 deliberately ships signature backfill only. The orphan empty-review pattern (`gh pr review --comment -b ""` followed by the real `--request-changes`) seen on PR #258 review `4115999363` is **not** addressed: submitted COMMENTED reviews can't be deleted or dismissed via the GitHub API, only overwritten — and a "superseded" marker is itself a permanent comment, trading one cosmetic orphan for another. Defer until the pattern recurs.
- The cross-App edit capability of `GITHUB_TOKEN` (the `github-actions[bot]` App) on reviews submitted by `claude[bot]` (a different GitHub App) is not documented. Empirical verification was done with a repo-admin PAT (succeeded) but not with `GITHUB_TOKEN` itself. The fallback `secrets.REVIEW_GUARD_PAT || secrets.GITHUB_TOKEN` and the `::error::` annotation make the failure path observable and recoverable without re-editing the workflow.
