### PR TITLE
[tooling] Allow Claude to read password-reset.* files via sandbox allowWithinDeny

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,16 @@
 {
   "enableAllProjectMcpServers": true,
   "permissions": {
+    "sandbox": {
+      "filesystem": {
+        "read": {
+          "allowWithinDeny": [
+            "playwright/typescript/tests/password-reset.spec.ts",
+            "playwright/typescript/pages/public/password-reset.page.ts"
+          ]
+        }
+      }
+    },
     "allow": [
       "Bash(bru run*)",
       "Bash(gh alias list*)",
@@ -60,7 +70,6 @@
       "mcp__playwright-report-mcp__get_test_attachment",
       "mcp__playwright-report-mcp__list_tests",
       "mcp__playwright-report-mcp__run_tests",
-      "Read(**/password-reset.page.ts)",
       "WebFetch(domain:docs.usebruno.com)",
       "WebFetch(domain:orwellstat.hubertgajewski.com)",
       "WebFetch(domain:playwright.dev)",


### PR DESCRIPTION
## Summary

- Adds `permissions.sandbox.filesystem.read.allowWithinDeny` pinning two Playwright test files (`password-reset.spec.ts`, `password-reset.page.ts`) so Claude Code can read them despite the global `**/*password*` sandbox deny.
- Removes the now-redundant `Read(**/password-reset.page.ts)` glob from `permissions.allow` — the new path-pinned entry covers it more precisely.
- Both files contain no credentials; they're E2E test artifacts for the public password-reset UI flow.

Closes #488

## Test plan

Verified during development:

- [x] `python3 -m json.tool .claude/settings.json` exits 0 (valid JSON).
- [x] `permissions.sandbox.filesystem.read.allowWithinDeny` lists both target paths.
- [x] `permissions.{allow,ask,deny}` remain siblings of `permissions.sandbox` (correct nesting).
- [x] `Read(**/*password*)` still present in `permissions.deny` — safety net intact.
- [x] Redundant `Read(**/password-reset.page.ts)` removed from `permissions.allow`.
- [x] No trailing-whitespace artifacts on the modified lines.
- [x] `/security-review` returned no findings.

To verify in review:

- [ ] Open a fresh Claude Code session in this repo; confirm both `playwright/typescript/tests/password-reset.spec.ts` and `playwright/typescript/pages/public/password-reset.page.ts` are readable without sandbox denial.
- [ ] Confirm a hypothetical out-of-allowlist `**/*password*` path (e.g. `passwords.txt`) remains denied — `Read(**/*password*)` is still in `permissions.deny`.
