### PR TITLE
#506 Reduce self-hosted runner pool to 4 in setup-runners.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ scripts/
   generate-quality-metrics.py  # generates QUALITY_METRICS.md and updates quality-metrics-history.json
   self-healing.py              # self-healing selector fix: parses test artifacts, posts PR comments or creates draft PRs
   test_self_healing.py         # unit tests for self-healing.py (loop prevention, classification, LLM-bound redaction)
-  setup-runners.sh             # registers and starts 8 self-hosted runner instances as launchd services
+  setup-runners.sh             # registers and starts 4 self-hosted runner instances as launchd services
 playwright/
   typescript/               # Playwright tests in TypeScript
 bruno/                      # Bruno API request collection

--- a/docs/CI_LOCAL.md
+++ b/docs/CI_LOCAL.md
@@ -30,7 +30,7 @@ Because `--ephemeral` de-registers the runner after every job, you must re-run `
 
 ### Multiple parallel workers
 
-To run parallel jobs (e.g. the full Playwright matrix), register multiple runner instances. `scripts/setup-runners.sh` automates this for 8 workers:
+To run parallel jobs (e.g. the full Playwright matrix), register multiple runner instances. `scripts/setup-runners.sh` automates this for 4 workers:
 
 ```bash
 # 1. Download and extract the runner package to ~/actions-runner-src
@@ -40,7 +40,24 @@ To run parallel jobs (e.g. the full Playwright matrix), register multiple runner
 ./scripts/setup-runners.sh
 ```
 
-The script copies the package into `~/actions-runner-1` … `~/actions-runner-8`, configures each with a unique name (`mac-runner-1` … `mac-runner-8`), and installs + starts a launchd service for each. Re-running the script is safe — it stops and reinstalls existing services before reconfiguring.
+The script copies the package into `~/actions-runner-1` … `~/actions-runner-4`, configures each with a unique name (`mac-runner-1` … `mac-runner-4`), and installs + starts a launchd service for each. Re-running the script is safe — it stops and reinstalls existing services before reconfiguring.
+
+The default of 4 workers anchors to the GitHub-hosted Linux runner hardware contract (4 vCPU) and leaves CPU and disk-cache headroom on a single Mac — every runner keeps its own `_work` checkout and Playwright browser cache (~600 MB), so adding more processes has diminishing returns once the host's I/O knee is reached.
+
+### Reducing the pool
+
+`setup-runners.sh` only provisions runners 1 through `WORKERS`; it does not remove higher-numbered runners left over from a previous higher-`WORKERS` run. After lowering `WORKERS` (for example, from 8 to 4), stop and uninstall the orphans manually:
+
+```bash
+# Replace 5..8 with whichever indices became orphans for your transition
+for i in 5 6 7 8; do
+  cd "$HOME/actions-runner-$i" 2>/dev/null || continue
+  ./svc.sh stop || true
+  ./svc.sh uninstall || true
+done
+```
+
+Then de-register the orphans at **GitHub → Settings → Actions → Runners** so they no longer count against the runner roster, and optionally delete the `~/actions-runner-{5..8}` directories.
 
 ### Routing jobs to the self-hosted runner
 

--- a/scripts/setup-runners.sh
+++ b/scripts/setup-runners.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-WORKERS=8
+WORKERS=4
 REPO_URL="https://github.com/hubertgajewski/orwellstat"
 SRC="${1:-$HOME/actions-runner-src}"
 


### PR DESCRIPTION
## Summary

Reduce the self-hosted Mac runner pool from 8 to 4 by changing `WORKERS=8` → `WORKERS=4` in `scripts/setup-runners.sh`, and update the docs.

### Rationale
- **4-vCPU CI hardware contract.** GitHub-hosted Linux runners (`ubuntu-latest`) are 4 vCPU, which is the de-facto baseline most CI tooling and Playwright defaults assume. Anchoring to it makes our self-hosted host behave like the runner contract the rest of the workflows are tuned for (cf. #483, which cut Playwright `--workers` from 100% → 50% on 4-vCPU runners).
- **Powers-of-2 sweep grid.** `1 / 2 / 4 / 8` is the conventional benchmark grid for parallelism tuning; 4 is the natural anchor below the upper end of the grid.
- **~600 MB browser cache × N constraint.** Each runner keeps its own `_work` checkout and Playwright browser cache (~600 MB). At `WORKERS=8` that's ~4.8 GB of caches alone before any browser process starts, which contributes to I/O contention on a single Mac. Halving the pool roughly halves the steady-state cache footprint.
- **Matrix-width tradeoff.** The Playwright matrix has 5 browser projects; with 4 runners one project leg waits ~one job duration when no other workflows are queued. That's an acceptable tradeoff for the host-side savings — closer to the I/O knee than 8, well above the serial baseline.

### Scope decisions
- This PR does **not** include a benchmark sweep (1 / 2 / 4 / 8); 4 is chosen on hardware-anchored grounds. A follow-up issue can add empirical measurement if desired.
- Orphan `mac-runner-5..8` cleanup is a manual host-side operation — the script does not auto-remove higher-numbered runners. The new `### Reducing the pool` subsection in `docs/CI_LOCAL.md` documents the cleanup commands so a maintainer transitioning from 8 → 4 isn't left with stale launchd services.

Closes #506

## Test plan

- [x] `bash -n scripts/setup-runners.sh` parses without syntax errors.
- [x] `git diff` review: `scripts/setup-runners.sh:16` is the only script line changed; `docs/CI_LOCAL.md` text + new subsection consistent at "4"; `README.md:92` scripts-tree comment updated to "4".
- [x] Acceptance Criteria #1 (script provisions runners 1..4 only) — verified by reading the loop `for i in $(seq 1 "$WORKERS")` against `WORKERS=4`.
- [x] Acceptance Criteria #2 (script does not touch orphans 5..8; manual cleanup documented) — verified: loop bound stops at 4; cleanup procedure documented in new "Reducing the pool" subsection.
- [ ] Maintainer runs `./scripts/setup-runners.sh` on the Mac host and confirms `mac-runner-1..4` appear at https://github.com/hubertgajewski/orwellstat/settings/actions/runners (and `mac-runner-5..8` are stopped/uninstalled per the new docs section). Requires host access — defer to maintainer post-merge.
