### PR TITLE
#262 Unmask reviewer action output to expose native-Anthropic failure URL

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,6 +56,9 @@ jobs:
         with:
           anthropic_api_key: ${{ (vars.ANTHROPIC_BASE_URL != '' && secrets.OPENROUTER_API_KEY) || (vars.ANTHROPIC_BASE_URL == '' && secrets.ANTHROPIC_API_KEY) || '' }}
           track_progress: false
+          # Diagnostic — unmask the URL on connection failures so issue #262
+          # can root-cause the native-Anthropic auth path. Remove once resolved.
+          show_full_output: true
           prompt: |
             You are executing a code review of pull request #${{ github.event.pull_request.number }}
             in ${{ github.repository }}. This is an autonomous task: complete it using tool calls


### PR DESCRIPTION
## Summary

- Step 1 of the debugging plan in #262. Adds `show_full_output: true` to the `anthropics/claude-code-action@v1` step so the next native-Anthropic failure surfaces the real URL instead of `"full output hidden for security"`.
- Scoped to that single flag plus a two-line comment explaining the diagnostic purpose. Removal is tracked as a later DoD item on the issue.

## Why this doesn't close #262

The issue's Implementation Hint lays out a five-step debugging sequence that cannot collapse into one PR:

1. **This PR** — unmask the action output so the failing URL becomes visible.
2. Follow-up test PR with `vars.ANTHROPIC_BASE_URL` / `ANTHROPIC_DEFAULT_SONNET_MODEL` / `ANTHROPIC_DEFAULT_HAIKU_MODEL` unset, to trigger the native path and observe the unmasked URL.
3. Depending on which host appears (managed-agents OAuth endpoint vs `api.anthropic.com`), either provision `CLAUDE_CODE_OAUTH_TOKEN` or rotate `ANTHROPIC_API_KEY`, and update the auth-convention comment block at `claude-code-review.yml` lines 40–49.
4. Remove `show_full_output: true` once the root cause is understood.
5. Restore the repo vars to OR+Minimax.

Accordingly this PR uses `Contributes to #262` rather than `Closes`.

Heads up: the reviewer workflow on this PR will 401 on the workflow-validation sandbox — `claude-code-action` refuses to run on a PR that edits its own workflow file. That is expected. Merge anyway; verification happens on the next unrelated PR.

Contributes to #262

## Test plan

- [x] `git diff origin/main -- .github/workflows/claude-code-review.yml` shows only the three-line addition (one `show_full_output: true` plus the two-line comment) and nothing else.
- [x] YAML parses on push (GitHub surfaced no workflow-syntax error on `git push`).
- [x] `/security-review` run on the diff returned no HIGH/MEDIUM findings; GitHub Actions secret-masking is unaffected by `show_full_output` and continues to redact `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `REVIEW_GUARD_PAT`, and `GITHUB_TOKEN`.
- [ ] After merge: on the next unrelated PR (where workflow-validation will not 401), with the three `ANTHROPIC_*` repo vars left unset, confirm the `claude-code-action` step logs the failing URL verbatim instead of `"full output hidden for security"`. Record whether the URL points at the managed-agents OAuth endpoint or `api.anthropic.com` so the follow-up PR can pick the right auth fix.
- [ ] Follow-up PR: implement the auth fix identified above, remove `show_full_output: true`, restore the OR+Minimax repo vars, and verify that a review posted by `claude[bot]` on a native-path PR ends with the signature `_Reviewed by native Anthropic/claude-sonnet-4-6_` — at which point #262 closes.
