### PR TITLE
#333 Extend lint-staged glob to .html and .xhtml

### DIFF
--- a/playwright/typescript/package.json
+++ b/playwright/typescript/package.json
@@ -22,7 +22,7 @@
     "prepare": "cd ../.. && husky playwright/typescript/.husky"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,json,md,yml,yaml}": "prettier --write"
+    "*.{ts,tsx,js,json,md,yml,yaml,html,xhtml}": "prettier --write"
   },
   "type": "module"
 }


### PR DESCRIPTION
Closes #333

## Summary

One-line change to `playwright/typescript/package.json`: extend the `lint-staged` glob from `*.{ts,tsx,js,json,md,yml,yaml}` to `*.{ts,tsx,js,json,md,yml,yaml,html,xhtml}` so Prettier runs on staged HTML and XHTML fixtures at pre-commit time.

## Why

CI's `Prettier format check` runs `prettier --check .` against every file Prettier parses, including `*.html` and `*.xhtml`. The existing glob omitted both, so committing an HTML/XHTML fixture locally passed the husky pre-commit hook but then failed the CI lint step. This was reproduced three times in PR #332 (tracking-html5.html, tracking-html4.html, tracking.xhtml), each requiring a follow-up commit.

## Test plan

- [x] Staged an unformatted HTML file, ran `npx lint-staged` in the worktree, confirmed Prettier reformatted it before lint-staged finished (output shows `*.{…,html,xhtml} — 1 file` → `prettier --write` → `COMPLETED`)
- [x] `npx prettier --check test-data/scripts/*.html test-data/scripts/*.xhtml` reports "All matched files use Prettier code style!"
- [x] No test-suite changes → no unit/Playwright runs needed
- [ ] CI `Prettier format check` step passes on this PR
- [ ] CI `Playwright Typescript Tests` step passes (unaffected by config change)
