### PR TITLE
[throwaway] Reviewer backfill probe — do not merge

### DIFF
--- a/playwright/typescript/tests/_reviewer-backfill-probe.spec.ts
+++ b/playwright/typescript/tests/_reviewer-backfill-probe.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test.fixme('reviewer backfill probe - deliberately flawed for PR #260 validation', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await page.waitForTimeout(1000);
+  expect(true).toBeTruthy();
+});


### PR DESCRIPTION
## Summary

**Throwaway PR for live validation of the signature backfill step shipped in PR #260.** Do NOT merge. Will be closed after observation.

This PR adds a single spec file (`_reviewer-backfill-probe.spec.ts`) with **four deliberate violations** of the reviewer's criteria, chosen to maximise the likelihood that the model produces a non-trivial CHANGES_REQUESTED body (so the Backfill step has something real to PUT against):

1. Imports `test, expect` from `@playwright/test` instead of the project fixture (`@fixtures/base.fixture` / `@fixtures/api.fixture`).
2. Uses `page.waitForTimeout(1000)` — a flakiness red-flag explicitly listed in the reviewer prompt.
3. Uses `expect(true).toBeTruthy()` — non-meaningful assertion, explicitly called out.
4. Has no `@smoke` / `@regression` tag — required per the test-tag convention documented in README.

The test is `test.fixme()`-guarded so it never runs in CI, even if someone approves it by mistake.

## What we're observing

When `claude-code-review.yml` fires on this PR, the new `Backfill review signature` step will take one of three branches:

- `"Signature present on review <id>; no-op."` → model complied; signature-path validation via AC #1.
- `::warning::Review <id> missing signature; backfilling.` + successful PUT → cross-App auth works under `secrets.GITHUB_TOKEN`; AC #2 validated.
- `::warning::` + `::error::PUT /reviews/<id> failed — ... REVIEW_GUARD_PAT.` → cross-App auth insufficient; follow-up: create `REVIEW_GUARD_PAT` fine-grained PAT.

Closes #259 (validation continuation; the primary closure happened on PR #260 merge).
