### PR TITLE
#326 Bypass npm min-release-age for playwright-report-mcp

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
     },
     "playwright-report-mcp": {
       "command": "npx",
-      "args": ["playwright-report-mcp@2.0.2"],
+      "args": ["--min-release-age=0", "playwright-report-mcp@2.0.2"],
       "type": "stdio",
       "env": {
         "PW_DIR": "playwright/typescript"


### PR DESCRIPTION
Closes #326

## Summary

Adds `--min-release-age=0` to the `npx` invocation for the `playwright-report-mcp` server in `.mcp.json` so machines with a global minimum-release-age / `before` npm policy can fetch and start the server. Scoped to this one entry — every other npm/npx call in the repo still inherits the user's global policy.

Safe because I own `playwright-report-mcp` and the version is pinned to `@2.0.2`; the bypass does not broaden what can be fetched.

## Test plan

- [x] `.mcp.json` still parses as valid JSON.
- [ ] After merge, a Claude Code restart on a machine with the previously-blocking policy shows `claude mcp list` → `playwright-report-mcp: ✓ Connected`.
- [ ] `mcp__playwright-report-mcp__run_tests` and friends appear in the in-session tool list.
- [ ] No change in behaviour for contributors without the policy.
