### PR TITLE
#282 Pin playwright-report-mcp to 2.0.1 in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
     },
     "playwright-report-mcp": {
       "command": "npx",
-      "args": ["playwright-report-mcp@latest"],
+      "args": ["playwright-report-mcp@2.0.1"],
       "type": "stdio",
       "env": {
         "PW_DIR": "playwright/typescript"

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Four MCP servers are declared in `.mcp.json` and loaded automatically by any MCP
 
 An MCP server that runs the Playwright test suite and returns structured JSON results, enabling agentic workflows (self-healing, test generation verification) to act on test outcomes without parsing shell output.
 
-**Setup:** No setup required — runs via `npx playwright-report-mcp@latest` from the official npm registry.
+**Setup:** No setup required — runs via `npx playwright-report-mcp@2.0.1` from the official npm registry. The version is pinned in `.mcp.json` so upstream releases don't silently change behavior between runs.
 
 **Configuration:** The following environment variables can be set in `.mcp.json` (unset variables use their defaults):
 
@@ -434,7 +434,7 @@ This repo sets `PW_DIR` to `playwright/typescript` so the server targets the cor
 ```json
 "playwright-report-mcp": {
   "command": "npx",
-  "args": ["playwright-report-mcp@latest"],
+  "args": ["playwright-report-mcp@2.0.1"],
   "type": "stdio",
   "env": {
     "PW_DIR": "playwright/typescript"


### PR DESCRIPTION
## Summary

Pins `playwright-report-mcp` in `.mcp.json` to an exact version (`2.0.1`) instead of `@latest`, matching the pinning style used for `@playwright/mcp@0.0.68`. Also updates `README.md` prose and the example config block so the docs reflect the pinned version and the rationale.

Closes #282

## Why

`@latest` means every `npx` invocation pulls whatever upstream has published most recently, so tool behavior can drift between two consecutive CI runs or between two local sessions. Pinning removes that drift and aligns with the sibling `@playwright/mcp` entry.

## Test plan

- [x] `.mcp.json` resolves `playwright-report-mcp` to `2.0.1`, not `@latest`
- [x] `README.md` setup prose and example JSON block both show `@2.0.1`
- [x] `npx playwright-report-mcp@2.0.1` installs from the registry (verified via `npm view` and a live install)
- [x] MCP `initialize` handshake succeeds with the pinned version (returned `protocolVersion 2024-11-05`, tools capability with `listChanged: true`)
- [x] No other files reference `playwright-report-mcp@latest` (grep verified)
- [x] CI lint/format workflows pass on the PR
