### PR TITLE
#349 Bump playwright-report-mcp pin to 3.1.0

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
     },
     "playwright-report-mcp": {
       "command": "npx",
-      "args": ["--min-release-age=0", "playwright-report-mcp@3.0.0"],
+      "args": ["--min-release-age=0", "playwright-report-mcp@3.1.0"],
       "type": "stdio",
       "env": {
         "PW_ALLOWED_DIRS": ".."


### PR DESCRIPTION
## Summary
Bump the `playwright-report-mcp` pin in `.mcp.json` from `3.0.0` to `3.1.0` (published 2026-04-24). The new version exposes six additional Playwright CLI flags on the `run_tests` tool: `updateSnapshots`, `headed`, `workers`, `retries`, `maxFailures`, `trace` (upstream PR #85). Pure config change — no consumer code in this repo calls those flags yet, but unlocking them lets future Claude sessions drive snapshot refreshes and retry tuning directly through the MCP.

Closes #349

## Test plan
- [x] `.mcp.json` pins `playwright-report-mcp@3.1.0`.
- [x] JSON still valid; `--min-release-age=0` guard preserved.
- [x] Schema snapshot confirms the currently-loaded 3.0.0 `run_tests` tool lacks the six new inputs (regression guard documented).
- [x] After restarting Claude Code against this branch, `mcp__playwright-report-mcp__run_tests` accepts `updateSnapshots`, `headed`, `workers`, `retries`, `maxFailures`, and `trace` inputs without schema error (requires fresh session — MCP servers are spawned at session start).

