### PR TITLE
#262 Remove diagnostic show_full_output after native path confirmed working

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,9 +56,6 @@ jobs:
         with:
           anthropic_api_key: ${{ (vars.ANTHROPIC_BASE_URL != '' && secrets.OPENROUTER_API_KEY) || (vars.ANTHROPIC_BASE_URL == '' && secrets.ANTHROPIC_API_KEY) || '' }}
           track_progress: false
-          # Diagnostic — unmask the URL on connection failures so issue #262
-          # can root-cause the native-Anthropic auth path. Remove once resolved.
-          show_full_output: true
           prompt: |
             You are executing a code review of pull request #${{ github.event.pull_request.number }}
             in ${{ github.repository }}. This is an autonomous task: complete it using tool calls


### PR DESCRIPTION
## Summary

Removes the three diagnostic lines added to `.github/workflows/claude-code-review.yml` in #264. Native-Anthropic path has been confirmed working end-to-end; the flag is no longer needed.

Closes #262

## Root cause

Original "Unable to connect" failure on 2026-04-15 (run 24478516759) was transient, not a persistent config bug. With the diagnostic flag in place I flipped the three `ANTHROPIC_*` repo vars empty and re-triggered the reviewer on an unrelated PR (#268). Run 24496195761 authenticated against `api.anthropic.com` on first attempt (~90 seconds — no 3×135s retry loop) and posted an APPROVED review ending with `_Reviewed by native Anthropic/claude-sonnet-4-6_`, exactly matching the DoD signature on #262. Vars were restored to OR+Minimax immediately afterwards.

Auth-convention comment block at workflow lines 40–49 needs **no changes** — the path works with `anthropic_api_key: secrets.ANTHROPIC_API_KEY` and all other auth envs empty, exactly as the comment already states. `CLAUDE_CODE_OAUTH_TOKEN` is not required.

## Definition of Done on #262

| Item | Status |
|---|---|
| Native path proven end-to-end | ✅ APPROVED review on #268 |
| Signature line `_Reviewed by native Anthropic/claude-sonnet-4-6_` | ✅ exact match in #268 review body |
| Workflow comment block reflects final auth contract | ✅ already accurate, no edit |
| `show_full_output: true` not left in production workflow | ✅ this PR |
| Repo vars restored to OR+Minimax | ✅ restored on 2026-04-16 right after the diagnostic run |

## Test plan

- [x] `git diff origin/main -- .github/workflows/claude-code-review.yml` shows only the three-line removal (the comment pair and the `show_full_output: true` entry) and nothing else.
- [x] YAML parses on push (GitHub accepted the workflow file without error).
- [x] The diagnostic run of the reviewer on #268 (run 24496195761, native-Anthropic path with empty vars) authenticated on first attempt, posted an APPROVED review, and emitted the mandated signature verbatim. Log archived; URL: https://github.com/hubertgajewski/orwellstat/actions/runs/24496195761.
- [x] `gh variable list` confirms `ANTHROPIC_BASE_URL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL` are restored to their pre-diagnostic values.
- [ ] Reviewer on this PR: expected to 401 on the workflow-validation sandbox (same upstream guard as #264 — any PR that edits `claude-code-review.yml`, including this revert, differs from main and trips the App's self-workflow-edit refusal). Merge anyway; OR+Minimax on `main` is unaffected by this PR.
- [ ] CI: no other workflows changed; existing jobs must continue to pass.
