### PR TITLE
Verify #293 — trivial-diff reviewer fallback via *.swp gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .auth/
 .idea/
 *.bak
+*.swp
 .DS_Store
 .claude/settings.local.json
 .playwright-mcp/


### PR DESCRIPTION
## Summary

Throwaway verification PR for #293 (merged in #296). Adds a single line to `.gitignore` (`*.swp` for vim swap files) — intentionally the same failure-trigger profile as PR #292 (trivial `.gitignore` change) that caused the OpenRouter Minimax preset to skip the `gh pr review` mandate and fire the #284 guard.

## Expected outcome

With the two-tier retry now on `main`, this PR's reviewer workflow should resolve green via **one of two paths**:

1. **Primary posts a review** — Minimax handles the trivial diff correctly this time, `Check if fallback needed` reports `need_fallback=false`, fallback is skipped, guard exits 0.
2. **Primary no-ops, fallback fires** — Minimax skips the mandate (the #293 failure mode reproducing), `Check if fallback needed` sets `need_fallback=true`, native Sonnet 4.6 runs as fallback and posts the review, guard exits 0.

Either path is a pass. The #284 guard firing red (as it would have on PR #292) is the failure we're proving no longer happens.

## Test plan

- [ ] Reviewer workflow completes `success` (not `failure`) on this PR
- [ ] A `claude[bot]` review exists at `HEAD_SHA` with either the primary signature or the fallback signature
- [ ] If the fallback signature is present: record the OpenRouter delta on #293 and note the no-op reproduction
- [ ] After verification: close this PR without merging (or merge if the change is desirable — `*.swp` is a sensible gitignore rule)

Ref #293, #284
