### PR TITLE
Bump fast-xml-parser override to >=5.7.0 in bruno (CVE-2026-41650)

### DIFF
--- a/bruno/package-lock.json
+++ b/bruno/package-lock.json
@@ -1516,6 +1516,19 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -3404,9 +3417,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "dev": true,
       "funding": [
         {
@@ -3420,9 +3433,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
-      "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "dev": true,
       "funding": [
         {
@@ -3432,8 +3445,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.4.0",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
       "bin": {

--- a/bruno/package.json
+++ b/bruno/package.json
@@ -8,7 +8,7 @@
   },
   "overrides": {
     "axios": ">=1.15.0",
-    "fast-xml-parser": ">=5.5.7",
+    "fast-xml-parser": ">=5.7.0",
     "picomatch": ">=2.3.2"
   }
 }


### PR DESCRIPTION
## Summary

Bumps the npm `overrides` floor for `fast-xml-parser` in `bruno/` from `>=5.5.7` to `>=5.7.0` to clear Dependabot alert [#18](https://github.com/hubertgajewski/orwellstat/security/dependabot/18) ([CVE-2026-41650](https://github.com/advisories/GHSA-gh4j-gqv2-49f6) — XMLBuilder comment & CDATA injection via unescaped delimiters, CVSS 6.1 medium).

`fast-xml-parser` is a transitive dev dependency reached via `@usebruno/cli → @aws-sdk/credential-providers → @aws-sdk/core → @aws-sdk/xml-builder`. After this bump, `npm ci` resolves `fast-xml-parser@5.7.1` (replacing the previously locked `5.5.11`), which is in the patched line.

Practical risk for this repo is low — Bruno only runs locally / in CI to exercise the OrwellStat backend, never builds XML from untrusted input — but the alert deserves a clean close.

## Test plan

- [x] `bruno/package.json` `overrides.fast-xml-parser` reads `>=5.7.0`
- [x] `cd bruno && npm ci` succeeds and resolves a single `fast-xml-parser@5.7.1`
- [x] `npm ls fast-xml-parser` in `bruno/` shows `>=5.7.0` only (no vulnerable copy left)
- [x] `npm audit` in `bruno/` no longer reports `fast-xml-parser` (the 3 remaining moderate findings are an unrelated `uuid<14` issue in `@usebruno/{cli,js}` with "no fix available", out of scope)
- [ ] CI green on this branch
- [ ] After merge: Dependabot dismisses alert #18 automatically

## Notes

- No source-code changes — only `bruno/package.json` (one line) and `bruno/package-lock.json` (regenerated).
- Follows the override pattern previously established in [#79](https://github.com/hubertgajewski/orwellstat/pull/79), [#129](https://github.com/hubertgajewski/orwellstat/pull/129), and [#172](https://github.com/hubertgajewski/orwellstat/pull/172).
