### PR TITLE
#291 Drop self-healing fixes whose broken selector is not referenced by any failed test

### DIFF
--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -754,16 +754,42 @@ def main(data_dir: str) -> None:
         print(f"[self-healing] Skipping: self-healing branch ({head_branch})")
         return
 
+    # Walk results.json artifacts once so Step 2 and the cross-check guard
+    # below share the same parsed failed-test data.
+    all_failed_tests: list[tuple[Path, list[FailedTest]]] = [
+        (rf, extract_failed_tests(rf)) for rf in data_path.rglob("results.json")
+    ]
+    # Authoritative set of failed-test error messages.  Any fix whose
+    # broken_selector does not appear in at least one of these is stale (e.g.
+    # a selector-fix.md left over from a prior run that wasn't cleaned up)
+    # and must be dropped — see issue #291.
+    failed_error_messages: list[str] = [
+        t.error_message for _, tests in all_failed_tests for t in tests
+    ]
+
+    def _drop_unreferenced_fixes(candidates: list[SelectorFix]) -> list[SelectorFix]:
+        kept = [
+            f for f in candidates
+            if any(f.broken_selector in msg for msg in failed_error_messages)
+        ]
+        dropped = len(candidates) - len(kept)
+        if dropped:
+            print(
+                f"[self-healing] Dropped {dropped} fix(es) whose broken selector "
+                f"is not referenced by any failed test",
+                file=sys.stderr,
+            )
+        return kept
+
     # Step 1: Find pre-computed selector fixes
     fixes = find_selector_fixes(data_path)
     fixes = filter_by_confidence(fixes)
     fixes = deduplicate_fixes(fixes)
+    fixes = _drop_unreferenced_fixes(fixes)
 
     # Step 2: Fallback — check results.json for selector errors and call AI
     if not fixes:
-        results_files = list(data_path.rglob("results.json"))
-        for results_file in results_files:
-            failed_tests = extract_failed_tests(results_file)
+        for results_file, failed_tests in all_failed_tests:
             selector_failures = [t for t in failed_tests if is_selector_error(t.error_message)]
             for test in selector_failures:
                 test_dir = results_file.parent
@@ -785,10 +811,24 @@ def main(data_dir: str) -> None:
                     fixes.append(fix)
         fixes = filter_by_confidence(fixes)
         fixes = deduplicate_fixes(fixes)
+        fixes = _drop_unreferenced_fixes(fixes)
 
     if not fixes:
         print("[self-healing] No actionable selector fixes found")
         return
+
+    # Defensive re-check (issue #291): every fix reaching the output stage must
+    # reference a real failed test.  The cross-check guards in Steps 1 and 2
+    # already enforce this — this is a last-ditch safety net against future
+    # regressions in the filter pipeline.
+    for fix in fixes:
+        if not any(fix.broken_selector in msg for msg in failed_error_messages):
+            print(
+                f"[self-healing] Refusing to act: fix for {fix.broken_selector!r} "
+                "is not referenced by any failed-test error message",
+                file=sys.stderr,
+            )
+            return
 
     # Step 3: Determine output mode
     pr_number = find_pr_for_branch(head_branch)

--- a/scripts/test_self_healing.py
+++ b/scripts/test_self_healing.py
@@ -895,6 +895,196 @@ class TestErrorContextSupport(unittest.TestCase):
 
 
 # ===================================================================
+# Cross-check guard: drop stale fixes not referenced by any failed test
+# (issue #291 — PR #287 reproduction)
+# ===================================================================
+
+
+class TestCrossCheckDropsStaleFixes(unittest.TestCase):
+    """A stale selector-fix.md whose broken_selector is not present in any
+    failed-test error message (e.g. the file was left over from a prior run)
+    must be dropped; the script must log the drop, print "No actionable
+    selector fixes found", and never call post_comment or create_draft_pr.
+    """
+
+    STALE_FIX_MD = textwrap.dedent("""\
+        # Selector Fix Proposal
+
+        **Confidence:** high
+        **Broken selector:** `recentlyAddedLinks.nth(1)`
+        **Suggested selector:** `recentlyAddedLinks.nth(0)`
+
+        ## Explanation
+        Pre-computed fix from a prior run that no longer applies.""")
+
+    # results.json with only a visual-regression failure — no selector errors,
+    # and the error message does not mention `recentlyAddedLinks.nth(1)`.
+    VISUAL_ONLY_RESULTS = {
+        "suites": [
+            {
+                "title": "visual.spec.ts",
+                "file": "visual.spec.ts",
+                "specs": [
+                    {
+                        "title": "home page visual",
+                        "ok": False,
+                        "tests": [
+                            {
+                                "projectId": "webkit",
+                                "projectName": "webkit",
+                                "results": [
+                                    {
+                                        "status": "failed",
+                                        "errors": [
+                                            {
+                                                "message": (
+                                                    "Error: expect(page).toHaveScreenshot() failed\n"
+                                                    "  12345 pixels (ratio 0.01) are different."
+                                                )
+                                            }
+                                        ],
+                                        "attachments": [],
+                                    }
+                                ],
+                                "status": "unexpected",
+                            }
+                        ],
+                        "file": "visual.spec.ts",
+                        "line": 1,
+                        "column": 1,
+                    }
+                ],
+                "suites": [],
+            }
+        ]
+    }
+
+    # A fix whose broken_selector IS substring-present in the failed test's
+    # error message — must flow through to the comment stage.
+    VALID_FIX_MD = textwrap.dedent("""\
+        # Selector Fix Proposal
+
+        **Confidence:** high
+        **Broken selector:** `getByRole('link', { name: 'Home' })`
+        **Suggested selector:** `getByRole('link', { name: 'Start' })`
+
+        ## Explanation
+        Label changed from Home to Start.""")
+
+    SELECTOR_ERROR_RESULTS = {
+        "suites": [
+            {
+                "title": "nav.spec.ts",
+                "file": "nav.spec.ts",
+                "specs": [
+                    {
+                        "title": "nav",
+                        "ok": False,
+                        "tests": [
+                            {
+                                "projectId": "Chromium",
+                                "projectName": "Chromium",
+                                "results": [
+                                    {
+                                        "status": "failed",
+                                        "errors": [
+                                            {
+                                                "message": (
+                                                    "locator.click: Timeout 15000ms exceeded.\n"
+                                                    "Call log:\n"
+                                                    "  - waiting for getByRole('link', { name: 'Home' })\n"
+                                                )
+                                            }
+                                        ],
+                                        "attachments": [],
+                                    }
+                                ],
+                                "status": "unexpected",
+                            }
+                        ],
+                        "file": "nav.spec.ts",
+                        "line": 5,
+                        "column": 3,
+                    }
+                ],
+                "suites": [],
+            }
+        ]
+    }
+
+    @patch("self_healing.create_draft_pr")
+    @patch("self_healing.post_comment")
+    @patch("self_healing.find_pr_for_branch")
+    def test_drops_stale_fix_against_visual_only_failures(
+        self, mock_find_pr, mock_post_comment, mock_create_draft_pr
+    ):
+        import io
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            shard = tmp_path / "self-healing-data-webkit"
+            _write_file(shard / "selector-fix.md", self.STALE_FIX_MD)
+            _write_file(shard / "results.json", json.dumps(self.VISUAL_ONLY_RESULTS))
+
+            captured_stderr = io.StringIO()
+            captured_stdout = io.StringIO()
+            with patch("sys.stderr", captured_stderr), \
+                 patch("sys.stdout", captured_stdout):
+                self_healing.main(str(tmp_path))
+
+            stderr_text = captured_stderr.getvalue()
+            stdout_text = captured_stdout.getvalue()
+
+        # Guard fired with the drop count and the canonical message.
+        self.assertIn(
+            "Dropped 1 fix(es) whose broken selector is not referenced by any failed test",
+            stderr_text,
+        )
+        # Script took the "nothing to do" exit path.
+        self.assertIn("No actionable selector fixes found", stdout_text)
+        # No PR comment and no draft PR were created.
+        mock_post_comment.assert_not_called()
+        mock_create_draft_pr.assert_not_called()
+        # The script must not even look up a PR — it exits before Step 3.
+        mock_find_pr.assert_not_called()
+
+    @patch("self_healing.create_draft_pr")
+    @patch("self_healing.post_comment")
+    @patch("self_healing.count_self_healing_comments", return_value=0)
+    @patch("self_healing.find_pr_for_branch", return_value=42)
+    def test_valid_fix_flows_through_to_comment(
+        self, _mock_find_pr, _mock_count, mock_post_comment, mock_create_draft_pr
+    ):
+        """Happy path: a fix whose broken_selector appears in a failed test's
+        error message passes the cross-check guard and the defensive re-check,
+        reaching the PR-comment stage."""
+        import io
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            shard = tmp_path / "self-healing-data-chromium"
+            _write_file(shard / "selector-fix.md", self.VALID_FIX_MD)
+            _write_file(shard / "results.json", json.dumps(self.SELECTOR_ERROR_RESULTS))
+
+            captured_stderr = io.StringIO()
+            with patch("sys.stderr", captured_stderr):
+                self_healing.main(str(tmp_path))
+
+            stderr_text = captured_stderr.getvalue()
+
+        # Guard must NOT drop the valid fix.
+        self.assertNotIn("Dropped", stderr_text)
+        self.assertNotIn("Refusing to act", stderr_text)
+        # The comment is posted on the found PR.
+        mock_post_comment.assert_called_once()
+        posted_body = mock_post_comment.call_args[0][1]
+        self.assertIn("getByRole('link', { name: 'Home' })", posted_body)
+        self.assertIn("getByRole('link', { name: 'Start' })", posted_body)
+        # Draft PR path is not taken.
+        mock_create_draft_pr.assert_not_called()
+
+
+# ===================================================================
 # YAML-level guard verification (static analysis of workflow file)
 # ===================================================================
 


### PR DESCRIPTION
## Summary

- Add a cross-check guard in `scripts/self-healing.py` `main()` that walks every `results.json` under `<data-dir>`, builds the authoritative set of failed-test error messages, and drops any `SelectorFix` whose `broken_selector` is not substring-present in at least one of them. Applied after both Step 1 (pre-computed fixes) and Step 2 (AI fallback). Drops are logged to stderr with the count: `[self-healing] Dropped N fix(es) whose broken selector is not referenced by any failed test`.
- Add a defensive re-check at the output boundary (just before the `find_pr_for_branch` call) so any regression that lets a stale fix past the Step 1 / Step 2 guards is logged and causes the script to refuse to post, rather than generating a spurious PR comment.
- Consolidate the `data_path.rglob("results.json")` + `extract_failed_tests()` walk into a single traversal shared by the guard and by Step 2's AI-fallback loop (no duplicate work).
- Add two unit tests in `scripts/test_self_healing.py`:
  - `test_drops_stale_fix_against_visual_only_failures` — reproduces the PR #287 scenario (stale `selector-fix.md` for `recentlyAddedLinks.nth(1)` + `results.json` with only `expect(page).toHaveScreenshot() failed` errors). Asserts the drop log fires, the "No actionable selector fixes found" exit path runs, and `post_comment` / `create_draft_pr` / `find_pr_for_branch` are never called.
  - `test_valid_fix_flows_through_to_comment` — happy path: a fix whose `broken_selector` does appear in a failed-test error message passes the guard and the defensive re-check, and `post_comment` is called with the correct body.

Closes #291
Contributes to #273

## Test plan

- [x] `python3 scripts/test_self_healing.py` — all 75 tests pass locally, including the 2 new ones.
- [x] Manual replay of the PR #287 scenario (stale `selector-fix.md` for `recentlyAddedLinks.nth(1)` + `results.json` with only visual-regression failures) produces exactly `[self-healing] Dropped 1 fix(es) whose broken selector is not referenced by any failed test` on stderr and `[self-healing] No actionable selector fixes found` on stdout, with no comment/PR side effect.
- [x] Happy-path sanity check: a valid selector fix whose `broken_selector` appears in the failed test's error message still flows through to `post_comment` (verified via direct script run in `DRY_RUN=true` with a mocked `find_pr_for_branch`).
- [x] `coverage report` on `scripts/self-healing.py` after the new tests — added/changed lines are ~80% covered. The only uncovered lines are 826–831, the defensive re-check's violation branch, which is structurally unreachable in correct operation (it's a safety net that fires only if the Step-1/Step-2 guards regress).
- [ ] Follow-up CI observation on the next unrelated PR with real WebKit visual-baseline drift — self-healing bot stays silent (per issue DoD; cannot be verified until that PR exists).

## Notes

- The issue's Implementation Hint suggested per-fix drop logs; this PR aggregates to a single count-line on stderr to match the existing log style (Step 2's filter uses the same shape). The information content is equivalent and logs stay greppable.
- Guard behaviour on the edge case "no `results.json` in `<data-dir>`": `failed_error_messages` is `[]`, every `any(... in msg for msg in [])` is `False`, so every fix is dropped. That is correct — with no failed-test evidence we cannot justify posting a fix.