### PR TITLE
#495 Bump axios to >=1.15.2 and ip-address to >=10.1.1; enroll mcp/* in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,24 @@ updates:
     groups:
       all:
         patterns: ["*"]
+  - package-ecosystem: npm
+    directory: /mcp/coverage-matrix
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels: [dependencies]
+    groups:
+      all:
+        patterns: ["*"]
+  - package-ecosystem: npm
+    directory: /mcp/quality-metrics
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels: [dependencies]
+    groups:
+      all:
+        patterns: ["*"]
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/bruno/package-lock.json
+++ b/bruno/package-lock.json
@@ -2643,9 +2643,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/bruno/package.json
+++ b/bruno/package.json
@@ -7,7 +7,7 @@
     "test": "bru run --env production"
   },
   "overrides": {
-    "axios": ">=1.15.0",
+    "axios": ">=1.15.2",
     "fast-xml-parser": ">=5.7.0",
     "picomatch": ">=2.3.2"
   }

--- a/mcp/coverage-matrix/package-lock.json
+++ b/mcp/coverage-matrix/package-lock.json
@@ -1412,9 +1412,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/mcp/coverage-matrix/package.json
+++ b/mcp/coverage-matrix/package.json
@@ -27,5 +27,8 @@
     "@vitest/coverage-v8": "^4.1.3",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"
+  },
+  "overrides": {
+    "ip-address": ">=10.1.1"
   }
 }

--- a/mcp/quality-metrics/package-lock.json
+++ b/mcp/quality-metrics/package-lock.json
@@ -1387,9 +1387,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/mcp/quality-metrics/package.json
+++ b/mcp/quality-metrics/package.json
@@ -25,5 +25,8 @@
     "@vitest/coverage-v8": "^4.1.3",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"
+  },
+  "overrides": {
+    "ip-address": ">=10.1.1"
   }
 }


### PR DESCRIPTION
## Summary
Closes the remaining 12 open Dependabot alerts and enrolls the two MCP package dirs that were missing from `.github/dependabot.yml`.

- `bruno/package.json`: raise `axios` override `>=1.15.0` → `>=1.15.2`. Lockfile resolves `axios 1.15.2`. Clears 10 alerts (#22–#34, including high-sev GHSA-q8qp-cvcw-x6jj / GHSA-pf86-5x62-jrwf / GHSA-6chq-wfr3-2hj9 / GHSA-pmwg-cvhr-8vh7).
- `mcp/coverage-matrix/package.json` + `mcp/quality-metrics/package.json`: add `overrides["ip-address"]: ">=10.1.1"`. Lockfiles resolve `ip-address 10.1.1`. Clears alerts #36 and #37 (GHSA-v2v4-37r5-5v8g).
- `.github/dependabot.yml`: register `/mcp/coverage-matrix` and `/mcp/quality-metrics` for npm so future advisories on these dirs get auto-PRs.

Closes #495.

## Test plan
- [ ] Bruno Tests CI run (workflow_dispatch, staging) passes — `npm ci` + `npm audit --audit-level=high` exits 0 and `bru run` succeeds.
- [ ] `npm test` for `mcp/coverage-matrix` and `mcp/quality-metrics` continues to pass.
- [ ] After merge: `/security/dependabot` shows 0 open alerts.
- [ ] After merge: Dependabot's next weekly run treats the two new `mcp/*` entries as registered (no errors in the Dependabot logs).
