### PR TITLE
#372 Move approval gate into reusable workflow so matrix always fans out

### DIFF
--- a/.github/workflows/playwright-run.yml
+++ b/.github/workflows/playwright-run.yml
@@ -41,6 +41,10 @@ on:
         description: "Git ref to check out (empty = workflow's own ref)"
         type: string
         default: ""
+      approved:
+        description: "Run the tests. False = skip (caller passes its PR approval gate here so the matrix still fans out)."
+        type: boolean
+        default: true
     secrets:
       ORWELLSTAT_USER:
         required: true
@@ -61,6 +65,7 @@ on:
 
 jobs:
   run:
+    if: inputs.approved
     name: ${{ inputs.project }}
     timeout-minutes: 15
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/playwright-run.yml
+++ b/.github/workflows/playwright-run.yml
@@ -66,7 +66,10 @@ on:
 jobs:
   run:
     if: inputs.approved
-    name: ${{ inputs.project }}
+    # Static name: GitHub does not resolve `${{ inputs.X }}` for skipped jobs and would render the
+    # literal expression in the Checks tab. The caller's matrix-scoped `name:` carries the project
+    # discriminator instead.
+    name: tests
     timeout-minutes: 15
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.env }}

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -51,8 +51,7 @@ concurrency:
 
 jobs:
   setup-matrix:
-    needs: check-approval
-    if: github.repository == 'hubertgajewski/orwellstat' && always() && (needs.check-approval.outputs.approved == 'true' || github.event_name == 'workflow_dispatch')
+    if: github.repository == 'hubertgajewski/orwellstat'
     runs-on: ${{ inputs.runner || vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 2
     outputs:
@@ -124,7 +123,7 @@ jobs:
 
   test:
     needs: [setup-matrix, check-approval]
-    if: github.repository == 'hubertgajewski/orwellstat' && always() && (needs.check-approval.outputs.approved == 'true' || github.event_name == 'workflow_dispatch')
+    if: github.repository == 'hubertgajewski/orwellstat' && !cancelled() && needs.setup-matrix.result == 'success'
     name: test (${{ matrix.browser }})
     strategy:
       fail-fast: false
@@ -139,6 +138,7 @@ jobs:
       env: ${{ inputs.env || 'staging' }}
       runner: ${{ inputs.runner || vars.RUNNER || 'ubuntu-latest' }}
       ref: ${{ github.event.inputs.ref || github.ref }}
+      approved: ${{ needs.check-approval.outputs.approved == 'true' || github.event_name == 'workflow_dispatch' }}
     secrets: inherit
 
   commit-baselines:

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -125,7 +125,7 @@ jobs:
   test:
     needs: [setup-matrix, check-approval]
     if: github.repository == 'hubertgajewski/orwellstat' && always() && (needs.check-approval.outputs.approved == 'true' || github.event_name == 'workflow_dispatch')
-    name: test
+    name: test (${{ matrix.browser }})
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -125,7 +125,7 @@ jobs:
   test:
     needs: [setup-matrix, check-approval]
     if: github.repository == 'hubertgajewski/orwellstat' && always() && (needs.check-approval.outputs.approved == 'true' || github.event_name == 'workflow_dispatch')
-    name: test (${{ matrix.browser }})
+    name: test
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -123,8 +123,8 @@ jobs:
 
   test:
     needs: [setup-matrix, check-approval]
-    if: github.repository == 'hubertgajewski/orwellstat' && !cancelled() && needs.setup-matrix.result == 'success'
-    name: test (${{ matrix.browser }})
+    if: github.repository == 'hubertgajewski/orwellstat' && needs.setup-matrix.result == 'success'
+    name: test (${{ matrix.id }})
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}


### PR DESCRIPTION
## Summary

Move the PR-approval gate from `playwright-typescript.yml`'s caller `if:` into a new boolean `approved` input on the reusable workflow `playwright-run.yml`. This guarantees the matrix always fanouts, so the Checks tab shows one human-readable entry per browser in both approved and skipped states — never a raw `${{ matrix.X }}` or `${{ inputs.X }}` literal.

## What changed

`.github/workflows/playwright-typescript.yml`:
- `setup-matrix` no longer depends on `check-approval`. It must run unconditionally so `needs.setup-matrix.outputs.matrix` is available downstream; otherwise the test matrix has nothing to fan out.
- `test` job's `if:` reduced to `github.repository == ... && needs.setup-matrix.result == 'success'`. The implicit `success()` over `needs:` treats *skipped* as success, so `workflow_dispatch` (where `check-approval` is skipped) still runs the test job.
- Caller `name:` switched from `test (${{ matrix.browser }})` to `test (${{ matrix.id }})` so per-browser entries are unique now that the called workflow no longer surfaces the project name.
- The old approval expression is forwarded as the `approved:` input to the reusable workflow.

`.github/workflows/playwright-run.yml`:
- New `approved` boolean input (default `true`) and `if: inputs.approved` on the `run` job. When false, each per-browser caller-job sees its inner `run` skip — names render correctly because they don't depend on `inputs.X`.
- `name: ${{ inputs.project }}` replaced with static `name: tests` — `${{ inputs.X }}` does not resolve for skipped jobs and would otherwise leak as `inputs.project` in the Checks tab (observed live on this PR's earlier run `24955881925`).

## Why caller-only fixes failed

PR #370 already exhausted the caller-only `name:` design space (4 commits walking through `${{ matrix.project }}`, no name, `test`, `test (${{ matrix.browser }})`); today's earlier commits on this branch repeated two of those. The recurring obstacle is GitHub's binary rule: if `name:` contains an expression, the unexpanded literal leaks when the job is skipped pre-fanout; if it doesn't, the auto-suffix lists every matrix dimension. The only remaining lever is structural — make the matrix always fan out — which is what this PR does.

## Test plan

- [x] Diff: 8 additions / 4 deletions across the two workflow files (no ad-hoc one-line fix).
- [x] Approved path — run [`24955968011`](https://github.com/hubertgajewski/orwellstat/actions/runs/24955968011) shows the five entries `test (chromium) / tests`, `test (firefox) / tests`, `test (mobile-chrome) / tests`, `test (mobile-safari) / tests`, `test (webkit) / tests` all green.
- [x] Skipped path — run [`24955938849`](https://github.com/hubertgajewski/orwellstat/actions/runs/24955938849) shows the same five entries, all in `skipping` state. No `${{` or `inputs.X` literal anywhere.

Closes #372
