### PR TITLE
#492 Bump Playwright actionTimeout from 15s to 30s for slow /zone/ first-load

### DIFF
--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
 
   use: {
     baseURL,
-    actionTimeout: 15_000,
+    actionTimeout: 30_000,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',


### PR DESCRIPTION
## Summary

Bumps the global Playwright `actionTimeout` from 15s to 30s in `playwright/typescript/playwright.config.ts` so authenticated tests don't fail spuriously when the post-login `/zone/` page takes >15s to become actionable on a cold-cache first hit.

The new value matches Playwright's default `navigationTimeout` (30s) and propagates automatically to `playwright.config.real-credential.ts` via its `...baseConfig.use` spread.

Closes #492

## Test plan

- [x] `playwright/typescript/playwright.config.ts:52` updated from `15_000` to `30_000`
- [x] `npm run format:check` passes
- [ ] Full Playwright matrix run on staging shows no `Timeout 15000ms exceeded` failures from `/zone/` first-load (CI verification)
- [ ] No new `Timeout 30000ms exceeded` failures introduced (CI verification — sanity check the bump is sufficient and not masking a different regression)
