### PR TITLE
#311 Fix Project #1 auto-link hijack in create-issue skill

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -61,6 +61,13 @@ If none of the existing milestones fit, **do not assign one silently** — propo
 - Target date field: `PVTF_lAHOAG7eT84BRbtyzg_QzzM`
 - Actual hours field: `PVTF_lAHOAG7eT84BRbtyzhC91mc` (populated by `fix-issue`)
 
+**Linking to Project #1 inside issue/PR bodies:** always write `[Project #1](https://github.com/users/hubertgajewski/projects/1)`, never bare `Project #1`. GitHub auto-links `#1` inside issue/PR body prose to issue #1, hijacking the reference. The markdown-link form is not auto-linked. In DoD boilerplate specifically:
+
+- `- [ ] Estimate = <N> set in [Project #1](https://github.com/users/hubertgajewski/projects/1).`
+- `- [ ] Actual hours recorded in [Project #1](https://github.com/users/hubertgajewski/projects/1).`
+
+This only applies to text that will be posted to GitHub. In-skill prose (headings like "Project #1 board fields" above) is fine as-is because it is read by Claude and never reaches an issue body.
+
 **Steps:**
 1. Decide story vs epic based on `$ARGUMENTS`. Draft the title and all required body sections (five for a story, three for an epic). Ask for clarification on any ambiguous section before proceeding.
 2. Select the appropriate milestone using the table above. If none fit, propose a new one and wait for approval.


### PR DESCRIPTION
## Summary

In issue / PR body prose, GitHub auto-links `#1` to **issue #1** (`Add Playwright page object helpers`) rather than to Project #1. Every recently-drafted story's Definition of Done hit this: e.g. issue #275's `- [x] Estimate = 3 set in Project #1.` has its `#1` rendering as a link to the wrong page.

`README.md:19` already avoids the hijack with `[GitHub Project #1](https://github.com/users/hubertgajewski/projects/1)` — GitHub does not auto-link `#N` that sits inside markdown link text. This PR codifies that same form in the `create-issue` skill so every new issue inherits the fix.

A one-shot sweep of existing issue bodies (open + closed) is being run out-of-band — it's a GitHub-side rewrite, not a code change, so it does not belong in this PR.

Closes #311

## Test plan

- [x] Diff reviewed — only the `create-issue` skill changes; in-skill prose headings left as plain `Project #1` (those are instructions to Claude, never reach GitHub).
- [ ] Next time I draft an issue via `/create-issue`, its DoD boilerplate lands as `[Project #1](https://github.com/users/hubertgajewski/projects/1)` — verifiable on the next story created after merge.
