### PR TITLE
#482 Reduce Playwright CI workers from 100% to 50% to leave CPU headroom on 4-vCPU runners

### DIFF
--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? '100%' : undefined,
+  workers: process.env.CI ? '50%' : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['html'],


### PR DESCRIPTION
## Summary
Lowers the per-leg Playwright `workers` cap on CI from `'100%'` to `'50%'` so the worker count stays under the runner's vCPU budget on standard `ubuntu-latest` (4 vCPU / 16 GB) and stops oversubscribing CPU during the test phase.

The matrix in `.github/workflows/playwright-typescript.yml` already fans out to 10 parallel legs (5 projects × 2 shards), each on its own runner — total fan-out is unchanged. Only the per-leg internal worker count drops from 4 to 2.

Closes #482

## Test plan
- [x] `playwright/typescript/playwright.config.ts:33` reads `workers: process.env.CI ? '50%' : undefined`.
- [x] `npx prettier --check playwright.config.ts` clean.
- [x] `npx tsc --noEmit` clean.
- [ ] CI: `playwright-typescript.yml` on this branch goes green at least once under the new setting.
- [ ] Reviewer / CI: per-leg wall-clock delta vs. a recent green main run is acceptable (target < ~20% degradation). If degradation is unacceptable or pass rate does not improve, revert per the issue's third Acceptance Criterion.
