### PR TITLE
Bump postcss to 8.5.10 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/mcp/quality-metrics/package-lock.json
+++ b/mcp/quality-metrics/package-lock.json
@@ -1972,9 +1972,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #20 (GHSA-qx2v-qp2m-jg93, CVE-2026-41305) — postcss < 8.5.10 fails to escape `</style>` in stringified output, enabling XSS when untrusted CSS is embedded in HTML.

- Bumps transitive `postcss` 8.5.8 → 8.5.10 under `vite`/`vitest` in `mcp/quality-metrics`.
- Lockfile-only change.
- Practical risk in this repo is none (the MCP doesn't render user-supplied CSS into pages), but keeping the alert closed avoids GHAS noise.

## Test plan
- [x] `npm test` in `mcp/quality-metrics` (11 passed)
