### PR TITLE
#421 Use getByRole('heading') for PreviouslyAddedPage.heading

### DIFF
--- a/playwright/typescript/pages/public/previously-added.page.ts
+++ b/playwright/typescript/pages/public/previously-added.page.ts
@@ -1,4 +1,4 @@
-import { type Page } from '@fixtures/base.fixture';
+import { type Locator, type Page } from '@fixtures/base.fixture';
 import { AbstractPage } from '@pages/abstract.page';
 import { NEWS, NEW_BROWSERS, NEW_OSES } from '@pages/common';
 
@@ -20,7 +20,15 @@ export class PreviouslyAddedPage extends AbstractPage {
     super(page, PreviouslyAddedPage.url, PreviouslyAddedPage.title);
   }
 
-  get heading() {
-    return this.page.getByText(PreviouslyAddedPage.previousBrowsersSection);
+  // /2/ renders no `<h*>` element with the "Poprzednio dodane" section text —
+  // those strings are body text only, following the `<h3>Obsługa nowych...</h3>`
+  // sub-headings. Every heading on /2/ (Logowanie do serwisu, Nowości, the two
+  // `<h3>Obsługa nowych...</h3>` sub-headings) is shared with `/`, so no truly
+  // page-specific heading exists. Expose `Nowości` — the first content `<h2>`,
+  // headlining the section that contains all of /2/'s content — so the abstract
+  // `heading: Locator` contract resolves to a real heading; same pattern as
+  // `HitsPage` and `AdminPage`.
+  get heading(): Locator {
+    return this.page.getByRole('heading', { name: PreviouslyAddedPage.news, exact: true });
   }
 }


### PR DESCRIPTION
Closes #421

## Summary

`PreviouslyAddedPage.heading` was returning `page.getByText(previousBrowsersSection)` — matching body text rather than a heading element, in violation of the abstract `heading: Locator` contract.

`/2/` does not render any `<h*>` element with the "Poprzednio dodane..." section text — those strings appear only as body text under `<h3>Obsługa nowych...</h3>` sub-headings. Every heading on `/2/` (`Logowanie do serwisu`, `Nowości`, the two `<h3>Obsługa nowych...</h3>` sub-headings) is also rendered on `/`, so no truly page-specific heading exists.

The getter now exposes the page's first content `<h2>` — `Nowości` — via `getByRole('heading', { name, exact: true })`. `Nowości` headlines the section that contains all of `/2/`'s content. This is the same pattern as `HitsPage` (exposes `<h2>Filtr</h2>`) and `AdminPage` (exposes `<h2>Twoje dane</h2>`), so the abstract contract stays unchanged across all page classes.

The page-specific `previousBrowsersSection` and `previousOsesSection` strings continue to be asserted via `getByText` in `home.spec.ts`, which is correct because those strings really are body text on this page.

## Test plan

- [x] `npx playwright test tests/home.spec.ts --project=Chromium` passes locally (3/3, ~19s)
- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean
- [x] Live `/2/` DOM verified via `curl`: `<h2>Nowości</h2>` is rendered; the `previousBrowsersSection` text is body content with no surrounding `<h*>`
- [ ] CI: full Playwright matrix (Chromium / Firefox / WebKit / Mobile Chrome / Mobile Safari) green
- [ ] CI: Playwright lint workflow green
