### PR TITLE
#337 Update failed-authentication API test for CSRF-gated /zone/ login

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Use `--grep` to run a subset and `--grep-invert` to exclude it (see [Running tes
 
 - `tests/` — Playwright test specs (`.spec.ts`)
   - `navigation.spec.ts` — UI navigation and title tests; tagged `@smoke`
-  - `api.spec.ts` — HTTP-level tests for public and authenticated pages; tagged `@smoke`
+  - `api.spec.ts` — HTTP-level tests for public and authenticated pages, plus the `/zone/` login CSRF gate: `failed authentication` GETs the login form to extract the rendered `_csrf` hidden input before POSTing bad credentials (asserts 401); sibling tests pin the CSRF-rejection paths (POST without `_csrf` → 403; POST with mismatched `_csrf` → 403); tagged `@smoke`
   - `accessibility.spec.ts` — WCAG accessibility tests across pages; tagged `@regression`
   - `home.spec.ts` — Home page content and navigation tests (including `PreviouslyAddedPage`); tagged `@regression`
   - `about-system.spec.ts` — About System page headings and statsbar content tests; tagged `@regression`
@@ -518,7 +518,7 @@ BASIC_AUTH_PASSWORD=<staging basic auth password>
 
 > `bruno/.env` must be at the collection root — Bruno CLI reads secrets from there, not from `environments/`.
 
-To adapt Bruno to another application, replace the `baseUrl` values in [production.bru](./bruno/environments/production.bru) and [staging.bru](./bruno/environments/staging.bru), then update the requests in [login-valid.bru](./bruno/login-valid.bru) and [login-invalid.bru](./bruno/login-invalid.bru) to match your login endpoint, request body, and expected status codes.
+To adapt Bruno to another application, replace the `baseUrl` values in [production.bru](./bruno/environments/production.bru) and [staging.bru](./bruno/environments/staging.bru), then update the requests in [csrf-bootstrap.bru](./bruno/csrf-bootstrap.bru), [login-valid.bru](./bruno/login-valid.bru), and [login-invalid.bru](./bruno/login-invalid.bru) to match your login endpoint, CSRF-token source, request body, and expected status codes.
 
 ### Environments
 
@@ -548,10 +548,11 @@ In `.bru` files:
 
 ### Requests
 
-| File                | Description                                          |
-| ------------------- | ---------------------------------------------------- |
-| `login-valid.bru`   | POST `/zone/` with valid credentials — expects 200   |
-| `login-invalid.bru` | POST `/zone/` with invalid credentials — expects 401 |
+| File                 | Description                                                                                                                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `csrf-bootstrap.bru` | GET `/zone/` (seq 0), extract the rendered `_csrf` hidden input via post-response script, store as `{{csrfToken}}` — expects 200 |
+| `login-invalid.bru`  | POST `/zone/` with invalid credentials + `_csrf: {{csrfToken}}` — expects 401                                                    |
+| `login-valid.bru`    | POST `/zone/` with valid credentials + `_csrf: {{csrfToken}}` — expects 200                                                      |
 
 **CI:** `.github/workflows/bruno.yml` — runs on push/PR to main/master, `pull_request_review` (submitted/dismissed), and `workflow_dispatch`; a `check-approval` pre-check job requires at least one `APPROVED` review before tests run — push and `workflow_dispatch` events bypass the gate automatically; writes secrets into `bruno/.env`, runs `bru run --env production`, then removes `.env` in a `Cleanup credentials` step (`if: always()`) so no plaintext credentials remain on the runner filesystem after the job. Supports `workflow_dispatch` with a `runner` text input (leave empty to use `vars.RUNNER`) for routing to a local self-hosted runner.
 

--- a/README.md
+++ b/README.md
@@ -550,9 +550,9 @@ In `.bru` files:
 
 | File                 | Description                                                                                                                      |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `csrf-bootstrap.bru` | GET `/zone/` (seq 0), extract the rendered `_csrf` hidden input via post-response script, store as `{{csrfToken}}` — expects 200 |
-| `login-invalid.bru`  | POST `/zone/` with invalid credentials + `_csrf: {{csrfToken}}` — expects 401                                                    |
-| `login-valid.bru`    | POST `/zone/` with valid credentials + `_csrf: {{csrfToken}}` — expects 200                                                      |
+| `csrf-bootstrap.bru` | GET `/zone/` (seq 0), extract the rendered `_csrf` hidden input via post-response script, store as `{{bootstrapCsrfToken}}` — expects 200. Captured once; not refreshed after `login-valid.bru` rotates the server-side token on success |
+| `login-invalid.bru`  | POST `/zone/` (seq 1) with invalid credentials + `_csrf: {{bootstrapCsrfToken}}` — expects 401                                                                                                                                           |
+| `login-valid.bru`    | POST `/zone/` (seq 2) with valid credentials + `_csrf: {{bootstrapCsrfToken}}` — expects 200                                                                                                                                             |
 
 **CI:** `.github/workflows/bruno.yml` — runs on push/PR to main/master, `pull_request_review` (submitted/dismissed), and `workflow_dispatch`; a `check-approval` pre-check job requires at least one `APPROVED` review before tests run — push and `workflow_dispatch` events bypass the gate automatically; writes secrets into `bruno/.env`, runs `bru run --env production`, then removes `.env` in a `Cleanup credentials` step (`if: always()`) so no plaintext credentials remain on the runner filesystem after the job. Supports `workflow_dispatch` with a `runner` text input (leave empty to use `vars.RUNNER`) for routing to a local self-hosted runner.
 

--- a/bruno/csrf-bootstrap.bru
+++ b/bruno/csrf-bootstrap.bru
@@ -1,0 +1,33 @@
+meta {
+  name: CSRF bootstrap
+  type: http
+  seq: 0
+}
+
+get {
+  url: {{baseUrl}}/zone/
+  auth: none
+}
+
+script:pre-request {
+  const user = bru.getProcessEnv('BASIC_AUTH_USER');
+  const pass = bru.getProcessEnv('BASIC_AUTH_PASSWORD');
+  if (user) {
+    req.setHeader('Authorization', 'Basic ' + btoa(user + ':' + pass));
+  }
+}
+
+script:post-response {
+  const match = res.body.match(/name=["']_csrf["']\s+value=["']([^"']+)["']/);
+  if (!match) {
+    throw new Error('login form did not render a _csrf hidden input');
+  }
+  bru.setVar('csrfToken', match[1]);
+}
+
+tests {
+  test("returns 200 OK and captures csrfToken", function() {
+    expect(res.status).to.equal(200);
+    expect(bru.getVar('csrfToken')).to.be.a('string').with.length.greaterThan(0);
+  });
+}

--- a/bruno/csrf-bootstrap.bru
+++ b/bruno/csrf-bootstrap.bru
@@ -22,12 +22,12 @@ script:post-response {
   if (!match) {
     throw new Error('login form did not render a _csrf hidden input');
   }
-  bru.setVar('csrfToken', match[1]);
+  bru.setVar('bootstrapCsrfToken', match[1]);
 }
 
 tests {
-  test("returns 200 OK and captures csrfToken", function() {
+  test("returns 200 OK and captures bootstrapCsrfToken", function() {
     expect(res.status).to.equal(200);
-    expect(bru.getVar('csrfToken')).to.be.a('string').with.length.greaterThan(0);
+    expect(bru.getVar('bootstrapCsrfToken')).to.be.a('string').with.length.greaterThan(0);
   });
 }

--- a/bruno/login-invalid.bru
+++ b/bruno/login-invalid.bru
@@ -26,6 +26,7 @@ body:form-urlencoded {
   username: test
   password: test
   option: login
+  _csrf: {{csrfToken}}
 }
 
 tests {

--- a/bruno/login-invalid.bru
+++ b/bruno/login-invalid.bru
@@ -26,7 +26,7 @@ body:form-urlencoded {
   username: test
   password: test
   option: login
-  _csrf: {{csrfToken}}
+  _csrf: {{bootstrapCsrfToken}}
 }
 
 tests {

--- a/bruno/login-valid.bru
+++ b/bruno/login-valid.bru
@@ -26,7 +26,7 @@ body:form-urlencoded {
   username: {{process.env.ORWELLSTAT_USER}}
   password: {{process.env.ORWELLSTAT_PASSWORD}}
   option: login
-  _csrf: {{csrfToken}}
+  _csrf: {{bootstrapCsrfToken}}
 }
 
 tests {

--- a/bruno/login-valid.bru
+++ b/bruno/login-valid.bru
@@ -26,6 +26,7 @@ body:form-urlencoded {
   username: {{process.env.ORWELLSTAT_USER}}
   password: {{process.env.ORWELLSTAT_PASSWORD}}
   option: login
+  _csrf: {{csrfToken}}
 }
 
 tests {

--- a/playwright/typescript/tests/api.spec.ts
+++ b/playwright/typescript/tests/api.spec.ts
@@ -36,7 +36,7 @@ test('authenticated pages', { tag: '@smoke' }, async ({ authenticatedRequest }) 
 test('failed authentication', { tag: '@smoke' }, async ({ unauthenticatedRequest }) => {
   const loginPage = await unauthenticatedRequest.get('/zone/');
   expect(loginPage.status()).toBe(200);
-  const match = (await loginPage.text()).match(/name="_csrf"\s+value="([^"]+)"/);
+  const match = (await loginPage.text()).match(/name=["']_csrf["']\s+value=["']([^"']+)["']/);
   if (!match) throw new Error('login form did not render a _csrf hidden input');
   const response = await unauthenticatedRequest.post('/zone/', {
     form: {

--- a/playwright/typescript/tests/api.spec.ts
+++ b/playwright/typescript/tests/api.spec.ts
@@ -33,13 +33,51 @@ test('authenticated pages', { tag: '@smoke' }, async ({ authenticatedRequest }) 
   }
 });
 
-test('failed authentication', { tag: '@smoke' }, async ({ request }) => {
-  const response = await request.post('/zone/', {
+test('failed authentication', { tag: '@smoke' }, async ({ unauthenticatedRequest }) => {
+  const loginPage = await unauthenticatedRequest.get('/zone/');
+  expect(loginPage.status()).toBe(200);
+  const match = (await loginPage.text()).match(/name="_csrf"\s+value="([^"]+)"/);
+  if (!match) throw new Error('login form did not render a _csrf hidden input');
+  const response = await unauthenticatedRequest.post('/zone/', {
     form: {
       username: 'test',
       password: 'test',
       option: 'login',
+      _csrf: match[1],
     },
   });
   expect(response.status()).toBe(401);
 });
+
+test(
+  'login POST without CSRF token is rejected',
+  { tag: '@smoke' },
+  async ({ unauthenticatedRequest }) => {
+    const response = await unauthenticatedRequest.post('/zone/', {
+      form: {
+        username: 'test',
+        password: 'test',
+        option: 'login',
+      },
+    });
+    expect(response.status()).toBe(403);
+  }
+);
+
+test(
+  'login POST with invalid CSRF token is rejected',
+  { tag: '@smoke' },
+  async ({ unauthenticatedRequest }) => {
+    // GET first so the session holds a real token; the POST then submits a wrong one.
+    await unauthenticatedRequest.get('/zone/');
+    const response = await unauthenticatedRequest.post('/zone/', {
+      form: {
+        username: 'test',
+        password: 'test',
+        option: 'login',
+        _csrf: 'deadbeef',
+      },
+    });
+    expect(response.status()).toBe(403);
+  }
+);


### PR DESCRIPTION
## Summary

Updates `playwright/typescript/tests/api.spec.ts:36` to fetch a CSRF token from the rendered login form before POSTing bad credentials, and adds two new smoke tests that pin the new CSRF-rejection behavior.

Backend commit `0a7212c` (2026-04-22) made `libs/operations.php::doit("login")` call `csrf_check()` before `login()`. Without a matching `_csrf` field, production now responds `403` before credential validation — short-circuiting the old `401 bad credentials` path the test expected. Existing test failed across every browser on CI until this change.

Switches the fixture from `request` (populated storageState, no login form in the logged-in view) to `unauthenticatedRequest` so the GET can return the login page with its CSRF hidden input.

Closes #337

## Test plan

- [x] `failed authentication` passes with a valid CSRF + bad credentials → 401, verified via `playwright-report-mcp` on `bugfix/337`.
- [x] `login POST without CSRF token is rejected` asserts 403, verified in the same run.
- [x] `login POST with invalid CSRF token is rejected` asserts 403, verified in the same run.
- [x] The three pre-existing api tests (`public pages without authentication`, `public pages with authentication`, `authenticated pages`) remain green.
- [ ] Full matrix re-run on this branch remains green (reviewer / CI to confirm).
