### PR TITLE
#306 Block direct Playwright CLI via PreToolUse Bash hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -157,6 +157,12 @@
             "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -q 'git commit'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 2; cd \"$ROOT/playwright/typescript\" || exit 2; OUT=$(npx tsc --noEmit 2>&1); TSC_EXIT=$?; if [ $TSC_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; OUT=$(npm run format:check 2>&1); FMT_EXIT=$?; if [ $FMT_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; fi",
             "timeout": 60,
             "statusMessage": "Verifying types and format before commit..."
+          },
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE '(^|[^a-zA-Z0-9_-])playwright[[:space:]]+test([^a-zA-Z0-9_-]|$)'; then echo 'BLOCKED: direct Playwright CLI is forbidden. Use mcp__playwright-report-mcp__run_tests instead (see CLAUDE.md MCP servers section). For multiple iterations, call the MCP tool repeatedly.' >&2; exit 2; fi",
+            "timeout": 10,
+            "statusMessage": "Checking for direct Playwright CLI..."
           }
         ]
       }


### PR DESCRIPTION
## Summary
Adds a `PreToolUse` Bash hook to `.claude/settings.json` that rejects direct Playwright CLI invocations (`playwright test`) with exit code 2 and a redirect message pointing to `mcp__playwright-report-mcp__run_tests`. The hook slots alongside the existing git-commit precheck in the same `PreToolUse > Bash > hooks` array.

## Deviation from the Implementation Hint
The Implementation Hint's trailing boundary `([[:space:]]|$)` did not block looped variants like `for i in $(seq 1 10); do npx playwright test; done` because `;` is not whitespace. AC-1 explicitly requires looped variants to be blocked, so the boundary was tightened to `([^a-zA-Z0-9_-]|$)` to also cover `;`, `&`, `|`, `)`, `>`, and other shell separators — while still letting `testfoo`/`test_helper` slip through (no false positive).

Closes #306

## Test plan
- [x] Pipe-test: blocks `npx playwright test`, `playwright test`, `bunx playwright test`, `pnpm playwright test`, `./node_modules/.bin/playwright test`
- [x] Pipe-test: blocks chained `cd ... && npx playwright test && echo done`
- [x] Pipe-test: blocks looped `for i in $(seq 1 10); do npx playwright test; done`
- [x] Pipe-test: blocks piped `npx playwright test | tee log` and subshelled `(npx playwright test)`
- [x] Pipe-test: does NOT block `npx playwright install`, `npx playwright install --with-deps`, `npx playwright show-report`
- [x] Pipe-test: does NOT block `echo playwright-test`, `echo 'my-playwright-tester'`, `git commit -m 'add playwright tests'`, `npx playwright testfoo`, `npx playwright test_helper`
- [x] Live in-session trigger: `npx playwright test --list` rejected with the BLOCKED redirect message visible in the transcript
- [x] JSON validity of `.claude/settings.json` confirmed
- [x] `/security-review` — no findings
- [x] CI passes on this branch
- [x] Reviewer confirms no regression in the existing git-commit precheck hook