### PR TITLE
#375 Pin claude-code-action to v1.0.103 to stop Sonnet leak via OpenRouter

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,7 +57,11 @@ jobs:
       #   The Anthropic SDK sends both headers with the proxy key; OpenRouter accepts
       #   either. No cross-provider leak: the Anthropic key is only ever emitted when
       #   ANTHROPIC_BASE_URL is empty.
-      - uses: anthropics/claude-code-action@v1
+      # Pinned to v1.0.103 (4e5d8b13): later @v1 SHAs (>=v1.0.104, claude-cli 2.1.118+)
+      # ignore ANTHROPIC_DEFAULT_SONNET_MODEL for internal Agent SDK sub-calls and leak
+      # native Sonnet billing through OpenRouter. Do NOT bump to @v1 until upstream fix
+      # lands and is verified clean for 48h. See issue #375.
+      - uses: anthropics/claude-code-action@4e5d8b13ca281a6d163cdb287d8917b216e00d6f # v1.0.103
         id: claude_code_action
         env:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
@@ -149,7 +153,8 @@ jobs:
       - name: Claude Code Review (native Sonnet fallback)
         id: claude_code_action_fallback
         if: steps.claude_code_action.conclusion == 'success' && steps.primary_check.outputs.need_fallback == 'true'
-        uses: anthropics/claude-code-action@v1
+        # Pinned to v1.0.103 (4e5d8b13) — see comment on the primary step above. #375
+        uses: anthropics/claude-code-action@4e5d8b13ca281a6d163cdb287d8917b216e00d6f # v1.0.103
         env:
           # Clear proxy config so the Anthropic SDK hits the native endpoint.
           ANTHROPIC_BASE_URL: ''


### PR DESCRIPTION
## Summary

Pins `anthropics/claude-code-action` to v1.0.103 (`4e5d8b13ca281a6d163cdb287d8917b216e00d6f`) at both `uses:` references in `.github/workflows/claude-code-review.yml`. v1.0.104+ ships claude-cli 2.1.118+, which ignores `ANTHROPIC_DEFAULT_SONNET_MODEL` for internal Agent SDK sub-calls and routes them as native `claude-sonnet-4-6` through OpenRouter — leaking spend on `OPENROUTER_API_KEY` despite the top-level reviewer correctly using the configured Minimax preset.

Verified leak window: 2026-04-23 (16 reqs, $0.509) and 2026-04-25 (18 reqs, $0.652), $1.16 total. Smoking-gun OpenRouter generation `gen-1777134452-vDJrQWnyZ2Yy0V8gXmOk` (`user_agent: claude-cli/2.1.119`, `model: anthropic/claude-4.6-sonnet-20260217`) was fired during reviewer run `24935331336` on PR #365.

## Test plan

- [x] Both `uses:` lines pinned to the full 40-char SHA `4e5d8b13ca281a6d163cdb287d8917b216e00d6f` with an inline comment explaining the pin and lift-criteria.
- [x] Pin SHA verified against upstream tag `v1.0.103` via `gh api repos/anthropics/claude-code-action/git/ref/tags/v1.0.103`.
- [x] No functional change to env vars, prompt, signature line, or fallback condition.
- [ ] Reviewer run completes successfully on a sample PR with the pin in place (CI-verified on the next reviewer-eligible PR after merge).
- [ ] Review signature is `_Reviewed by proxy/@preset/minimax-minimax-m2-7-no-thinking_` (unchanged) on that PR.
- [ ] OpenRouter `/v1/activity` for the day after the pin shows **zero** `anthropic/claude-sonnet-4.6` requests.

Closes #375
