### PR TITLE
#363 Rename CODEX.md to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CODEX.md
+# AGENTS.md
 
 Follow the repository guidance in [CLAUDE.md](./CLAUDE.md).
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Size is a coarse roadmap guess for epics, not a mechanical sum of children's poi
 .mcp.json                   # MCP server definitions (MCP_DOCKER, playwright, playwright-report-mcp, quality-metrics) — loaded by Claude Code and other MCP-compatible AI assistants
 .github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
-CODEX.md                    # Codex entrypoint; delegates shared repository guidance to CLAUDE.md
+AGENTS.md                   # Codex entrypoint; delegates shared repository guidance to CLAUDE.md
 GEMINI.md                   # Gemini entrypoint; delegates shared repository guidance to CLAUDE.md
 QUALITY_METRICS.md          # auto-generated quality metrics report (escape rate, MTTR, coverage, trends)
 SECURITY.md                 # security policy and vulnerability reporting


### PR DESCRIPTION
## Summary
Renames `CODEX.md` → `AGENTS.md` so Codex (and other agents.md-aware tooling) discovers the entrypoint at the conventional path. Updates the heading inside the file and the structure listing in `README.md` accordingly.

Closes #363

## Test plan
- [x] `git mv` preserved history (rename detected at 100% similarity in the commit).
- [x] `grep -r "CODEX.md"` returns no matches in tracked files.
- [x] `README.md` repo-structure listing references `AGENTS.md`.
- [x] `AGENTS.md` H1 heading matches the new filename.