### PR TITLE
#425 Rename /deep-review to /deep-review-next in REFERENCES + project-checklist agent prose

### DIFF
--- a/.claude/agents/deep-review-project-checklist.md
+++ b/.claude/agents/deep-review-project-checklist.md
@@ -5,7 +5,7 @@ tools: Read, Grep, Glob
 model: sonnet
 ---
 
-You are a project-specific code reviewer for the orwellstat repository. Your sole job is to apply the project's Playwright/POM/fixture/tag conventions to the staged and unstaged changes. Do not review generic security, simplification, TypeScript, Python, QA, CI, or docs concerns — those are owned by sibling specialist agents called by `/deep-review`.
+You are a project-specific code reviewer for the orwellstat repository. Your sole job is to apply the project's Playwright/POM/fixture/tag conventions to the staged and unstaged changes. Do not review generic security, simplification, TypeScript, Python, QA, CI, or docs concerns — those are owned by sibling specialist agents called by `/deep-review-next`.
 
 ## How to run
 
@@ -41,4 +41,4 @@ Failures (in order of priority):
   2. ...
 ```
 
-If there are no failures, end after the summary line and write `Failures: none.` Do not propose edits — the calling skill (`/deep-review`) decides whether to fix or surface the findings.
+If there are no failures, end after the summary line and write `Failures: none.` Do not propose edits — the calling skill (`/deep-review-next`) decides whether to fix or surface the findings.

--- a/.claude/skills/deep-review-next/REFERENCES.md
+++ b/.claude/skills/deep-review-next/REFERENCES.md
@@ -1,6 +1,6 @@
-# Bibliography for `/deep-review`
+# Bibliography for `/deep-review-next`
 
-This file is the single source of truth for the public standards and documentation cited by `/deep-review`'s specialist agents. Each agent must reference findings by **Short ID** (e.g. "OWASP-T10 A01" or "WCAG-2.2 1.4.3") and obey the **Quotation policy** column when copying text from the source.
+This file is the single source of truth for the public standards and documentation cited by `/deep-review-next`'s specialist agents. Each agent must reference findings by **Short ID** (e.g. "OWASP-T10 A01" or "WCAG-2.2 1.4.3") and obey the **Quotation policy** column when copying text from the source.
 
 The list deliberately excludes ISO/IEC/IEEE 29119: it is paywalled and the procedural ground it covers is already covered by ISTQB-FL.
 


### PR DESCRIPTION
## Summary

Prose-only fixup left over from #441 (which delivered #425). When `REFERENCES.md` was moved into `.claude/skills/deep-review-next/` to stage all "new world" assets together, the prose still referred to the slash-command name `/deep-review`. Until #435 promotes the new orchestrator and reclaims the canonical name, the calling skill is `/deep-review-next` — so all four mentions across the two files are renamed accordingly.

Pure prose rename, four occurrences, no path or behavioural changes:

- `.claude/skills/deep-review-next/REFERENCES.md` — title and first paragraph (2 occurrences).
- `.claude/agents/deep-review-project-checklist.md` — agent description prose and final output-format sentence (2 occurrences).

The DoD reference in #425 to `.claude/skills/deep-review/SKILL.md` is intentionally untouched: that path refers to the *legacy* skill (the source of the verbatim checklist), not to the new orchestrator's slash-command name.

Related to #425 (closed) and epic #436.

## Test plan

- [x] `grep -rn '\`/deep-review\`' .claude/skills/deep-review-next/REFERENCES.md .claude/agents/deep-review-project-checklist.md` returns no matches on this branch.
- [x] `grep -rn '\`/deep-review-next\`' .claude/skills/deep-review-next/REFERENCES.md .claude/agents/deep-review-project-checklist.md` returns exactly four matches (1 title + 1 paragraph in REFERENCES.md, 1 description + 1 output-format sentence in the agent file).
- [x] `npx prettier --check` clean for both files (only string substitutions, no whitespace touched).
- [ ] CI green on this branch.
- [ ] Reviewer (claude-code-review.yml) bot pass.
