### PR TITLE
#313 Auto-symlink env files into new git worktrees + anti-stall footers on /fix-issue

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -146,6 +146,28 @@
             "statusMessage": "Checking types and formatting..."
           }
         ]
+      },
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); TARGET=$(echo \"$INPUT\" | jq -r '.tool_input.path // .tool_response.path // empty'); if [ -n \"$TARGET\" ] && [ -d \"$TARGET\" ]; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && \"$ROOT/scripts/provision-worktree-env.sh\" \"$TARGET\" || true; fi",
+            "timeout": 10,
+            "statusMessage": "Provisioning env files for the new worktree..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE 'git[[:space:]]+worktree[[:space:]]+add[[:space:]]'; then TARGET=$(echo \"$CMD\" | awk '{a=0;s=0;for(i=1;i<=NF;i++){if($i==\"add\"){a=1;continue}if(!a)continue;if(s){s=0;continue}if($i==\"-b\"||$i==\"-B\"){s=1;continue}if(substr($i,1,1)==\"-\")continue;print $i;exit}}'); if [ -n \"$TARGET\" ] && [ -d \"$TARGET\" ]; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && \"$ROOT/scripts/provision-worktree-env.sh\" \"$TARGET\" || true; fi; fi",
+            "timeout": 10,
+            "statusMessage": "Provisioning env files after git worktree add..."
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -31,8 +31,12 @@ Implement the fix described in the issue. Follow all conventions in `CLAUDE.md` 
 **Step 4 — Security review (mandatory, do this first)**
 Run `/security-review` (built-in Claude Code command). This must be done before the code review checklist — do not skip or defer it. If the command is unavailable, manually check: injection via untrusted input, path traversal in file I/O, unhandled parse errors, hardcoded secrets, overly broad permissions. Fix any findings before continuing.
 
+> **Do not stall when the skill returns.** `/security-review` (and every other embedded skill) may end its prompt with instructions like *"your final reply must contain the markdown report and nothing else"*. That constraint applies only to the skill's reply shape — it does **not** halt `/fix-issue`. If the report is clean, proceed to Step 4b in the same turn. If it has findings, fix them, re-run `/security-review`, and then proceed. Never treat a clean report as a terminal output.
+
 **Step 4b — Code review checklist**
 Work through `.claude/skills/deep-review/SKILL.md` in full. State a finding for each checklist item (pass, fail, or N/A with reason).
+
+> **Same flow-control rule as Step 4.** `/deep-review` runs its own embedded `/security-review` and `/simplify` sub-cycles — none of those sub-skills' reply-shape constraints halt `/fix-issue`. When the checklist reports pass / N/A only with zero failures, proceed to Step 5 in the same turn.
 
 **Step 5 — Run the affected test(s)**
 Run only the tests touched by the change. They must all pass before proceeding.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ cd playwright/typescript && npm ci && npx playwright install --with-deps && cd .
 
 Then open your AI assistant from the **repo root** so `.mcp.json` is picked up and all MCP server tools are available.
 
+## Working with git worktrees
+
+Per-issue worktrees under `.claude/worktrees/` let parallel Claude Code sessions avoid colliding on HEAD. Gitignored env files (`.env`, `.vars`, `bruno/.env`) are auto-symlinked into a new worktree by a `PostToolUse` hook on `git worktree add` and Claude Code's `EnterWorktree` tool — you do not need to copy anything by hand. If you create a worktree in a way the hook cannot see (a script spawned outside Claude Code, an editor plugin, etc.), run `./scripts/provision-worktree-env.sh <worktree-path>` once; the script is idempotent, so re-running is safe.
+
+The `Bash` hook parses the first non-flag positional argument after `add` (skipping `-b <branch>` / `-B <branch>`), matching the common `git worktree add <path> [<branch>]` and `git worktree add -b <branch> <path>` invocations.
+
+**Windows (best-effort, unverified):** run Claude Code inside Git Bash or WSL so the hooks (`jq` / `awk` / `bash`) can execute — the existing husky pre-commit hook already assumes this. Native NTFS symlinks need Windows 10/11 Developer Mode (Settings → Privacy & Security → For developers → Developer Mode) or an elevated PowerShell; without either, the provisioning script auto-falls back to copying the three env files and prints a stderr `WARN`. Copies drift from the main checkout — re-run `./scripts/provision-worktree-env.sh <path>` after any edit to `.env` / `.vars` / `bruno/.env` in the main checkout. This path is designed-for but not CI-verified; please open an issue if it breaks.
+
 ## Adapting to your own environment
 
 For adapting this repo to a different deployment target, see [FORK.md](FORK.md).

--- a/scripts/provision-worktree-env.sh
+++ b/scripts/provision-worktree-env.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:?usage: provision-worktree-env.sh <worktree-path>}"
+target="$(cd "$target" && pwd)"
+
+common_git="$(git -C "$target" rev-parse --path-format=absolute --git-common-dir)"
+main="$(dirname "$common_git")"
+
+if [[ "$main" == "$target" ]]; then
+  echo "provision-worktree-env: target is main checkout, skipping" >&2
+  exit 0
+fi
+
+link() {
+  local src="$main/$1" dst="$target/$1"
+  if [[ ! -e "$src" ]]; then
+    echo "provision-worktree-env: WARN $src missing, skipping" >&2
+    return 0
+  fi
+  mkdir -p "$(dirname "$dst")"
+  if ln -sfn "$src" "$dst" 2>/dev/null; then
+    echo "provision-worktree-env: linked $1" >&2
+  else
+    cp -f "$src" "$dst"
+    echo "provision-worktree-env: WARN symlink failed, copied $1 instead — re-run this script if you edit $src in the main checkout (likely Windows without Developer Mode)" >&2
+  fi
+}
+
+link .env
+link .vars
+link bruno/.env


### PR DESCRIPTION
## Summary

Closes #313.

Two commits:

1. **`b234f5d` — the feature itself.** New `scripts/provision-worktree-env.sh` resolves the main checkout via `git rev-parse --path-format=absolute --git-common-dir` and symlinks `.env`, `.vars`, `bruno/.env` into a target worktree (with a `cp -f` fallback for Windows without Developer Mode). Two PostToolUse hooks in `.claude/settings.json` dispatch to the script on `EnterWorktree` and on `git worktree add <path>` (the `Bash` hook parses the first non-flag positional after `add`, skipping `-b` / `-B` branch args). README gets a "Working with git worktrees" section documenting the auto-provisioning, manual fallback, and the best-effort Windows caveat.

2. **`123a935` — anti-stall footers on `/fix-issue` Steps 4 and 4b.** During this PR's own `/fix-issue` run, I stalled after `/security-review` returned — the skill's prompt ends with *"your final reply must contain the markdown report and nothing else"*, which I followed literally and stopped the workflow. Two blockquote footers now live directly under the Steps that trigger the stall, clarifying that embedded-skill reply-shape constraints never halt `/fix-issue` step progression. This is structural (next to the instruction that triggered the failure) rather than memory-only (which proved too soft a lever).

## Test plan

- [x] `scripts/provision-worktree-env.sh` is executable (`-rwxr-xr-x`), idempotent, and passes `set -euo pipefail`.
- [x] Happy path: `git worktree add .claude/worktrees/tmp-313-v2 origin/main` followed by the script produced three absolute symlinks into the main checkout (`readlink` confirmed on all three).
- [x] Idempotency: re-running the script on the same worktree printed `linked` three more times and left the symlinks unchanged (`ln -sfn` replaces without following).
- [x] Main-checkout skip: `./scripts/provision-worktree-env.sh .` prints `target is main checkout, skipping` and exits 0.
- [x] Missing-source: in a throwaway `git init` repo with no `.env`, the script printed three `WARN ... missing, skipping` lines to stderr and exited 0.
- [x] Cross-platform fallback path: `ln -sfn "$src" "$dst" 2>/dev/null || cp -f "$src" "$dst"` — design-verified only; actual Windows/NTFS verification deferred (per issue scope).
- [x] `jq -e . .claude/settings.json` passes; `PostToolUse` array now has three entries (Edit|Write, EnterWorktree, Bash) as confirmed by `jq '.hooks.PostToolUse[].matcher'`.
- [x] `awk` path-extraction unit-tested against six representative command strings (`add <path>`, `add -b <branch> <path>`, `add --force <path>`, `add -B <branch> <path>`, `worktree list`, chained `cd && git worktree add <path>`).
- [x] Bash hook pipeline end-to-end with a mocked JSON payload: non-existent target → silent no-op, existing target → script invoked and provisioned.
- [x] `git worktree remove` cleanup leaves no orphan references.
- [ ] **Runtime verification of `EnterWorktree` hook** — requires a fresh Claude Code session so the harness reloads `.claude/settings.json`. Will be confirmed on the next worktree spin-up after merge.
- [ ] **CI `playwright-typescript-lint.yml`** — runs only on `playwright/typescript/**` changes; this PR touches nothing there, so it should no-op. Confirm on GitHub.
- [ ] **PR reviewer (`claude-code-review.yml`)** — triggers automatically on PR open.
