### PR TITLE
#508 Make fix-issue skill description YAML-safe

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Fix a GitHub issue end-to-end: fetch, implement, test, review, commit, and open a PR.
+description: Fix a GitHub issue end-to-end - fetch, implement, test, review, commit, and open a PR.
 ---
 
 Issue number: $ARGUMENTS


### PR DESCRIPTION
Closes #508

## Summary

Update the `fix-issue` skill frontmatter description so it no longer contains an unquoted `: ` sequence that YAML parsers treat as a mapping delimiter.

## Test plan

- [x] Verified the `origin/main` frontmatter fails with `mapping values are not allowed in this context`.
- [x] Verified `.claude/skills/fix-issue/SKILL.md` frontmatter parses successfully with Ruby YAML.
- [x] Ran `git diff --cached --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated description text formatting for improved clarity.

* **Chores**
  * Minor metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->