### PR TITLE
#196 Generate test.fixme stubs for uncovered coverage matrix gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ npx playwright test tests/statistics.spec.ts
 npx playwright test tests/validation.spec.ts
 npx playwright test tests/visual.spec.ts
 npx playwright test tests/network-mocking.spec.ts
+npx playwright test tests/register.spec.ts
+npx playwright test tests/password-reset.spec.ts
+npx playwright test tests/zone-information.spec.ts
+npx playwright test tests/zone-stats.spec.ts
+npx playwright test tests/zone-hits.spec.ts
+npx playwright test tests/zone-scripts.spec.ts
+npx playwright test tests/zone-admin.spec.ts
+npx playwright test tests/forms.spec.ts
 
 # Specific browser
 npx playwright test --project=chromium
@@ -255,7 +263,7 @@ Tests are tagged `@smoke` or `@regression` using Playwright's test options synta
 | Tag           | Purpose                                                                              | Files                                                                                                                                                                       |
 | ------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@smoke`      | Quick health check: HTTP status, page titles, heading visibility                     | `api.spec.ts`, `navigation.spec.ts`                                                                                                                                         |
-| `@regression` | Deep checks: table content, SVG analysis, external link hrefs, accessibility, visual | `home.spec.ts`, `about-system.spec.ts`, `contact.spec.ts`, `statistics.spec.ts`, `accessibility.spec.ts`, `validation.spec.ts`, `visual.spec.ts`, `network-mocking.spec.ts` |
+| `@regression` | Deep checks: table content, SVG analysis, external link hrefs, accessibility, visual | `home.spec.ts`, `about-system.spec.ts`, `contact.spec.ts`, `statistics.spec.ts`, `accessibility.spec.ts`, `validation.spec.ts`, `visual.spec.ts`, `network-mocking.spec.ts`, `register.spec.ts`, `password-reset.spec.ts`, `zone-information.spec.ts`, `zone-stats.spec.ts`, `zone-hits.spec.ts`, `zone-scripts.spec.ts`, `zone-admin.spec.ts`, `forms.spec.ts` |
 
 Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tests](#running-tests)).
 
@@ -273,7 +281,15 @@ Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tes
   - `statistics.spec.ts` — Service statistics page: SVG chart rendering and statistics table tests; tagged `@regression`
   - `validation.spec.ts` — XHTML DTD and CSS validation tests across all pages. XHTML validation runs locally via `xmllint` by default (no network traffic, authenticated HTML never leaves the runner); set `VALIDATE_REMOTE=true` to switch to the classic W3C Markup Validator for a periodic official cross-check. CSS validation uses the W3C CSS validator API. Chromium-only; tagged `@regression`
   - `network-mocking.spec.ts` — Network mocking tests using `page.route()`: mocks the SVG chart endpoint with a static response (deterministic render, no animation timing) and mocks the W3C markup validator to return validation errors (negative test for error detection); Chromium-only; tagged `@regression`
-  - `visual.spec.ts` — Full-page visual regression snapshots for home (default and Purple Rain style), about system, contact, and statistics pages using `toHaveScreenshot()` with `maxDiffPixelRatio: 0.01`; home page masks `#statsbar` lists (dynamic new-browser/OS list items) via `getByRole('list')`; statistics page masks `getByRole('table')` (live data) and `object[type="image/svg+xml"]` (dynamic SVG chart), removes all but the first 5 rows from the statistics table via `page.evaluate()` to keep the footer at a stable position regardless of how many browser/OS rows live data contains (CSS height/overflow tricks are ineffective here: Playwright's `fullPage` screenshot and mask both use the element's full bounding box, not the clipped visual; physically removing rows is the only reliable fix), waits for `<object>` to be visible before screenshotting to stabilise layout, and disables animations; baselines stored in `tests/visual.spec.ts-snapshots/` with per-platform suffixes (`-darwin`, `-linux`); tagged `@regression`
+  - `visual.spec.ts` — Full-page visual regression snapshots for home (default and Purple Rain style), about system, contact, and statistics pages using `toHaveScreenshot()` with `maxDiffPixelRatio: 0.01`; home page masks `#statsbar` lists (dynamic new-browser/OS list items) via `getByRole('list')`; statistics page masks `getByRole('table')` (live data) and `object[type="image/svg+xml"]` (dynamic SVG chart), removes all but the first 5 rows from the statistics table via `page.evaluate()` to keep the footer at a stable position regardless of how many browser/OS rows live data contains (CSS height/overflow tricks are ineffective here: Playwright's `fullPage` screenshot and mask both use the element's full bounding box, not the clipped visual; physically removing rows is the only reliable fix), waits for `<object>` to be visible before screenshotting to stabilise layout, and disables animations; baselines stored in `tests/visual.spec.ts-snapshots/` with per-platform suffixes (`-darwin`, `-linux`); also holds `test.fixme` stubs for the register, password reset, previously added, information, stats, hits, scripts, and admin pages (coverage matrix gaps — see `coverage-matrix.json`); tagged `@regression`
+  - `register.spec.ts` — `test.fixme` stub for the registration page content (coverage matrix gap); tagged `@regression`
+  - `password-reset.spec.ts` — `test.fixme` stub for the password reset page content (coverage matrix gap); tagged `@regression`
+  - `zone-information.spec.ts` — `test.fixme` stub for the authenticated information page content (coverage matrix gap); tagged `@regression`
+  - `zone-stats.spec.ts` — `test.fixme` stub for the authenticated stats page content (coverage matrix gap); tagged `@regression`
+  - `zone-hits.spec.ts` — `test.fixme` stub for the authenticated hits page content (coverage matrix gap); tagged `@regression`
+  - `zone-scripts.spec.ts` — `test.fixme` stub for the authenticated scripts page content (coverage matrix gap); tagged `@regression`
+  - `zone-admin.spec.ts` — `test.fixme` stub for the authenticated admin page content (coverage matrix gap); tagged `@regression`
+  - `forms.spec.ts` — `test.fixme` stubs for the `login`, `hitsFilter`, and `adminSettings` forms (coverage matrix gaps — see the `forms` section of `coverage-matrix.json`); tagged `@regression`
 - `auth.setup.ts` — Playwright auth setup: logs in via UI and saves storage state to `.auth/user.json`
 - `pages/` — Page Object Model classes
   - `base.page.ts` — `BasePage` interface (`url`, `title`, `goto()`, `heading`, optional `accessKey`)

--- a/playwright/typescript/coverage-matrix.json
+++ b/playwright/typescript/coverage-matrix.json
@@ -52,35 +52,35 @@
     "/zone/": {
       "title": true,
       "content": false,
-      "accessibility": false,
+      "accessibility": true,
       "visualRegression": false,
       "api": true
     },
     "/zone/stats/": {
       "title": true,
       "content": false,
-      "accessibility": false,
+      "accessibility": true,
       "visualRegression": false,
       "api": true
     },
     "/zone/hits/": {
       "title": true,
       "content": false,
-      "accessibility": false,
+      "accessibility": true,
       "visualRegression": false,
       "api": true
     },
     "/zone/scripts/": {
       "title": true,
       "content": false,
-      "accessibility": false,
+      "accessibility": true,
       "visualRegression": false,
       "api": true
     },
     "/zone/admin/": {
       "title": true,
       "content": false,
-      "accessibility": false,
+      "accessibility": true,
       "visualRegression": false,
       "api": true
     }

--- a/playwright/typescript/tests/forms.spec.ts
+++ b/playwright/typescript/tests/forms.spec.ts
@@ -1,0 +1,22 @@
+import { test } from '@fixtures/base.fixture';
+import { HomePage } from '@pages/public/home.page';
+import { HitsPage } from '@pages/authenticated/hits.page';
+import { AdminPage } from '@pages/authenticated/admin.page';
+
+test.fixme('login form', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to HomePage.url and verify the login form (fields, labels, submit button,
+  // error state for invalid credentials).
+  await page.goto(HomePage.url);
+});
+
+test.fixme('hitsFilter form', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to HitsPage.url and verify the hits filter form (fields, labels, submit
+  // button, that applying a filter updates the page content).
+  await page.goto(HitsPage.url);
+});
+
+test.fixme('adminSettings form', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to AdminPage.url and verify the admin settings form (fields, labels,
+  // submit button, that saving a setting persists the value).
+  await page.goto(AdminPage.url);
+});

--- a/playwright/typescript/tests/password-reset.spec.ts
+++ b/playwright/typescript/tests/password-reset.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@fixtures/base.fixture';
+import { PasswordResetPage } from '@pages/public/password-reset.page';
+
+test.fixme('password reset page - content', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to PasswordResetPage.url and verify page content (headings, form fields, labels).
+  await page.goto(PasswordResetPage.url);
+});

--- a/playwright/typescript/tests/register.spec.ts
+++ b/playwright/typescript/tests/register.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@fixtures/base.fixture';
+import { RegisterPage } from '@pages/public/register.page';
+
+test.fixme('register page - content', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to RegisterPage.url and verify page content (headings, form fields, labels).
+  await page.goto(RegisterPage.url);
+});

--- a/playwright/typescript/tests/visual.spec.ts
+++ b/playwright/typescript/tests/visual.spec.ts
@@ -3,6 +3,14 @@ import { HomePage } from '@pages/public/home.page';
 import { AboutSystemPage } from '@pages/public/about-system.page';
 import { ContactPage } from '@pages/public/contact.page';
 import { ServiceStatisticsPage } from '@pages/public/service-statistics.page';
+import { RegisterPage } from '@pages/public/register.page';
+import { PasswordResetPage } from '@pages/public/password-reset.page';
+import { PreviouslyAddedPage } from '@pages/public/previously-added.page';
+import { InformationPage } from '@pages/authenticated/information.page';
+import { StatsPage } from '@pages/authenticated/stats.page';
+import { HitsPage } from '@pages/authenticated/hits.page';
+import { ScriptsPage } from '@pages/authenticated/scripts.page';
+import { AdminPage } from '@pages/authenticated/admin.page';
 import {
   STYLE_SELECTOR,
   STYLE_IRISH_GREEN_SVG,
@@ -198,3 +206,45 @@ for (const style of [STYLE_PURPLE_RAIN, STYLE_HIGH_CONTRAST] as const) {
     }
   );
 }
+
+test.fixme('register page visual regression', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to RegisterPage.url and add toHaveScreenshot() assertion.
+  await page.goto(RegisterPage.url);
+});
+
+test.fixme('password reset page visual regression', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to PasswordResetPage.url and add toHaveScreenshot() assertion.
+  await page.goto(PasswordResetPage.url);
+});
+
+test.fixme('previously added page visual regression', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to PreviouslyAddedPage.url and add toHaveScreenshot() assertion.
+  // The page renders dynamic browser/OS lists inside #statsbar; match the home page
+  // approach and mask both via getByRole('list') before capturing the baseline.
+  await page.goto(PreviouslyAddedPage.url);
+});
+
+test.fixme('information page visual regression', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to InformationPage.url and add toHaveScreenshot() assertion.
+  await page.goto(InformationPage.url);
+});
+
+test.fixme('stats page visual regression', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to StatsPage.url and add toHaveScreenshot() assertion.
+  await page.goto(StatsPage.url);
+});
+
+test.fixme('hits page visual regression', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to HitsPage.url and add toHaveScreenshot() assertion.
+  await page.goto(HitsPage.url);
+});
+
+test.fixme('scripts page visual regression', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to ScriptsPage.url and add toHaveScreenshot() assertion.
+  await page.goto(ScriptsPage.url);
+});
+
+test.fixme('admin page visual regression', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to AdminPage.url and add toHaveScreenshot() assertion.
+  await page.goto(AdminPage.url);
+});

--- a/playwright/typescript/tests/zone-admin.spec.ts
+++ b/playwright/typescript/tests/zone-admin.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@fixtures/base.fixture';
+import { AdminPage } from '@pages/authenticated/admin.page';
+
+test.fixme('admin page - content', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to AdminPage.url and verify page content.
+  await page.goto(AdminPage.url);
+});

--- a/playwright/typescript/tests/zone-hits.spec.ts
+++ b/playwright/typescript/tests/zone-hits.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@fixtures/base.fixture';
+import { HitsPage } from '@pages/authenticated/hits.page';
+
+test.fixme('hits page - content', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to HitsPage.url and verify page content.
+  await page.goto(HitsPage.url);
+});

--- a/playwright/typescript/tests/zone-information.spec.ts
+++ b/playwright/typescript/tests/zone-information.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@fixtures/base.fixture';
+import { InformationPage } from '@pages/authenticated/information.page';
+
+test.fixme('information page - content', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to InformationPage.url and verify page content.
+  await page.goto(InformationPage.url);
+});

--- a/playwright/typescript/tests/zone-scripts.spec.ts
+++ b/playwright/typescript/tests/zone-scripts.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@fixtures/base.fixture';
+import { ScriptsPage } from '@pages/authenticated/scripts.page';
+
+test.fixme('scripts page - content', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to ScriptsPage.url and verify page content.
+  await page.goto(ScriptsPage.url);
+});

--- a/playwright/typescript/tests/zone-stats.spec.ts
+++ b/playwright/typescript/tests/zone-stats.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@fixtures/base.fixture';
+import { StatsPage } from '@pages/authenticated/stats.page';
+
+test.fixme('stats page - content', { tag: '@regression' }, async ({ page }) => {
+  // TODO: Navigate to StatsPage.url and verify page content.
+  await page.goto(StatsPage.url);
+});


### PR DESCRIPTION
## Summary

- Added 8 `test.fixme` visual-regression stubs to `tests/visual.spec.ts` for the register, password reset, previously added, information, stats, hits, scripts, and admin pages.
- Created 7 content stub files: `register.spec.ts`, `password-reset.spec.ts`, `zone-information.spec.ts`, `zone-stats.spec.ts`, `zone-hits.spec.ts`, `zone-scripts.spec.ts`, `zone-admin.spec.ts`.
- Created `tests/forms.spec.ts` with 3 stubs (`login form`, `hitsFilter form`, `adminSettings form`).
- Flipped `accessibility` to `true` for the 5 authenticated pages in `coverage-matrix.json` (they are already covered via the `AUTHENTICATED_PAGE_CLASSES` loop in `accessibility.spec.ts`).
- Updated `README.md`: single-test-file list, `@regression` tag row, and the architecture spec list.

`PreviouslyAddedPage` is kept standalone (not added to `PUBLIC_PAGE_CLASSES`); only its visual regression stub was generated. No visual baselines are created by the stubs — `test.fixme` never executes, so baselines will be captured when the stubs are implemented.

Closes #196

## Test plan

- [x] `npx tsc --noEmit` passes from `playwright/typescript/`
- [x] `npm run format:check` passes
- [x] `playwright-report-mcp list_tests` shows 18 new fixme tests (8 visual + 7 content + 3 forms) — all tagged `@regression`
- [x] `coverage-matrix.json` diff flips exactly the 5 authenticated-page `accessibility` booleans to `true`; no other matrix values changed
- [x] `README.md` lists all 8 new spec files in the single-test-file list, the `@regression` tag row, and the architecture spec list
- [x] CI `playwright-typescript-lint.yml` passes on this PR
- [x] Reviewer confirms the `forms.spec.ts` naming and structure match the intended follow-up implementation style

