### PR TITLE
#457 Add Step 4 token-estimate footer to /deep-review

### DIFF
--- a/.claude/skills/deep-review/SKILL.md
+++ b/.claude/skills/deep-review/SKILL.md
@@ -14,6 +14,22 @@ Also apply the general diff checks and (if `.github/workflows/*.yml` files chang
 
 After completing all checks, provide a summary: total pass / fail / N/A counts and a prioritised list of any failures that must be fixed before committing.
 
+## Step 4 — Token-estimate footer
+
+After the summary, emit one footer block estimating LLM token usage for each phase that ran. The estimate is approximate because the parent session cannot directly read token usage of the built-in `/security-review` and `/simplify` slash commands; derive each per-phase figure from observed I/O sizes (input ≈ bytes of diff fed in; output ≈ bytes produced).
+
+- The `/simplify` line accumulates across all cycles and shows the cycle count.
+- Emit the footer even when the loop hits the 3-cycle cap with remaining findings — print it before the prompt that asks how to proceed.
+- If `/security-review` or `/simplify` is unavailable and the skill falls back to manual checks, replace that phase's per-token numbers with `manual fallback` and append a numeric estimate covering the manual checks (e.g. `/simplify: manual fallback ~<X2> input / ~<Y2> output`); on the `/simplify` line, also drop the `across <C> cycle(s)` suffix since no cycles ran. The appended numeric estimate is what feeds the total.
+
+```
+Token estimate:
+  /security-review: ~<X1> input / ~<Y1> output
+  /simplify:        ~<X2> input / ~<Y2> output across <C> cycle(s)
+  inline checklist: ~<X3> input / ~<Y3> output
+  total:            ~<X> input / ~<Y> output
+```
+
 ---
 
 ## Code review checklist


### PR DESCRIPTION
## Summary

Adds a `Step 4 — Token-estimate footer` section to `.claude/skills/deep-review/SKILL.md`, mirroring the analogous footer in `/deep-review-next` while accounting for `/deep-review`'s different runtime shape (built-in slash commands invoked from the parent session rather than `Task(...)` agent dispatches).

The footer specifies a four-line block (`/security-review`, `/simplify`, `inline checklist`, `total:`) plus three operational rules: (a) `/simplify` accumulates across cycles and shows the cycle count, (b) the footer must still be emitted on the 3-cycle cap exit before the "how to proceed" prompt, (c) when `/security-review` or `/simplify` falls back to manual checks, that phase's numbers are replaced with `manual fallback` followed by a numeric estimate (and the cycle-suffix is dropped on the `/simplify` line since no cycles ran).

Closes #457

## Test plan

- [x] `Step 4 — Token-estimate footer` section present in `.claude/skills/deep-review/SKILL.md`
- [x] Four-line block format documented with `/security-review`, `/simplify`, `inline checklist`, `total:`
- [x] Convergence-cycle accumulation behaviour documented (bullet 1)
- [x] 3-cycle cap behaviour documented (bullet 2)
- [x] Manual-fallback annotation documented including cycle-suffix-drop guidance (bullet 3)
- [x] `/security-review` returned clean across all 3 convergence cycles
- [x] `/simplify` converged after cycle-1 fixes (terminology, dense paragraph, fallback-total ambiguity, redundant phrasing) and cycle-2 fixes (cause/effect non-sequitur, missing fallback-suffix guidance); cycle 3 returned no findings
- [x] `/deep-review` checklist: 2 pass / 0 fail / 12 N/A (markdown skill prose; most checklist items are Playwright/TypeScript-specific and N/A)
- [x] `README.md` verified — no update needed (only references `/deep-review` at high level)
- [ ] Reviewer confirms the footer prose reads cleanly and matches the issue's implementation hint
