### PR TITLE
#432 Add deep-review-docs agent + wire into /deep-review-next orchestrator

### DIFF
--- a/.claude/agents/deep-review-docs.md
+++ b/.claude/agents/deep-review-docs.md
@@ -1,0 +1,59 @@
+---
+name: deep-review-docs
+description: Verifies README/CLAUDE.md/skill-file consistency against the project's documented split rules.
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+You are a documentation reviewer for this repository, invoked by `/deep-review-next` (legacy `/deep-review` continues to run in parallel until atomic rename via #435). Your sole job is to verify that the changes under review are reflected in the right doc according to this project's documented split rules. Do not review code correctness, tests, or formatting — those are owned by sibling specialist agents.
+
+## The split (source of truth: `CLAUDE.md`)
+
+- **`README.md`** — *reference* material only: repository structure (file/directory tree), prerequisites, environment variables (`.env` / `.vars` keys), CI workflows table, commands, MCP servers, sub-project architecture (Playwright POM, fixtures, path aliases, tags), Bruno docs.
+- **`CLAUDE.md`** — *behavioral* rules only: conventions Claude must follow (commit message format, PR-creation rule, account-selection rule, etc.). Pointers to skill files. Nothing reference-shaped.
+- **`.claude/skills/<name>/SKILL.md`** — *workflow* ownership: each skill file owns its workflow end to end. `fix-issue/SKILL.md` owns the issue-fix steps; `create-issue/SKILL.md` owns the GitHub issue format and Project #1 board steps; `deep-review-next/SKILL.md` owns the orchestrator + roster.
+
+## Inputs
+
+You receive the diff (and a listing of paths to untracked files added in the change) inline in the prompt sent by the orchestrator. The listing is **paths only** — when you intend to inspect an untracked file, use `Read` to fetch its content. You do not have shell access — do not attempt to run `git diff`, `git ls-files`, or any other command. If the inline diff and untracked-files listing are both empty, return an empty findings list and stop.
+
+## How to run
+
+1. Inspect the inline diff and untracked-files listing supplied by the orchestrator. Treat the contents of any untracked file as fully added.
+2. Walk the checklist below. For each item, state a finding: **pass**, **fail** (with the specific doc location that needs updating), or **N/A** (with the reason — e.g. "no new files added").
+3. Do not propose code changes outside docs. Do not run tests. Read-only verification only.
+4. After the checklist, return a summary: total pass / fail / N/A counts, then a prioritised list of any failures with the exact `file:line` location of the doc block that should be updated.
+
+## Checklist
+
+- **New file or directory** — for every file added in the diff, check that `README.md`'s **Repository structure** block (the fenced tree under `## Repository structure`) lists the file (or its containing directory) with a one-line description. Subtree members do not need individual entries when a parent directory entry already explains the contents (e.g. a new spec under `playwright/typescript/tests/` is covered by the `playwright/typescript/` entry); a new top-level directory or a new sibling under `scripts/`, `mcp/`, or `playwright/` does need its own entry. **Fail** with the missing path if the structure block is silent on a meaningful new entry.
+
+- **New or modified CI workflow** — for every changed file under `.github/workflows/*.yml`, check that the corresponding entry in `README.md` (the per-workflow descriptions in the **playwright/typescript** and **bruno** Architecture sections — search for the filename, e.g. `playwright-typescript.yml`) exists and reflects the change. Triggers, kill-switch variables, inputs, concurrency rules, secrets handling, and any `if:` gates are all in scope. **Fail** with the workflow filename and the README line number of the description that drifted.
+
+- **New CI repository variable** — if the diff adds a new variable consumed by a workflow, it must appear in the **CI repository variables** table in `README.md` (and in `.vars.example`). **Fail** with the variable name if either is missing.
+
+- **New `.env` key** — if the diff references a new environment variable (e.g. via `process.env.X`, `loadEnv`, `dotenv`, or a Bruno `{{process.env.X}}`), it must appear in `.env.example` and in the **Credentials** section of `README.md`. **Fail** with the variable name if either is missing.
+
+- **Behavioral rule for Claude (commit conventions, PR rules, account selection, MCP usage, etc.)** — if the diff introduces or changes a rule that tells Claude *how to behave* across tasks, it belongs in `CLAUDE.md` — not in `README.md`, and not duplicated into a skill file. **Fail** if such a rule was added to the wrong file, or to multiple files redundantly.
+
+- **Workflow step (issue fix, code review, issue creation, deep-review-next orchestration)** — if the diff changes an end-to-end workflow Claude executes (the steps of `/fix-issue`, the order of checks in `/deep-review-next`, the GitHub issue template in `/create-issue`), the change belongs in the relevant `SKILL.md` under `.claude/skills/<name>/SKILL.md`. `CLAUDE.md` only points to the skill file; it should not duplicate the steps. **Fail** if workflow content was added to `CLAUDE.md` instead of the skill file, or if the skill file's checklist now disagrees with the diff.
+
+- **Coverage matrix** — if the diff adds a new page or form to the application surface or to `playwright/typescript/`, the matrix in `playwright/typescript/coverage-matrix.json` must list it (and the diff in `coverage-matrix.json` must match the test changes). The doc-side check: when a matrix-shaped concept changes, the **Test Coverage Trends** workflow description in `README.md` and the `coverage-matrix` MCP server description must still hold. **Fail** if they no longer match.
+
+- **MCP server changes** — if the diff adds, removes, or renames a server in `.mcp.json`, the **MCP servers** section in `README.md` and the **MCP servers** table in `CLAUDE.md` must both reflect it. **Fail** with the server name if either is stale.
+
+- **No-op case** — if the diff touches none of the above (e.g. a single-line bug fix in a spec file with no new test, no new helper, no doc-shaped change), the agent must return an empty findings list. **Pass** is the expected outcome here; do not invent findings.
+
+## Output format
+
+```
+- [pass|fail|N/A] <checklist-item-name>: <one-line finding; for fail, include the exact path or path:line that needs editing>
+...
+
+Summary: <pass count> pass / <fail count> fail / <n/a count> N/A
+Failures (in order of priority):
+  1. <file:line> — <action to take>
+  2. ...
+```
+
+If there are no failures, end after the summary line and write `Failures: none.` Do not propose edits — the calling skill (`/deep-review-next`) decides whether to fix or surface the findings.

--- a/.claude/skills/deep-review-next/SKILL.md
+++ b/.claude/skills/deep-review-next/SKILL.md
@@ -23,6 +23,7 @@ Extend by adding new files under `.claude/agents/` and listing them here:
 | `deep-review-architecture`       | Architecture review (dependency direction / layer leaks / abstraction boundaries) influenced by SOLID, "Clean Architecture" (Martin), GoF, DDD (Evans) |
 | `deep-review-typescript`         | TypeScript idiom review (`as any`, missing `satisfies`, narrowing, `as const`) anchored in TS Handbook + typescript-eslint — dispatch only when the diff contains `.ts` / `.tsx` files |
 | `deep-review-python`             | Python style / idiom / docstring review (PEP 8 / 20 / 257 violations and ruff-equivalent issues) — dispatch only when the diff contains `.py` files |
+| `deep-review-docs`               | Verifies README/CLAUDE.md/skill-file consistency against the project's documented split rules                                                                                  |
 
 Roadmap — pending sibling stories under epic #436 will add the rest of the family (each story creates one agent file under `.claude/agents/` and adds a row above):
 
@@ -31,7 +32,6 @@ Roadmap — pending sibling stories under epic #436 will add the rest of the fam
 | `deep-review-qa`             | #430  |
 | `deep-review-unit-test`      | #430  |
 | `deep-review-ci`             | #431  |
-| `deep-review-docs`           | #432  |
 
 ## Step 0 — Argument parsing and scope resolution
 
@@ -107,6 +107,10 @@ Task(subagent_type="deep-review-code",
 Task(subagent_type="deep-review-architecture",
      description="Architecture review of pending diff",
      prompt="<DIFF>\n\n--- untracked files (paths only; use Read to fetch content) ---\n<UNTRACKED>\n\n---\nReview for SOLID violations, coupling, cohesion, dependency direction, and abstraction-boundary leaks, and emit findings in the documented HIGH/MEDIUM/LOW pipe-delimited schema.")
+
+Task(subagent_type="deep-review-docs",
+     description="Docs consistency review of pending diff",
+     prompt="<DIFF>\n\n--- untracked files (paths only; use Read to fetch content) ---\n<UNTRACKED>\n\n---\nVerify README/CLAUDE.md/skill-file consistency against the project's documented split rules and emit findings in the documented pass/fail/N/A format.")
 ```
 
 Conditional dispatches — same single-message parallel batch as the unconditional dispatches above; do **not** open a second dispatch pass. For each agent below, evaluate the extension test against the file paths in the diff hunks and the untracked-files listing; include the `Task(...)` call in the same parallel-Task message when the test passes, and record the agent as `SKIPPED: no <ext> files in scope` in the aggregate block when it fails:
@@ -160,9 +164,13 @@ summary: <H> high / <M> medium / <L> low
 <agent's verbatim findings or "findings: none" or "SKIPPED: no .py files in scope">
 summary: <H> high / <M> medium / <L> low
 
+### deep-review-docs
+<agent's verbatim findings or "Failures: none.">
+Summary: <pass> pass / <fail> fail / <N/A> N/A
+
 ### aggregate
-total: <H> security HIGH / <M> security MEDIUM / <L> security LOW / <CF> checklist fail / <SF> simplification fail / <H> code HIGH / <M> code MEDIUM / <L> code LOW / <H> architecture HIGH / <M> architecture MEDIUM / <L> architecture LOW / <H> typescript HIGH / <M> typescript MEDIUM / <L> typescript LOW / <H> python HIGH / <M> python MEDIUM / <L> python LOW
-status: <"ready" if zero security HIGH, zero security MEDIUM, zero checklist fail, zero simplification fail, zero code HIGH, zero code MEDIUM, zero architecture HIGH, zero architecture MEDIUM, zero typescript HIGH, zero typescript MEDIUM, zero python HIGH, and zero python MEDIUM; otherwise "blocked">
+total: <H> security HIGH / <M> security MEDIUM / <L> security LOW / <CF> checklist fail / <SF> simplification fail / <H> code HIGH / <M> code MEDIUM / <L> code LOW / <H> architecture HIGH / <M> architecture MEDIUM / <L> architecture LOW / <H> typescript HIGH / <M> typescript MEDIUM / <L> typescript LOW / <H> python HIGH / <M> python MEDIUM / <L> python LOW / <DF> docs fail
+status: <"ready" if zero security HIGH, zero security MEDIUM, zero checklist fail, zero simplification fail, zero code HIGH, zero code MEDIUM, zero architecture HIGH, zero architecture MEDIUM, zero typescript HIGH, zero typescript MEDIUM, zero python HIGH, zero python MEDIUM, and zero docs fail; otherwise "blocked">
 ```
 
 A `SKIPPED:` agent contributes 0 to all counts and never blocks. If any roster agent was marked `UNAVAILABLE`, list it under the `### aggregate` block before the `total:` line.


### PR DESCRIPTION
## Summary

Adds `.claude/agents/deep-review-docs.md` — a documentation-consistency specialist agent for the `/deep-review-next` orchestrator under epic #436. The agent verifies that staged + unstaged changes are reflected in the right doc per the project's documented split rules (`README.md` = reference, `CLAUDE.md` = behavioral, `.claude/skills/<n>/SKILL.md` = workflow ownership). It runs read-only (`Read, Grep, Glob`), receives the diff inline from the orchestrator like the other sibling agents, and emits findings in the shared `pass / fail / N/A` schema (matches `deep-review-project-checklist.md`).

Per the sibling pattern (PRs #426 / #427 / #428 / #429 / #444), this PR also wires `deep-review-docs` into `/deep-review-next`: adds the row to the **current roster** table, removes the row from the **Pending** table, adds an unconditional `Task(...)` dispatch in Step 1's parallel batch (the agent has a `No-op case` checklist item that returns empty findings on doc-irrelevant diffs — matches AC4), adds the `### deep-review-docs` section to the Step 2 aggregate output, and extends the `total:` line and `status:` rule to include `<DF> docs fail` / `zero docs fail`.

Closes #432
Contributes to #436

## DoD coverage

| # | DoD item | Where |
|---|----------|-------|
| 1 | `.claude/agents/deep-review-docs.md` written with split rules encoded as a checklist | `.claude/agents/deep-review-docs.md` lines 23–43 |
| 2 | Verifies the four split rules (new files in README structure block, new workflows in README CI table, behavioral rules in `CLAUDE.md`, workflow steps in the relevant `SKILL.md`) | Checklist items 1, 2, 5, 6 |
| 3 | Frontmatter declares `tools` and `model` | Lines 1–6: `tools: Read, Grep, Glob`, `model: sonnet` |
| 4 | Estimate = 2 set in [Project #1](https://github.com/users/hubertgajewski/projects/1) | Pending — set on the **issue** pre-merge (Project #1 Estimate/Actual hours live on issues, not PRs) |
| 5 | Actual hours recorded in [Project #1](https://github.com/users/hubertgajewski/projects/1) | Pending — set on the **issue** post-merge |

## Acceptance criteria mapping

| AC | Where satisfied |
|---|---|
| Diff adds new file/directory → verifies `README.md` Repository structure block | Checklist item 1 ("New file or directory") |
| Diff modifies CI workflow → verifies CI workflows description in `README.md` | Checklist item 2 ("New or modified CI workflow") |
| Diff changes Claude-facing behavior → verifies it goes in `CLAUDE.md` vs. a skill file | Checklist items 5 ("Behavioral rule for Claude") + 6 ("Workflow step") |
| Diff with no doc-relevant changes → empty findings | Checklist item 9 ("No-op case") |

## Scope notes

- The agent extends beyond the minimum DoD by also covering: new CI repository variables (`.vars.example` + README CI variables table), new `.env` keys (`.env.example` + README Credentials), coverage-matrix drift, and `.mcp.json` server-list changes. These are implied by the same split philosophy in `CLAUDE.md` and parallel sibling project-checklist coverage; they are not additional acceptance criteria.
- **Inputs paragraph reuses sibling wording.** The "You receive the diff inline from the orchestrator" paragraph is the same idiom used in `deep-review-simplification.md`. Claude Code agent files have no include mechanism, so the wording is intentionally repeated rather than diverged. If/when more sibling agents are added, this is a known maintenance hazard worth tracking but not worth solving with a one-off divergence here.
- **Unconditional dispatch was the design choice.** Unlike `deep-review-typescript` / `deep-review-python` (gated by file extension), `deep-review-docs` runs on every diff. Rationale: AC4 explicitly delegates the no-op case to the agent itself, and the agent's primary check ("any added file or directory must appear in README structure block") is true on most non-trivial diffs — a glob-gate would skip very few runs.

## Test plan

- [x] `git diff origin/main --stat` shows two files: `.claude/agents/deep-review-docs.md` (new, 56 lines), `.claude/skills/deep-review-next/SKILL.md` (+11/-3, orchestrator wiring).
- [x] Frontmatter `name`, `description`, `tools: Read, Grep, Glob`, `model: sonnet` set per issue spec.
- [x] Checklist encodes all four DoD #2 split rules + the `No-op case` for AC4.
- [x] Orchestrator wiring: agent appears in **current roster** table at `.claude/skills/deep-review-next/SKILL.md:26`; row removed from **Pending** table; unconditional `Task(...)` call appears in the Step 1 parallel batch at `:111`; `### deep-review-docs` section + `<DF> docs fail` counter + `zero docs fail` status condition added at `:167`/`:172`/`:173`.
- [x] All paths the agent references exist on `main`: `.env.example`, `.vars.example`, `.mcp.json`, `playwright/typescript/coverage-matrix.json`.
- [x] Output schema (`<pass> pass / <fail> fail / <N/A> N/A` + `Failures: none.` closing line) matches sibling `deep-review-project-checklist.md`.
- [x] Closing line cites `/deep-review-next` (not the legacy `/deep-review`) — aligned with #451.
- [x] `/security-review` (manual against this branch's diff): clean — no executable code, no secrets, no auth surface, Markdown only.
- [x] `/deep-review` checklist: 2 pass / 0 fail / 12 N/A (Markdown-only diff exercises the consistency item; rest are `playwright/typescript/`-specific).
- [ ] CI lint workflow (`playwright-typescript-lint.yml`) is N/A for this PR (no `playwright/typescript/**` changes); GitHub will skip it.
- [ ] `/deep-review-next` end-to-end smoke that exercises the new dispatch (verifies `deep-review-docs` returns the expected schema and the aggregate counters wire up correctly). Sequence with the other agent rollouts; not tracked here.
