### PR TITLE
#375 Bump claude-code-review timeout-minutes 15 → 20

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,9 +10,11 @@ env:
 jobs:
   review:
     if: github.actor != 'dependabot[bot]' && vars.AI_REVIEW == 'true'
-    # 15 min (was 10) to accommodate a back-to-back primary + fallback run when the
-    # primary (proxy/Minimax) skips the mandate on a trivial diff; see #293.
-    timeout-minutes: 15
+    # 20 min (was 15) — the proxy/Minimax preset routinely runs 14–15 min on substantive
+    # diffs and was killed mid-stream on #377 (PR was 600 lines). 20 gives ~33 % headroom
+    # for the primary while still leaving room for a back-to-back fallback within the
+    # GitHub-hosted runner's overall budget. See #293 for the back-to-back rationale.
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Bumps `timeout-minutes` on the `review` job in `.github/workflows/claude-code-review.yml` from 15 → 20.

## Context

PR #377's reviewer run on the pinned `claude-code-action@v1.0.103` was cancelled at 15 min 6 s mid-stream (`gh run view 24959209466`). The `claude-code-action` step had run cleanly for the entire 15 minutes but didn't get a chance to flush the review before the GitHub-Actions hard timeout fired. A re-run on the same diff completed in ~13 min — so the existing 15 min budget has effectively zero headroom on substantive diffs (PR #377 was ~600 lines).

20 min gives ~33 % headroom for the primary while still leaving room for the back-to-back primary + fallback path documented in the prior comment (the original reason the cap was raised from 10 → 15 in #293).

This is independent of #375's pin (which is doing its job — the action ran fine on the pinned SHA, it just ran out of clock).

## Test plan

- [x] Comment updated to capture both the 10 → 15 history (#293) and the 15 → 20 rationale (this PR).
- [x] Only `timeout-minutes` and the surrounding comment touched — no other workflow changes.
- [ ] Reviewer run on this PR completes within 20 min and posts a review (CI verifies live).
- [ ] Subsequent reviewer runs on PRs with substantive diffs (e.g. on top of #377 once it's merged) finish well under 20 min.
