### PR TITLE
#283 Remove selenium/ references from README and SECURITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ scripts/
   setup-runners.sh             # registers and starts 8 self-hosted runner instances as launchd services
 playwright/
   typescript/               # Playwright tests in TypeScript
-selenium/                   # Selenium tests (planned)
 bruno/                      # Bruno API request collection
 mcp/
   quality-metrics/          # local MCP server exposing escape rate, MTTR, and metrics history

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-This repository contains test automation code (Playwright, Selenium, Bruno) for the orwellstat project. It is not a versioned software product and does not have supported release versions.
+This repository contains test automation code (Playwright, Bruno) for the orwellstat project. It is not a versioned software product and does not have supported release versions.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Decision on #283: **remove**. The `selenium/` placeholder is not tracked in git and no concrete scope existed to justify keeping it advertised. Stripping the remaining doc references — `README.md` repo tree and `SECURITY.md` prose — completes option (a) of the issue's acceptance criteria.

## Changes

- `README.md`: drop `selenium/` line from the repo structure tree.
- `SECURITY.md`: drop "Selenium" from the test-automation tooling list.

The workspace-level `CLAUDE.md` already had no selenium references.

## Test plan

- [x] `grep -rn -i selenium README.md SECURITY.md CLAUDE.md` returns no matches.
- [x] `git ls-files selenium/` is empty (directory was never tracked).
- [ ] CI (`playwright-typescript-lint.yml`, link/format checks) green on this branch.

Closes #283
