### PR TITLE
#419 Reconcile README + CLAUDE.md MCP section with live .mcp.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,11 @@ This repository defines MCP (Model Context Protocol) servers in `.mcp.json` at t
 | `playwright-report-mcp` | Run the Playwright test suite and retrieve structured results (pass/fail, errors, attachments) |
 | `playwright`            | Browser automation — navigate pages, take screenshots, interact with UI elements               |
 | `MCP_DOCKER`            | Docker MCP gateway — interact with containers (used with `act` for local CI)                   |
+| `quality-metrics`       | Query defect escape rate, MTTR, and metrics history without running `quality-metrics.yml`      |
+| `coverage-matrix`       | Query and update `playwright/typescript/coverage-matrix.json` through typed tools              |
 
 - Use `playwright-report-mcp` when you need to run or inspect test results programmatically — e.g. during self-healing workflows, verifying a fix, or checking which tests are failing. Prefer it over invoking `npx playwright test` via shell and parsing stdout. Every tool call must include `workingDirectory`: `"playwright/typescript"` for the main worktree, or `"../<worktree-name>/playwright/typescript"` (e.g. `"../orwellstat-330/playwright/typescript"`) for a sibling worktree. Omitting it defaults to the repo root, which has no `playwright.config.*` and will fail. The allowlist (`PW_ALLOWED_DIRS=".."` in `.mcp.json`) authorizes the repo root's parent, covering every sibling worktree under the same directory.
 - Use `playwright` for exploratory or diagnostic tasks that benefit from live browser interaction — e.g. inspecting the running application, verifying a UI fix, taking screenshots. Prefer it over describing what the page looks like from memory.
 - Use `MCP_DOCKER` when interacting with Docker containers started by `act` — e.g. running a command inside a container or finding a container by name.
+- Use `quality-metrics` when you need defect escape rate, MTTR, or historical metrics on demand. Prefer it over re-running `scripts/generate-quality-metrics.py` or waiting for the monthly `quality-metrics.yml` workflow.
+- Use `coverage-matrix` when you need to query coverage gaps or summary percentages, or to flip a single page-category cell to covered. Prefer it over reading or editing `playwright/typescript/coverage-matrix.json` by hand.

--- a/README.md
+++ b/README.md
@@ -457,24 +457,24 @@ Five MCP servers are declared in `.mcp.json` and loaded automatically by any MCP
 
 An MCP server that runs the Playwright test suite and returns structured JSON results, enabling agentic workflows (self-healing, test generation verification) to act on test outcomes without parsing shell output.
 
-**Setup:** No setup required — runs via `npx playwright-report-mcp@2.0.1` from the official npm registry. The version is pinned in `.mcp.json` so upstream releases don't silently change behavior between runs.
+**Setup:** No setup required — runs via `npx playwright-report-mcp@3.1.0` from the official npm registry. The version is pinned in `.mcp.json` so upstream releases don't silently change behavior between runs.
 
-**Configuration:** The following environment variables can be set in `.mcp.json` (unset variables use their defaults):
+**Configuration:** Each tool call accepts an optional `workingDirectory` argument naming the Playwright project directory; the `PW_ALLOWED_DIRS` environment variable in `.mcp.json` defines which paths that argument is allowed to resolve to:
 
-| Variable          | Default                              | Description                                                                                                                                |
-| ----------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `PW_DIR`          | `process.cwd()`                      | Root of the Playwright project. Relative paths are resolved against the directory from which the AI assistant is launched (the repo root). |
-| `PW_RESULTS_FILE` | `<PW_DIR>/test-results/results.json` | Path to the JSON reporter output file. Override if your `playwright.config.ts` writes results elsewhere.                                   |
+| Setting             | Where                | Default | Description                                                                                                                                                                                                                                              |
+| ------------------- | -------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `workingDirectory`  | per tool-call arg    | `"."`   | Playwright project directory, absolute or relative to the MCP server launch directory (the repo root). The default `.` points at the repo root, which has no `playwright.config.*` and will fail — every call must pass an explicit `workingDirectory`. |
+| `PW_ALLOWED_DIRS`   | `.mcp.json` env var  | unset   | Colon-separated allowlist of directories `workingDirectory` is permitted to resolve under. This repo sets `".."` (the repo root's parent) so sibling worktrees like `../orwellstat-<N>/playwright/typescript` are reachable.                              |
 
-This repo sets `PW_DIR` to `playwright/typescript` so the server targets the correct sub-project:
+This repo sets `PW_ALLOWED_DIRS` to `..` so the repo root's parent and every sibling worktree under it are reachable from a single allowlist entry:
 
 ```json
 "playwright-report-mcp": {
   "command": "npx",
-  "args": ["playwright-report-mcp@2.0.1"],
+  "args": ["--min-release-age=0", "playwright-report-mcp@3.1.0"],
   "type": "stdio",
   "env": {
-    "PW_DIR": "playwright/typescript"
+    "PW_ALLOWED_DIRS": ".."
   }
 }
 ```


### PR DESCRIPTION
## Summary

Reconciles `README.md` and `CLAUDE.md` against the live `.mcp.json` (the three drift points called out in the 2026-04-28 review):

- **Version pin**: `playwright-report-mcp@2.0.1` → `@3.1.0` in `README.md` (now matches `.mcp.json:15`).
- **Configuration mechanism**: replaces the obsolete `PW_DIR` / `PW_RESULTS_FILE` env-var table (gone in v3+) with documentation of the live wiring — the per-call `workingDirectory` argument and the `PW_ALLOWED_DIRS` env-var allowlist. The JSON example in `README.md` now matches the live `.mcp.json` block byte-for-byte.
- **MCP server list**: `CLAUDE.md` now lists all 5 servers consistent with `.mcp.json` and `README.md` — adds `quality-metrics` and `coverage-matrix` rows plus matching "when to prefer this server" bullets.

The `workingDirectory` mandate in `CLAUDE.md` is retained: the default `.` resolves to the repo root, which has no `playwright.config.*` and would fail. `PW_ALLOWED_DIRS` is the allowlist (security boundary), not a substitute. Verified by calling `mcp__playwright-report-mcp__list_tests` with `workingDirectory: "../orwellstat-419/playwright/typescript"` from a sibling worktree — returned 23 @smoke tests.

Closes #419

## Test plan

- [x] `README.md` `playwright-report-mcp` version reference matches `.mcp.json:15` (`@3.1.0`)
- [x] No doc file claims a pin that disagrees with `.mcp.json` (`grep -n "@2.0.1\|PW_DIR\|PW_RESULTS_FILE"` returns nothing in `README.md` or `CLAUDE.md`)
- [x] `CLAUDE.md` MCP server table lists all 5 servers consistent with `README.md` and `.mcp.json`
- [x] `CLAUDE.md` retains the `workingDirectory` mandate (still required because default `.` resolves to repo root with no `playwright.config.*`)
- [x] Verified end-to-end: one `playwright-report-mcp` tool call from a sibling worktree following the documented instructions succeeded — `mcp__playwright-report-mcp__list_tests` with `workingDirectory: "../orwellstat-419/playwright/typescript"` returned 23 `@smoke` tests
- [ ] Reviewer confirms README/CLAUDE.md split is honoured: `README.md` owns reference (purpose, version pin, config table, JSON example), `CLAUDE.md` owns behavioural rules (when to prefer one server over another, mandatory args)
