### PR TITLE
#278 Extend .gitignore for .coverage, Claude lockfile, and Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,12 @@ test-results/
 # GitHub Actions self-hosted runner binaries and config (if downloaded inside repo)
 _work/
 runner/
+
+# Coverage
+.coverage
+
+# Claude Code runtime
+.claude/scheduled_tasks.lock
+
+# Python bytecode
+scripts/__pycache__/


### PR DESCRIPTION
## Summary

Extends `.gitignore` with three regenerable artifacts that keep surfacing as untracked files: pytest coverage binary (`.coverage`), Claude Code runtime lockfile (`.claude/scheduled_tasks.lock`), and Python bytecode cache (`scripts/__pycache__/`).

Non-goals (intentionally excluded): `*.png` at repo root and `review-*.md/txt` at repo root — those are human-created, case-by-case decisions.

Closes #278
Contributes to #277

## Test plan

- [x] `git check-ignore -v .coverage` resolves to `.gitignore:23`
- [x] `git check-ignore -v .claude/scheduled_tasks.lock` resolves to `.gitignore:26`
- [x] `git check-ignore -v scripts/__pycache__/` resolves to `.gitignore:29`
- [x] Before the change, `.claude/scheduled_tasks.lock` and `scripts/__pycache__/` appeared in `git status`; after the change they no longer appear
- [x] Spot-check: a throwaway `spot-check.png` at repo root is NOT ignored (`git check-ignore` reports no match); `review-*.md` files at repo root still appear in `git status`
- [x] `.env` (line 1) and `bruno/.env` (line 9) remain gitignored — no regressions
- [x] CI workflows pass on this branch
