### PR TITLE
#334 Adopt @prettier/plugin-xml for .xhtml files

### DIFF
--- a/playwright/typescript/.prettierrc
+++ b/playwright/typescript/.prettierrc
@@ -3,5 +3,15 @@
   "singleQuote": true,
   "printWidth": 100,
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "plugins": ["@prettier/plugin-xml"],
+  "xmlWhitespaceSensitivity": "preserve",
+  "overrides": [
+    {
+      "files": ["*.xhtml"],
+      "options": {
+        "parser": "xml"
+      }
+    }
+  ]
 }

--- a/playwright/typescript/package-lock.json
+++ b/playwright/typescript/package-lock.json
@@ -9,6 +9,7 @@
         "@axe-core/playwright": "^4.11.2",
         "@google/generative-ai": "^0.24.1",
         "@playwright/test": "^1.59.1",
+        "@prettier/plugin-xml": "^3.4.2",
         "@types/node": "^25.6.0",
         "@types/pngjs": "^6.0.5",
         "dotenv": "^17.4.2",
@@ -90,6 +91,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@prettier/plugin-xml": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.4.2.tgz",
+      "integrity": "sha512-/UyNlHfkuLXG6Ed85KB0WBF283xn2yavR+UtRibBRUcvEJId2DSLdGXwJ/cDa1X++SWDPzq3+GSFniHjkNy7yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xml-tools/parser": "^1.0.11"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -108,6 +122,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@xml-tools/parser": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chevrotain": "7.1.1"
       }
     },
     "node_modules/ansi-escapes": {
@@ -160,6 +184,16 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+      "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "regexp-to-ast": "0.5.0"
       }
     },
     "node_modules/cli-cursor": {
@@ -517,6 +551,13 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",

--- a/playwright/typescript/package.json
+++ b/playwright/typescript/package.json
@@ -4,6 +4,7 @@
     "@axe-core/playwright": "^4.11.2",
     "@google/generative-ai": "^0.24.1",
     "@playwright/test": "^1.59.1",
+    "@prettier/plugin-xml": "^3.4.2",
     "@types/node": "^25.6.0",
     "@types/pngjs": "^6.0.5",
     "dotenv": "^17.4.2",

--- a/playwright/typescript/test-data/scripts/tracking.xhtml
+++ b/playwright/typescript/test-data/scripts/tracking.xhtml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
   <head>
     <title>Orwell Stat tracking fixture - XHTML</title>


### PR DESCRIPTION
Closes #334

## Summary

- Installed `@prettier/plugin-xml@3.4.2` as a dev dependency (required `--legacy-peer-deps` because the plugin's peer range is `^3.0.0` while this repo is on Prettier `^3.8.3`).
- Registered the plugin in `playwright/typescript/.prettierrc` and added an override that maps `*.xhtml` to the `xml` parser.
- Set `xmlWhitespaceSensitivity: "preserve"` so `&amp;` entities inside `<script>` blocks and other whitespace-sensitive constructs are not reflowed.
- Reformatted `test-data/scripts/tracking.xhtml` with the new plugin: two whitespace-only cosmetic changes (space before `?>` in the XML declaration, DOCTYPE wrapped to two lines). Every `&amp;` entity and the `osScriptSource` URL are preserved byte-for-byte.

## Test plan

- [x] `npm run format:check` passes across the repo after the reformat
- [x] `npx playwright test tests/zone-scripts.spec.ts` passes on Chromium (all 4 tests: structural + 3 E2E)
- [x] Diff on `tracking.xhtml` is limited to the two XML-prolog/DOCTYPE cosmetics (no changes inside the `<script>` block)
- [ ] CI `Playwright Typescript Lint and Types` passes
- [ ] CI `Playwright Typescript Tests` passes on Chromium, Firefox, Webkit, Mobile Chrome, Mobile Safari
