### PR TITLE
#497 Add MCP Tests workflow for coverage-matrix and quality-metrics

### DIFF
--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -1,0 +1,50 @@
+name: MCP Tests
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'mcp/**'
+      - '.github/workflows/mcp-tests.yml'
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'mcp/**'
+      - '.github/workflows/mcp-tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: github.repository == 'hubertgajewski/orwellstat'
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [coverage-matrix, quality-metrics]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Build mcp/shared
+        working-directory: mcp/shared
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install ${{ matrix.package }}
+        working-directory: mcp/${{ matrix.package }}
+        run: npm ci
+
+      - name: Audit ${{ matrix.package }}
+        working-directory: mcp/${{ matrix.package }}
+        run: npm audit --audit-level=high
+
+      - name: Test ${{ matrix.package }}
+        working-directory: mcp/${{ matrix.package }}
+        run: npm test


### PR DESCRIPTION
## Summary
Adds `.github/workflows/mcp-tests.yml` so PRs touching `mcp/**` (including Dependabot bumps for `mcp/coverage-matrix` and `mcp/quality-metrics`, enrolled in #496) get CI signal. Builds `mcp/shared` first so each consumer's `file:../shared` import resolves, then runs `npm ci` + `npm audit --audit-level=high` + `npm test` per package in a matrix.

Closes #497

## Test plan
- [x] `cd mcp/shared && npm ci && npm run build` succeeds locally.
- [x] `cd mcp/coverage-matrix && npm ci && npm test` passes locally (16/16).
- [x] `cd mcp/quality-metrics && npm ci && npm test` passes locally (11/11).
- [ ] On this PR, both `MCP Tests / test (coverage-matrix)` and `MCP Tests / test (quality-metrics)` checks run and pass.
- [ ] After merge, the same workflow runs and passes on the `main` push.
- [ ] Next Dependabot bump PR for `mcp/coverage-matrix` or `mcp/quality-metrics` shows the matching `MCP Tests` check.
