### PR TITLE
#319 Bump playwright-report-mcp 2.0.1 → 2.0.2 in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
     },
     "playwright-report-mcp": {
       "command": "npx",
-      "args": ["playwright-report-mcp@2.0.1"],
+      "args": ["playwright-report-mcp@2.0.2"],
       "type": "stdio",
       "env": {
         "PW_DIR": "playwright/typescript"


### PR DESCRIPTION
Closes #319

## Summary
Bumps the pinned `playwright-report-mcp` version in `.mcp.json` from `2.0.1` to `2.0.2`. 2.0.2 upstream fix: `serverInfo.name` / `serverInfo.version` now loaded from `package.json` (upstream PR #74 / issue #71) instead of hardcoded — no tool-surface or protocol changes.

Verified 2.0.2 out-of-band under Node 25.7.0 via stdio:
- `initialize` returns `serverInfo: {"name":"playwright-report-mcp","version":"2.0.2"}`.
- `tools/list` returns the same four tools (`run_tests`, `get_failed_tests`, `get_test_attachment`, `list_tests`) with unchanged input schemas.
- `list_tests({tag:"@smoke"})` returns the same 20 specs as 2.0.1.

## Test plan
- [x] `.mcp.json` pins `playwright-report-mcp@2.0.2` (single-line diff).
- [x] JSON is valid (parsed with `python3 -m json.tool`).
- [x] 2.0.2 server boots and reports `serverInfo.version: "2.0.2"` (verified via stdio).
- [x] `list_tests({tag:"@smoke"})` returns 20 specs under 2.0.2 (verified via stdio).
- [ ] Fresh Claude Code session started against this branch loads the MCP without error (requires session restart — reviewer / post-merge check).
- [ ] Post-merge: tick DoD checkboxes on #319 and record Actual hours on Project #1.
