### PR TITLE
#275 Pair self-healing artifacts with the failing test via testInfo.outputDir

### DIFF
--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -86,7 +86,7 @@ class SelectorFix:
 class FailedTest:
     """A failed test extracted from results.json."""
 
-    __slots__ = ("title", "project", "file", "line", "error_message")
+    __slots__ = ("title", "project", "file", "line", "error_message", "output_dir")
 
     def __init__(
         self,
@@ -95,12 +95,18 @@ class FailedTest:
         file: str,
         line: int,
         error_message: str,
+        output_dir: str | None = None,
     ):
         self.title = title
         self.project = project
         self.file = file
         self.line = line
         self.error_message = error_message
+        # Path of the test's testInfo.outputDir relative to the shard root
+        # (e.g. "test-results/home-home-page-Webkit-retry1"), derived from the
+        # last result's attachments.  Used to pair error-context/dom artifacts
+        # with the test that produced them — see issue #275.
+        self.output_dir = output_dir
 
 
 # ---------------------------------------------------------------------------
@@ -224,6 +230,7 @@ def _walk_suite(suite: dict, failed: list[FailedTest]) -> None:
             # Extract file path (relative to playwright/typescript/)
             file_path = spec.get("file", "")
             line = spec.get("line", 0)
+            output_dir = _extract_output_dir(last.get("attachments", []))
             failed.append(
                 FailedTest(
                     title=spec.get("title", ""),
@@ -231,10 +238,38 @@ def _walk_suite(suite: dict, failed: list[FailedTest]) -> None:
                     file=file_path,
                     line=line,
                     error_message=error_msg,
+                    output_dir=output_dir,
                 )
             )
     for child in suite.get("suites", []):
         _walk_suite(child, failed)
+
+
+def _extract_output_dir(attachments: list[dict]) -> str | None:
+    """Derive the test's outputDir (relative to the shard root) from attachments.
+
+    The Playwright JSON reporter records attachment paths as absolute runner
+    paths like
+    ``/home/runner/.../playwright/typescript/test-results/<slug>/dom.xhtml``.
+    The self-healing workflow collects artifacts preserving the
+    ``test-results/<slug>/`` segment (see ``Collect self-healing data`` step in
+    ``playwright-typescript.yml``), so stripping everything before
+    ``test-results/`` yields a path that resolves under the shard root.
+
+    Returns ``None`` if no attachment carries a usable path — caller treats
+    that as "no artifacts, skip this test" (issue #275).
+    """
+    for att in attachments:
+        raw = att.get("path")
+        if not isinstance(raw, str) or not raw:
+            continue
+        parts = Path(raw).parent.parts
+        try:
+            idx = parts.index("test-results")
+        except ValueError:
+            continue
+        return str(Path(*parts[idx:]))
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -792,17 +827,36 @@ def main(data_dir: str) -> None:
         for results_file, failed_tests in all_failed_tests:
             selector_failures = [t for t in failed_tests if is_selector_error(t.error_message)]
             for test in selector_failures:
-                test_dir = results_file.parent
-                # Prefer error-context.md (Playwright built-in: includes test source
-                # and accessibility tree) over raw dom.xhtml
-                error_context = None
-                ec_files = list(test_dir.rglob("error-context.md"))
-                if ec_files:
-                    error_context = ec_files[0].read_text(encoding="utf-8", errors="replace")
-                dom_files = list(test_dir.rglob("dom.xhtml"))
-                if not dom_files and not error_context:
+                # Pair artifacts with the test that produced them by using the
+                # test's own testInfo.outputDir (issue #275).  A shard-wide
+                # rglob[0] would pick whichever error-context/dom appeared
+                # first in traversal order, which may belong to a different
+                # failing test.
+                if not test.output_dir:
+                    print(
+                        f"[self-healing] Skipping {test.title!r} ({test.project}): "
+                        "no attachments recorded in results.json",
+                        file=sys.stderr,
+                    )
                     continue
-                dom_content = dom_files[0].read_text(encoding="utf-8", errors="replace") if dom_files else ""
+                test_output_dir = results_file.parent / test.output_dir
+                ec_path = test_output_dir / "error-context.md"
+                dom_path = test_output_dir / "dom.xhtml"
+                error_context = (
+                    ec_path.read_text(encoding="utf-8", errors="replace")
+                    if ec_path.is_file() else None
+                )
+                dom_content = (
+                    dom_path.read_text(encoding="utf-8", errors="replace")
+                    if dom_path.is_file() else ""
+                )
+                if not error_context and not dom_content:
+                    print(
+                        f"[self-healing] Skipping {test.title!r} ({test.project}): "
+                        f"no error-context.md or dom.xhtml under {test_output_dir}",
+                        file=sys.stderr,
+                    )
+                    continue
                 fix = request_selector_fix_from_ai(
                     test.error_message, dom_content, provider,
                     error_context=error_context,

--- a/scripts/test_self_healing.py
+++ b/scripts/test_self_healing.py
@@ -895,6 +895,269 @@ class TestErrorContextSupport(unittest.TestCase):
 
 
 # ===================================================================
+# Per-test artifact pairing (issue #275)
+#
+# The earlier implementation paired each selector failure with the first
+# error-context.md / dom.xhtml found anywhere under the shard — when a shard
+# had 2+ failing tests, this silently fed one test's DOM into another test's
+# AI fix request.  The fix threads testInfo.outputDir through `FailedTest`
+# via the `attachments[].path` field of `results.json` and resolves artifacts
+# per-test under the shard root.
+# ===================================================================
+
+
+class TestExtractOutputDir(unittest.TestCase):
+    def test_returns_relative_segment_from_absolute_path(self):
+        # Mimic what the Playwright JSON reporter writes on a runner.
+        attachments = [
+            {
+                "name": "DOM",
+                "contentType": "text/html",
+                "path": "/home/runner/work/orwellstat/orwellstat/playwright/typescript/test-results/home-home-page-Webkit-retry1/dom.xhtml",
+            },
+        ]
+        self.assertEqual(
+            self_healing._extract_output_dir(attachments),
+            "test-results/home-home-page-Webkit-retry1",
+        )
+
+    def test_ignores_attachments_without_path(self):
+        attachments = [
+            {"name": "stdout", "contentType": "text/plain"},
+            {
+                "name": "error-context",
+                "contentType": "text/markdown",
+                "path": "/runner/test-results/foo/error-context.md",
+            },
+        ]
+        self.assertEqual(
+            self_healing._extract_output_dir(attachments),
+            "test-results/foo",
+        )
+
+    def test_returns_none_when_no_test_results_segment(self):
+        attachments = [
+            {"name": "DOM", "path": "/tmp/unrelated/dir/dom.xhtml"},
+        ]
+        self.assertIsNone(self_healing._extract_output_dir(attachments))
+
+    def test_returns_none_for_empty_attachments(self):
+        self.assertIsNone(self_healing._extract_output_dir([]))
+
+
+class TestPerTestArtifactPairing(unittest.TestCase):
+    """Two failing tests in the same shard with distinct error-context/dom
+    artifacts must each be paired with their OWN artifacts when calling the
+    AI — not whichever file rglob happened to pick first.  A test with no
+    artifacts under its outputDir must be skipped (not fall back to a
+    neighbor's data).
+    """
+
+    @staticmethod
+    def _results_json(tests: list[dict]) -> dict:
+        """Build a results.json skeleton with one spec per entry."""
+        specs = []
+        for t in tests:
+            specs.append({
+                "title": t["title"],
+                "ok": False,
+                "file": t.get("file", "home.spec.ts"),
+                "line": t.get("line", 1),
+                "column": 1,
+                "tests": [
+                    {
+                        "projectId": t["project"],
+                        "projectName": t["project"],
+                        "status": "unexpected",
+                        "results": [
+                            {
+                                "status": "failed",
+                                "errors": [{"message": t["error"]}],
+                                "attachments": t["attachments"],
+                            }
+                        ],
+                    }
+                ],
+            })
+        return {
+            "suites": [
+                {
+                    "title": "home.spec.ts",
+                    "file": "home.spec.ts",
+                    "specs": specs,
+                    "suites": [],
+                }
+            ]
+        }
+
+    @patch("self_healing.create_draft_pr")
+    @patch("self_healing.post_comment")
+    @patch("self_healing.count_self_healing_comments", return_value=0)
+    @patch("self_healing.find_pr_for_branch", return_value=99)
+    @patch("self_healing.request_selector_fix_from_ai")
+    def test_pairs_each_failure_with_its_own_artifacts(
+        self,
+        mock_ai,
+        _mock_find_pr,
+        _mock_count,
+        _mock_post,
+        _mock_draft,
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            shard = Path(tmp) / "self-healing-data-chromium"
+            tr_a = shard / "test-results" / "home-home-page-Chromium"
+            tr_b = shard / "test-results" / "home-recent-links-Chromium"
+            _write_file(tr_a / "error-context.md", "ERROR-CONTEXT-A")
+            _write_file(tr_a / "dom.xhtml", "<html>DOM-A</html>")
+            _write_file(tr_b / "error-context.md", "ERROR-CONTEXT-B")
+            _write_file(tr_b / "dom.xhtml", "<html>DOM-B</html>")
+
+            # Absolute paths as Playwright would write them on a runner —
+            # the script is expected to resolve them relative to the shard.
+            results = self._results_json([
+                {
+                    "title": "home page",
+                    "project": "Chromium",
+                    "error": "waiting for locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })",
+                    "attachments": [
+                        {
+                            "name": "DOM",
+                            "contentType": "text/html",
+                            "path": "/runner/work/orwellstat/playwright/typescript/test-results/home-home-page-Chromium/dom.xhtml",
+                        },
+                        {
+                            "name": "error-context",
+                            "contentType": "text/markdown",
+                            "path": "/runner/work/orwellstat/playwright/typescript/test-results/home-home-page-Chromium/error-context.md",
+                        },
+                    ],
+                },
+                {
+                    "title": "recent-links",
+                    "project": "Chromium",
+                    "error": "waiting for getByRole('link', { name: 'ostatnio dodanych' })",
+                    "attachments": [
+                        {
+                            "name": "DOM",
+                            "contentType": "text/html",
+                            "path": "/runner/work/orwellstat/playwright/typescript/test-results/home-recent-links-Chromium/dom.xhtml",
+                        },
+                        {
+                            "name": "error-context",
+                            "contentType": "text/markdown",
+                            "path": "/runner/work/orwellstat/playwright/typescript/test-results/home-recent-links-Chromium/error-context.md",
+                        },
+                    ],
+                },
+            ])
+            _write_file(shard / "results.json", json.dumps(results))
+
+            # AI returns a plausible fix keyed off the broken selector in the
+            # error message so the cross-check guard keeps the fix.
+            def _fake_fix(err_msg, dom, _provider, error_context=None):
+                if "Strona glowna" in err_msg:
+                    return self_healing.SelectorFix(
+                        confidence="high",
+                        broken_selector="locator('#menubar').getByRole('link', { name: 'Strona glowna', exact: true })",
+                        suggested_selector="locator('#menubar').getByRole('link', { name: 'Strona główna', exact: true })",
+                        explanation="diacritic fix",
+                    )
+                return self_healing.SelectorFix(
+                    confidence="high",
+                    broken_selector="getByRole('link', { name: 'ostatnio dodanych' })",
+                    suggested_selector="getByRole('link', { name: 'ostatnio dodanych' }).first()",
+                    explanation="nth(1) fix",
+                )
+            mock_ai.side_effect = _fake_fix
+
+            self_healing.main(str(Path(tmp)))
+
+            # Two AI calls — one per failing test — each paired with its own
+            # artifacts.
+            self.assertEqual(mock_ai.call_count, 2)
+            pairings = {}
+            for call in mock_ai.call_args_list:
+                err_msg = call.args[0]
+                dom = call.args[1]
+                ec = call.kwargs.get("error_context")
+                key = "A" if "Strona glowna" in err_msg else "B"
+                pairings[key] = (dom, ec)
+
+            self.assertIn("DOM-A", pairings["A"][0])
+            self.assertIn("ERROR-CONTEXT-A", pairings["A"][1])
+            self.assertNotIn("DOM-B", pairings["A"][0])
+            self.assertNotIn("ERROR-CONTEXT-B", pairings["A"][1])
+
+            self.assertIn("DOM-B", pairings["B"][0])
+            self.assertIn("ERROR-CONTEXT-B", pairings["B"][1])
+            self.assertNotIn("DOM-A", pairings["B"][0])
+            self.assertNotIn("ERROR-CONTEXT-A", pairings["B"][1])
+
+    @patch("self_healing.create_draft_pr")
+    @patch("self_healing.post_comment")
+    @patch("self_healing.find_pr_for_branch", return_value=None)
+    @patch("self_healing.request_selector_fix_from_ai")
+    def test_skips_test_with_no_artifacts_and_logs_reason(
+        self, mock_ai, _mock_find_pr, _mock_post, _mock_draft
+    ):
+        import io
+
+        with tempfile.TemporaryDirectory() as tmp:
+            shard = Path(tmp) / "self-healing-data-webkit"
+            # Only test B has artifacts; test A has attachments: [] → skip.
+            tr_b = shard / "test-results" / "home-recent-links-Webkit"
+            _write_file(tr_b / "error-context.md", "ERROR-CONTEXT-B")
+            _write_file(tr_b / "dom.xhtml", "<html>DOM-B</html>")
+
+            results = self._results_json([
+                {
+                    "title": "lonely test",
+                    "project": "Webkit",
+                    "error": "waiting for locator('#lonely')",
+                    "attachments": [],
+                },
+                {
+                    "title": "recent-links",
+                    "project": "Webkit",
+                    "error": "waiting for getByRole('link', { name: 'ostatnio dodanych' })",
+                    "attachments": [
+                        {
+                            "name": "DOM",
+                            "contentType": "text/html",
+                            "path": "/runner/test-results/home-recent-links-Webkit/dom.xhtml",
+                        },
+                        {
+                            "name": "error-context",
+                            "contentType": "text/markdown",
+                            "path": "/runner/test-results/home-recent-links-Webkit/error-context.md",
+                        },
+                    ],
+                },
+            ])
+            _write_file(shard / "results.json", json.dumps(results))
+
+            mock_ai.return_value = self_healing.SelectorFix(
+                confidence="high",
+                broken_selector="getByRole('link', { name: 'ostatnio dodanych' })",
+                suggested_selector="getByRole('link', { name: 'ostatnio dodanych' }).first()",
+                explanation="fix",
+            )
+
+            captured_stderr = io.StringIO()
+            with patch("sys.stderr", captured_stderr):
+                self_healing.main(str(Path(tmp)))
+            stderr_text = captured_stderr.getvalue()
+
+        # Only the test WITH artifacts reached the AI — the other was skipped.
+        self.assertEqual(mock_ai.call_count, 1)
+        self.assertIn("DOM-B", mock_ai.call_args.args[1])
+        self.assertIn("ERROR-CONTEXT-B", mock_ai.call_args.kwargs.get("error_context"))
+        # The skip was logged with a reason (so it's debuggable from CI logs).
+        self.assertIn("lonely test", stderr_text)
+        self.assertIn("no attachments recorded", stderr_text)
+
+
+# ===================================================================
 # Cross-check guard: drop stale fixes not referenced by any failed test
 # (issue #291 — PR #287 reproduction)
 # ===================================================================


### PR DESCRIPTION
## Summary

- Replaces the shard-wide `rglob("error-context.md")[0]` / `rglob("dom.xhtml")[0]` in `scripts/self-healing.py` with per-test resolution: each failing test's artifacts are now looked up under its own `testInfo.outputDir`, derived from `results.json` `attachments[].path`.
- When a failing test has no recorded attachments (or its artifacts are missing on disk), it is now skipped with a logged reason — no cross-test fallback.
- Adds `scripts/test_self_healing.py` coverage: `_extract_output_dir` unit tests and end-to-end `main()` tests for the two-failing-tests pairing case and the missing-artifact skip case.

Closes #275
Contributes to #273

## Test plan

- [x] `python3 scripts/test_self_healing.py` — all 81 unit tests pass locally, including the 6 new tests covering per-test pairing and the skip paths.
- [x] Inspected a real `results.json` (cached from PR #287's webkit shard) and confirmed attachments of a failed test carry absolute runner paths with a `test-results/<slug>/` segment (e.g. `.../test-results/home-home-page-Webkit-retry1/dom.xhtml`), matching what `_extract_output_dir` expects.
- [x] Local end-to-end reproduction: built a synthetic shard with two selector-failing tests + distinct `error-context.md` / `dom.xhtml` artifacts, stubbed `request_selector_fix_from_ai` to capture its inputs, and ran `self_healing.main()`. Confirmed each of the two AI calls received its own test's DOM and error-context, with no cross-test content bleed; the same harness reproduced the opposite (wrong pairing) when run against the pre-fix code path — proving the fix resolves the bug, not just makes the test pass.
- [x] CI green on this PR (Playwright Typescript Tests + lint).
