### PR TITLE
#460 Fix stale /deep-review references and unnamed sibling pointers in deep-review-{code,architecture}

### DIFF
--- a/.claude/agents/deep-review-architecture.md
+++ b/.claude/agents/deep-review-architecture.md
@@ -51,9 +51,9 @@ Do not emit findings for the following, even when the diff exhibits them. A sibl
 - **TypeScript-specific typing or lint** — owned by `deep-review-typescript`.
 - **Python-specific style or typing** — owned by `deep-review-python`.
 - **Playwright POM / fixture / tag conventions** — owned by `deep-review-project-checklist`.
-- **test design / boundary cases** — owned by the QA reviewer agent.
+- **test design / boundary cases** — owned by `deep-review-qa`.
 - **CI / GitHub Actions workflow content** — owned by `deep-review-ci`.
-- **README / CLAUDE.md / skill-file consistency** — owned by the docs reviewer agent.
+- **README / CLAUDE.md / skill-file consistency** — owned by `deep-review-docs`.
 
 If a hunk only touches an out-of-scope category, return no finding for it.
 
@@ -93,7 +93,7 @@ After the findings (or the `findings: none` line), emit one summary line:
 summary: <high count> high / <medium count> medium / <low count> low
 ```
 
-The orchestrator (`/deep-review`) consumes these lines verbatim and decides whether to fix or surface them. Do not propose code edits, run tests, or narrate your search; do not emit prose outside the schema above.
+The orchestrator (`/deep-review-next`) consumes these lines verbatim and decides whether to fix or surface them. Do not propose code edits, run tests, or narrate your search; do not emit prose outside the schema above.
 
 ## Citations
 

--- a/.claude/agents/deep-review-code.md
+++ b/.claude/agents/deep-review-code.md
@@ -45,9 +45,9 @@ Do not emit findings for the following, even when the diff exhibits them. A sibl
 - **TypeScript-specific typing or lint** — owned by `deep-review-typescript`.
 - **Python-specific style or typing** — owned by `deep-review-python`.
 - **Playwright POM / fixture / tag conventions / coverage matrix** — owned by `deep-review-project-checklist`.
-- **test design / boundary cases / assertion shape** — owned by the QA reviewer agent.
+- **test design / boundary cases / assertion shape** — owned by `deep-review-qa`.
 - **CI / GitHub Actions workflow content** — owned by `deep-review-ci`.
-- **README / CLAUDE.md / skill-file consistency** — owned by the docs reviewer agent.
+- **README / CLAUDE.md / skill-file consistency** — owned by `deep-review-docs`.
 
 If a hunk only touches an out-of-scope category, return no finding for it.
 
@@ -87,7 +87,7 @@ After the findings (or the `findings: none` line), emit one summary line:
 summary: <high count> high / <medium count> medium / <low count> low
 ```
 
-The orchestrator (`/deep-review`) consumes these lines verbatim and decides whether to fix or surface them. Do not propose code edits, run tests, or narrate your search; do not emit prose outside the schema above.
+The orchestrator (`/deep-review-next`) consumes these lines verbatim and decides whether to fix or surface them. Do not propose code edits, run tests, or narrate your search; do not emit prose outside the schema above.
 
 ## Citations
 


### PR DESCRIPTION
## Summary

Closes #460
Contributes to #436

Two agent files (`deep-review-code.md`, `deep-review-architecture.md`) still pointed at the legacy `/deep-review` orchestrator in their closing footer and referenced siblings by generic descriptors ("QA reviewer agent", "docs reviewer agent") instead of by canonical agent id. The other deep-review siblings already use `/deep-review-next` and canonical ids; this aligns the two outliers.

- Footer: ``(`/deep-review`)`` → ``(`/deep-review-next`)``
- Out-of-scope sections: "owned by the QA reviewer agent" → ``owned by `deep-review-qa` ``; "owned by the docs reviewer agent" → ``owned by `deep-review-docs` ``

## Test plan

- [x] `grep -rn '(\`/deep-review\`)' .claude/agents/` returns no matches
- [x] Both files now reference `/deep-review-next` in the closing footer (verified in diff)
- [x] Both files name `deep-review-qa` and `deep-review-docs` with canonical ids (verified in diff)
- [x] Sibling consistency: footer wording now matches `deep-review-security.md`, `deep-review-typescript.md`, `deep-review-python.md`, `deep-review-ci.md`
- [x] Swept `.claude/` for other stale unqualified `/deep-review` references — only remaining match is `.claude/skills/fix-issue/SKILL.md:41`, which legitimately invokes the legacy `/deep-review` slash command (the embedded sub-cycle remains operational until atomic rename #435 lands) and is therefore out of scope for this issue
