### PR TITLE
#413 Lock + atomic-rename markCovered to prevent lost parallel writes

### DIFF
--- a/mcp/coverage-matrix/index.ts
+++ b/mcp/coverage-matrix/index.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { readFileSync, writeFileSync, realpathSync } from 'fs';
+import { readFileSync, writeFileSync, renameSync, rmSync, realpathSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { z } from 'zod';
+import lockfile from 'proper-lockfile';
 import { repoRoot, ok, err } from '@orwellstat/mcp-shared';
 
 const PAGE_CATEGORIES = ['title', 'content', 'accessibility', 'visualRegression', 'api'] as const;
@@ -113,30 +114,47 @@ async function markCovered(args: { pageUrl: string; category: string }) {
     return err(`Invalid category "${category}". Valid categories: ${PAGE_CATEGORIES.join(', ')}`);
   }
 
-  const { matrix, error } = readMatrix();
-  if (!matrix) return err(error ?? 'unknown error');
-
-  if (!(pageUrl in matrix.pages)) {
-    return err(
-      `Unknown page URL "${pageUrl}". Known URLs: ${Object.keys(matrix.pages).join(', ')}`
-    );
-  }
-
-  const previous = matrix.pages[pageUrl][category];
-  matrix.pages[pageUrl][category] = true;
-
   const file = matrixPath();
+  let release: () => Promise<void>;
   try {
-    writeFileSync(file, JSON.stringify(matrix, null, 2) + '\n', 'utf8');
+    release = await lockfile.lock(file, {
+      retries: { retries: 20, factor: 1.5, minTimeout: 20, maxTimeout: 500 },
+    });
   } catch (e) {
-    return err(`Failed to write ${file}: ${(e as Error).message}`);
+    return err(`Failed to acquire lock on ${file}: ${(e as Error).message}`);
   }
 
-  return ok({
-    pageUrl,
-    category,
-    previous: previous === true,
-  });
+  try {
+    const { matrix, error } = readMatrix();
+    if (!matrix) return err(error ?? 'unknown error');
+
+    if (!(pageUrl in matrix.pages)) {
+      return err(
+        `Unknown page URL "${pageUrl}". Known URLs: ${Object.keys(matrix.pages).join(', ')}`
+      );
+    }
+
+    const previous = matrix.pages[pageUrl][category];
+    matrix.pages[pageUrl][category] = true;
+
+    // Same-dir tmp file so renameSync stays on one filesystem (atomic).
+    const tmp = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+    try {
+      writeFileSync(tmp, JSON.stringify(matrix, null, 2) + '\n', 'utf8');
+      renameSync(tmp, file);
+    } catch (e) {
+      rmSync(tmp, { force: true });
+      return err(`Failed to write ${file}: ${(e as Error).message}`);
+    }
+
+    return ok({
+      pageUrl,
+      category,
+      previous: previous === true,
+    });
+  } finally {
+    await release();
+  }
 }
 
 const server = new McpServer({ name: 'coverage-matrix', version: '1.0.0' });

--- a/mcp/coverage-matrix/package-lock.json
+++ b/mcp/coverage-matrix/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@orwellstat/mcp-shared": "file:../shared",
+        "proper-lockfile": "^4.1.2",
         "zod": "^4.0.0"
       },
       "bin": {
@@ -17,6 +18,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "@types/proper-lockfile": "^4.1.4",
         "@vitest/coverage-v8": "^4.1.3",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
@@ -560,6 +562,23 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.4",
@@ -1294,6 +1313,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2017,6 +2042,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2076,6 +2112,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rolldown": {
@@ -2296,6 +2341,12 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/source-map-js": {

--- a/mcp/coverage-matrix/package.json
+++ b/mcp/coverage-matrix/package.json
@@ -18,10 +18,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@orwellstat/mcp-shared": "file:../shared",
+    "proper-lockfile": "^4.1.2",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@types/proper-lockfile": "^4.1.4",
     "@vitest/coverage-v8": "^4.1.3",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"

--- a/mcp/coverage-matrix/test/server.test.ts
+++ b/mcp/coverage-matrix/test/server.test.ts
@@ -280,6 +280,31 @@ describe('coverage-matrix MCP', () => {
       expect(after).toBe(before);
     });
 
+    it('serialises ≥5 concurrent markCovered calls; every flip lands', async () => {
+      const calls = [
+        { pageUrl: '/a/', category: 'content' },
+        { pageUrl: '/a/', category: 'visualRegression' },
+        { pageUrl: '/c/', category: 'title' },
+        { pageUrl: '/c/', category: 'content' },
+        { pageUrl: '/c/', category: 'accessibility' },
+        { pageUrl: '/c/', category: 'visualRegression' },
+        { pageUrl: '/c/', category: 'api' },
+      ];
+      const results = await Promise.all(calls.map((c) => markCovered(c)));
+      for (const r of results) {
+        expect(r.isError).toBeFalsy();
+      }
+      const final = readMatrix();
+      expect(final.pages['/a/'].content).toBe(true);
+      expect(final.pages['/a/'].visualRegression).toBe(true);
+      expect(final.pages['/c/'].title).toBe(true);
+      expect(final.pages['/c/'].content).toBe(true);
+      expect(final.pages['/c/'].accessibility).toBe(true);
+      expect(final.pages['/c/'].visualRegression).toBe(true);
+      expect(final.pages['/c/'].api).toBe(true);
+      expect(final.pages['/b/']).toEqual(SAMPLE_MATRIX.pages['/b/']);
+    });
+
     it('preserves trailing newline and JSON structure when writing', async () => {
       await markCovered({ pageUrl: '/a/', category: 'content' });
       const raw = readFileSync(

--- a/mcp/coverage-matrix/tsconfig.json
+++ b/mcp/coverage-matrix/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "rootDir": ".",
     "strict": true,
+    "esModuleInterop": true,
     "types": ["node"]
   },
   "include": ["index.ts"],


### PR DESCRIPTION
## Summary

Fixes a silent lost-write race in `mcp/coverage-matrix`'s `mark_covered` handler when two Claude sessions (typical with worktree-per-issue) race on the matrix file. The handler now serialises read-modify-write under an advisory lock and persists via temp-file + atomic rename.

- `markCovered` acquires a `proper-lockfile` advisory lock on `coverage-matrix.json`, re-reads inside the lock, writes to a same-directory tmp file, and `renameSync`s atomically over the target.
- Tmp file lives next to the target (not under `tmpdir()`) to guarantee the rename stays on one filesystem.
- Lock retry config: `retries: 20, factor: 1.5, minTimeout: 20, maxTimeout: 500` — bounded under contention; `proper-lockfile`'s default 10s stale detection unwedges crashed holders.
- Added a Vitest concurrency test that fires 7 concurrent `markCovered` calls (covering both `pages` keys present in the sample matrix and 5 of the 5 categories) and asserts every flip lands plus that an unrelated page is untouched.
- Enabled `esModuleInterop` in `mcp/coverage-matrix/tsconfig.json` so the CJS `proper-lockfile` package can be imported with default-import syntax.

Closes #413

## Test plan

- [x] `npm run build` in `mcp/coverage-matrix/` succeeds (after `mcp/shared/` is built per the file-dep order documented in README.md)
- [x] `npm test` in `mcp/coverage-matrix/` passes — 13/13 (12 prior + 1 new concurrency test)
- [x] New test fires 7 concurrent `markCovered` calls; all flips land; sibling `/b/` page bytes unchanged
- [x] Manual fresh-reviewer pass on full diff (no dead code, helpful WHY comment on the same-dir tmp choice, error handling consistent with existing pattern)
- [ ] CI green on this PR (Verify Coverage Matrix, lint-and-types, etc.)

## Notes for reviewer

- The issue's implementation hint suggested writing the tmp file under `os.tmpdir()`. I deviated to write it next to the target file because `renameSync` only guarantees atomicity within the same filesystem — `tmpdir()` is on a separate mount on some macOS configurations and Linux containers, and the rename would fail with `EXDEV` there.
- Uncovered branch: the `rmSync(tmp, { force: true })` cleanup path that runs when `writeFileSync` of the tmp file itself fails. Exercising it requires mocking `fs`. The branch is straightforward defensive cleanup; not worth a mock harness.
- Cross-process safety relies on `proper-lockfile`'s documented filesystem-level lockfile semantics (`<file>.lock` directory created via mkdir, which is atomic on POSIX). The single-process Promise.all stress test exercises lock acquire/release ordering under contention; cross-process behaviour is provided by the library primitive rather than a multi-process test (which would require a `pretest` build step and a worker script — not justified given the library's documented guarantees).
