### PR TITLE
#281 Document rationale on Chromium-only test.skip() calls

### DIFF
--- a/playwright/typescript/tests/accessibility.spec.ts
+++ b/playwright/typescript/tests/accessibility.spec.ts
@@ -6,7 +6,7 @@ import { AUTHENTICATED_PAGE_CLASSES } from '@pages/authenticated/index';
 test.describe('accessibility', { tag: '@regression' }, () => {
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
-    'Accessibility tests run on Chromium only'
+    'Chromium-only: axe-core analyzes the DOM tree, so results are engine-independent. Running on other browsers burns CI minutes for zero added signal.'
   );
 
   for (const PageClass of PUBLIC_PAGE_CLASSES) {

--- a/playwright/typescript/tests/network-mocking.spec.ts
+++ b/playwright/typescript/tests/network-mocking.spec.ts
@@ -14,7 +14,7 @@ type W3cResponse = {
 test.describe('network mocking with page.route()', { tag: '@regression' }, () => {
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
-    'Network mocking tests run on Chromium only'
+    'Chromium-only: page.route() is a Playwright DevTools-protocol abstraction — behavior is uniform across supported browsers, and the assertion is on the mock hit, not rendering.'
   );
 
   test('SVG chart renders with mocked static response', async ({ page }) => {

--- a/playwright/typescript/tests/validation.spec.ts
+++ b/playwright/typescript/tests/validation.spec.ts
@@ -7,7 +7,7 @@ import { HomePage } from '@pages/public/home.page';
 test.describe('markup and CSS validation', { tag: '@regression' }, () => {
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
-    'Validation tests run on Chromium only'
+    'Chromium-only: the test is a pure HTTP POST to the XHTML validator; no browser engine involvement, so other browsers add no signal.'
   );
 
   const xhtmlHeaders = { Accept: 'application/xhtml+xml' };


### PR DESCRIPTION
## Summary

Replaces the generic `"X tests run on Chromium only"` message in three specs with rationale explaining *why* cross-browser execution adds no signal. No predicate change, no test-behaviour change.

- `accessibility.spec.ts` — axe-core analyzes the DOM tree, so results are engine-independent.
- `validation.spec.ts` — the test is a pure HTTP POST to the XHTML validator; no browser engine involvement.
- `network-mocking.spec.ts` — `page.route()` is a Playwright DevTools-protocol abstraction; behavior is uniform across supported browsers, and the assertion is on the mock hit, not rendering.

Closes #281.

## Test plan

- [x] `npx prettier --check tests/accessibility.spec.ts tests/validation.spec.ts tests/network-mocking.spec.ts` — passes
- [x] `npx playwright test --project=chromium --list tests/accessibility.spec.ts tests/validation.spec.ts tests/network-mocking.spec.ts` — 26 tests listed (unchanged)
- [x] `npx playwright test --project=firefox tests/accessibility.spec.ts` — 11 skipped, 1 setup passed (skip count unchanged; new rationale string applied)
- [ ] CI: all required status checks green
