### PR TITLE
#510 Reference Claude skills and agents from Codex

### DIFF
--- a/.agents/skills/create-issue
+++ b/.agents/skills/create-issue
@@ -1,0 +1,1 @@
+../../.claude/skills/create-issue

--- a/.agents/skills/deep-review
+++ b/.agents/skills/deep-review
@@ -1,0 +1,1 @@
+../../.claude/skills/deep-review

--- a/.agents/skills/deep-review-next
+++ b/.agents/skills/deep-review-next
@@ -1,0 +1,1 @@
+../../.claude/skills/deep-review-next

--- a/.agents/skills/fix-issue
+++ b/.agents/skills/fix-issue
@@ -1,0 +1,1 @@
+../../.claude/skills/fix-issue

--- a/.agents/skills/generate-stubs
+++ b/.agents/skills/generate-stubs
@@ -1,0 +1,1 @@
+../../.claude/skills/generate-stubs

--- a/.agents/skills/generate-test
+++ b/.agents/skills/generate-test
@@ -1,0 +1,1 @@
+../../.claude/skills/generate-test

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -185,7 +185,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); CMD=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.command // empty'); case \"$CMD\" in *git*|*commit*|*';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'$'*|*'('*|*')'*|*'{'*|*'}'*|*'='*|*'`'*) ;; *) exit 0;; esac; ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; SCRIPT=\"$ROOT/scripts/verify_commit_command_hook.py\"; EXPECTED='0c6d499e65f850b8066158c2d8ce548da0756c7f3c83acd5afb2ef453d6aaa95'; ACTUAL=$(shasum -a 256 \"$SCRIPT\" 2>/dev/null | awk '{print $1}') || exit 2; if [ \"$ACTUAL\" != \"$EXPECTED\" ]; then echo 'BLOCKED: commit hook helper hash mismatch; review scripts/verify_commit_command_hook.py and update the pinned hook hash deliberately.' >&2; exit 2; fi; printf '%s' \"$INPUT\" | python3 \"$SCRIPT\"",
+            "command": "INPUT=$(cat); CMD=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.command // empty'); case \"$CMD\" in *git*|*commit*|*';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'$'*|*'('*|*')'*|*'{'*|*'}'*|*'='*|*'`'*) ;; *) exit 0;; esac; ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; SCRIPT=\"$ROOT/scripts/verify_commit_command_hook.py\"; EXPECTED='0c6d499e65f850b8066158c2d8ce548da0756c7f3c83acd5afb2ef453d6aaa95'; ACTUAL=$(shasum -a 256 \"$SCRIPT\" 2>/dev/null | awk '{print $1}') || exit 2; if [ \"$ACTUAL\" != \"$EXPECTED\" ]; then echo 'BLOCKED: commit hook helper hash mismatch; review scripts/verify_commit_command_hook.py and update the pinned hook hash deliberately.' >&2; exit 2; fi; printf '%s' \"$INPUT\" | python3 \"$SCRIPT\" claude",
             "timeout": 60,
             "statusMessage": "Verifying types and format before commit..."
           },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -185,7 +185,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -q 'git commit'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 2; cd \"$ROOT/playwright/typescript\" || exit 2; OUT=$(npx tsc --noEmit 2>&1); TSC_EXIT=$?; if [ $TSC_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; OUT=$(npm run format:check 2>&1); FMT_EXIT=$?; if [ $FMT_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; fi",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE '(^|;|&&|\\|\\|)[[:space:]]*(git[[:space:]]+commit)([[:space:]]|$)'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 2; cd \"$ROOT/playwright/typescript\" || exit 2; OUT=$(npx tsc --noEmit 2>&1); TSC_EXIT=$?; if [ $TSC_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; OUT=$(npm run format:check 2>&1); FMT_EXIT=$?; if [ $FMT_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; fi",
             "timeout": 60,
             "statusMessage": "Verifying types and format before commit..."
           },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -185,7 +185,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE '(^|;|&&|\\|\\|)[[:space:]]*(git[[:space:]]+commit)([[:space:]]|$)'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 2; cd \"$ROOT/playwright/typescript\" || exit 2; OUT=$(npx tsc --noEmit 2>&1); TSC_EXIT=$?; if [ $TSC_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; OUT=$(npm run format:check 2>&1); FMT_EXIT=$?; if [ $FMT_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; fi",
+            "command": "INPUT=$(cat); CMD=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.command // empty'); case \"$CMD\" in *git*|*commit*|*';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'$'*|*'('*|*')'*|*'{'*|*'}'*|*'='*|*'`'*) ;; *) exit 0;; esac; ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; SCRIPT=\"$ROOT/scripts/verify_commit_command_hook.py\"; EXPECTED='0c6d499e65f850b8066158c2d8ce548da0756c7f3c83acd5afb2ef453d6aaa95'; ACTUAL=$(shasum -a 256 \"$SCRIPT\" 2>/dev/null | awk '{print $1}') || exit 2; if [ \"$ACTUAL\" != \"$EXPECTED\" ]; then echo 'BLOCKED: commit hook helper hash mismatch; review scripts/verify_commit_command_hook.py and update the pinned hook hash deliberately.' >&2; exit 2; fi; printf '%s' \"$INPUT\" | python3 \"$SCRIPT\"",
             "timeout": 60,
             "statusMessage": "Verifying types and format before commit..."
           },

--- a/.codex/agents/deep-review-architecture.toml
+++ b/.codex/agents/deep-review-architecture.toml
@@ -1,0 +1,10 @@
+description = "Architecture specialist — reviews dependency direction, layer leaks, and abstraction boundaries in the diff."
+developer_instructions = '''
+Read `.claude/agents/deep-review-architecture.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-architecture.toml
+++ b/.codex/agents/deep-review-architecture.toml
@@ -1,3 +1,4 @@
+name = "deep-review-architecture"
 description = "Architecture specialist — reviews dependency direction, layer leaks, and abstraction boundaries in the diff."
 developer_instructions = '''
 Read `.claude/agents/deep-review-architecture.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-ci.toml
+++ b/.codex/agents/deep-review-ci.toml
@@ -1,0 +1,10 @@
+description = "CI / GitHub Actions specialist — actionlint + shellcheck static pass first, LLM semantic pass for non-trivial workflows."
+developer_instructions = '''
+Read `.claude/agents/deep-review-ci.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-ci.toml
+++ b/.codex/agents/deep-review-ci.toml
@@ -1,3 +1,4 @@
+name = "deep-review-ci"
 description = "CI / GitHub Actions specialist — actionlint + shellcheck static pass first, LLM semantic pass for non-trivial workflows."
 developer_instructions = '''
 Read `.claude/agents/deep-review-ci.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-code.toml
+++ b/.codex/agents/deep-review-code.toml
@@ -1,0 +1,10 @@
+description = "General code-review specialist — Google Code Review Developer Guide-anchored review of functionality, tests, naming, comments, and dead code in the diff."
+developer_instructions = '''
+Read `.claude/agents/deep-review-code.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-code.toml
+++ b/.codex/agents/deep-review-code.toml
@@ -1,3 +1,4 @@
+name = "deep-review-code"
 description = "General code-review specialist — Google Code Review Developer Guide-anchored review of functionality, tests, naming, comments, and dead code in the diff."
 developer_instructions = '''
 Read `.claude/agents/deep-review-code.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-docs.toml
+++ b/.codex/agents/deep-review-docs.toml
@@ -1,0 +1,10 @@
+description = "Verifies README/CLAUDE.md/skill-file consistency against the project's documented split rules."
+developer_instructions = '''
+Read `.claude/agents/deep-review-docs.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-docs.toml
+++ b/.codex/agents/deep-review-docs.toml
@@ -1,3 +1,4 @@
+name = "deep-review-docs"
 description = "Verifies README/CLAUDE.md/skill-file consistency against the project's documented split rules."
 developer_instructions = '''
 Read `.claude/agents/deep-review-docs.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-project-checklist.toml
+++ b/.codex/agents/deep-review-project-checklist.toml
@@ -1,3 +1,4 @@
+name = "deep-review-project-checklist"
 description = "Apply orwellstat-specific Playwright/POM/fixture/tag conventions to changed code."
 developer_instructions = '''
 Read `.claude/agents/deep-review-project-checklist.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-project-checklist.toml
+++ b/.codex/agents/deep-review-project-checklist.toml
@@ -1,0 +1,10 @@
+description = "Apply orwellstat-specific Playwright/POM/fixture/tag conventions to changed code."
+developer_instructions = '''
+Read `.claude/agents/deep-review-project-checklist.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-python.toml
+++ b/.codex/agents/deep-review-python.toml
@@ -1,0 +1,10 @@
+description = "Python specialist — PEP-8/20/257-anchored idiom and style review of `.py` changes. Dispatch only when the diff contains `.py` files."
+developer_instructions = '''
+Read `.claude/agents/deep-review-python.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-python.toml
+++ b/.codex/agents/deep-review-python.toml
@@ -1,3 +1,4 @@
+name = "deep-review-python"
 description = "Python specialist — PEP-8/20/257-anchored idiom and style review of `.py` changes. Dispatch only when the diff contains `.py` files."
 developer_instructions = '''
 Read `.claude/agents/deep-review-python.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-qa.toml
+++ b/.codex/agents/deep-review-qa.toml
@@ -1,3 +1,4 @@
+name = "deep-review-qa"
 description = "QA specialist — Playwright E2E + Bruno API test review anchored in ISTQB-FL technique-based testing, Playwright Best Practices, and WCAG 2.2. Walks an explicit state-class checklist (empty, populated, max, form-input edges, auth, network, accessibility, multi-browser, locale) so AI-suggested tests cannot ship as happy-path-only."
 developer_instructions = '''
 Read `.claude/agents/deep-review-qa.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-qa.toml
+++ b/.codex/agents/deep-review-qa.toml
@@ -1,0 +1,10 @@
+description = "QA specialist — Playwright E2E + Bruno API test review anchored in ISTQB-FL technique-based testing, Playwright Best Practices, and WCAG 2.2. Walks an explicit state-class checklist (empty, populated, max, form-input edges, auth, network, accessibility, multi-browser, locale) so AI-suggested tests cannot ship as happy-path-only."
+developer_instructions = '''
+Read `.claude/agents/deep-review-qa.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-security.toml
+++ b/.codex/agents/deep-review-security.toml
@@ -1,3 +1,4 @@
+name = "deep-review-security"
 description = "Security specialist — OWASP Top 10:2021 / OWASP ASVS 4.0.3 / CWE Top 25 (2024) anchored vulnerability review of code changes."
 developer_instructions = '''
 Read `.claude/agents/deep-review-security.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-security.toml
+++ b/.codex/agents/deep-review-security.toml
@@ -1,0 +1,10 @@
+description = "Security specialist — OWASP Top 10:2021 / OWASP ASVS 4.0.3 / CWE Top 25 (2024) anchored vulnerability review of code changes."
+developer_instructions = '''
+Read `.claude/agents/deep-review-security.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-simplification.toml
+++ b/.codex/agents/deep-review-simplification.toml
@@ -1,0 +1,10 @@
+description = "Reviews diffs for code reuse, quality (DRY / Fowler smells), and efficiency."
+developer_instructions = '''
+Read `.claude/agents/deep-review-simplification.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-simplification.toml
+++ b/.codex/agents/deep-review-simplification.toml
@@ -1,3 +1,4 @@
+name = "deep-review-simplification"
 description = "Reviews diffs for code reuse, quality (DRY / Fowler smells), and efficiency."
 developer_instructions = '''
 Read `.claude/agents/deep-review-simplification.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-typescript.toml
+++ b/.codex/agents/deep-review-typescript.toml
@@ -1,3 +1,4 @@
+name = "deep-review-typescript"
 description = "TypeScript specialist — TS-Handbook/typescript-eslint-anchored idiom review of `.ts` / `.tsx` changes. Dispatch only when the diff contains `.ts` or `.tsx` files."
 developer_instructions = '''
 Read `.claude/agents/deep-review-typescript.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-typescript.toml
+++ b/.codex/agents/deep-review-typescript.toml
@@ -1,0 +1,10 @@
+description = "TypeScript specialist — TS-Handbook/typescript-eslint-anchored idiom review of `.ts` / `.tsx` changes. Dispatch only when the diff contains `.ts` or `.tsx` files."
+developer_instructions = '''
+Read `.claude/agents/deep-review-typescript.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/agents/deep-review-unit-test.toml
+++ b/.codex/agents/deep-review-unit-test.toml
@@ -1,3 +1,4 @@
+name = "deep-review-unit-test"
 description = "Unit-test specialist — Vitest (TypeScript) + pytest (Python) review anchored in ISTQB-FL boundary value analysis and the test-shape sections of the Google Code Review Developer Guide. Walks an explicit boundary-class checklist (empty/null inputs, numeric edges, collection sizes, string content, error paths, configuration boundaries) so AI-suggested unit tests cannot ship as happy-path-only, and enforces the project's ≥ 90% changed-line coverage rule on `scripts/`, `mcp/*/`, and `playwright/typescript/scripts/`."
 developer_instructions = '''
 Read `.claude/agents/deep-review-unit-test.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.

--- a/.codex/agents/deep-review-unit-test.toml
+++ b/.codex/agents/deep-review-unit-test.toml
@@ -1,0 +1,10 @@
+description = "Unit-test specialist — Vitest (TypeScript) + pytest (Python) review anchored in ISTQB-FL boundary value analysis and the test-shape sections of the Google Code Review Developer Guide. Walks an explicit boundary-class checklist (empty/null inputs, numeric edges, collection sizes, string content, error paths, configuration boundaries) so AI-suggested unit tests cannot ship as happy-path-only, and enforces the project's ≥ 90% changed-line coverage rule on `scripts/`, `mcp/*/`, and `playwright/typescript/scripts/`."
+developer_instructions = '''
+Read `.claude/agents/deep-review-unit-test.md` and follow it as the authoritative agent instruction source for this Codex agent. Do not rely on this TOML file for the review policy beyond the tool-name adaptations below.
+
+Adapt Claude-only tool names and paths to Codex equivalents while preserving the behavior required by the Claude source file:
+- `Read`, `Grep`, and `Glob` mean use Codex file inspection and search tools.
+- `Task` means use Codex spawned-agent support only when the caller explicitly authorizes sub-agents; otherwise perform the bounded work locally.
+- Claude hook behavior means use configured Codex hooks where available, otherwise run the equivalent explicit workflow check.
+- If the Claude source references `.claude/skills/deep-review-next/REFERENCES.md`, read that path directly; it remains the bibliography source of truth.
+'''

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,31 @@
+sandbox_mode = "workspace-write"
+
+[mcp_servers.MCP_DOCKER]
+args = [
+    "mcp",
+    "gateway",
+    "run",
+]
+command = "docker"
+
+[mcp_servers.coverage-matrix]
+args = ["mcp/coverage-matrix/dist/index.js"]
+command = "node"
+
+[mcp_servers.playwright]
+args = ["@playwright/mcp@0.0.68"]
+command = "npx"
+
+[mcp_servers.playwright-report-mcp]
+args = [
+    "--min-release-age=0",
+    "playwright-report-mcp@3.1.0",
+]
+command = "npx"
+
+[mcp_servers.playwright-report-mcp.env]
+PW_ALLOWED_DIRS = ".."
+
+[mcp_servers.quality-metrics]
+args = ["mcp/quality-metrics/dist/index.js"]
+command = "node"

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,58 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // empty'); if echo \"$FILE\" | grep -q 'playwright/typescript'; then ROOT=$(git -C \"$(dirname \"$FILE\")\" rev-parse --show-toplevel 2>/dev/null) && cd \"$ROOT/playwright/typescript\" && npx tsc --noEmit && npm run format; fi; true",
+            "timeout": 60,
+            "statusMessage": "Checking types and formatting..."
+          }
+        ]
+      },
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); TARGET=$(echo \"$INPUT\" | jq -r '.tool_input.path // .tool_response.path // empty'); if [ -n \"$TARGET\" ] && [ -d \"$TARGET\" ]; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && \"$ROOT/scripts/provision-worktree-env.sh\" \"$TARGET\" || true; fi",
+            "timeout": 10,
+            "statusMessage": "Provisioning env files for the new worktree..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE 'git[[:space:]]+worktree[[:space:]]+add[[:space:]]'; then TARGET=$(echo \"$CMD\" | awk '{a=0;s=0;for(i=1;i<=NF;i++){if($i==\"add\"){a=1;continue}if(!a)continue;if(s){s=0;continue}if($i==\"-b\"||$i==\"-B\"){s=1;continue}if(substr($i,1,1)==\"-\")continue;print $i;exit}}'); if [ -n \"$TARGET\" ] && [ -d \"$TARGET\" ]; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && \"$ROOT/scripts/provision-worktree-env.sh\" \"$TARGET\" || true; fi; fi",
+            "timeout": 10,
+            "statusMessage": "Provisioning env files after git worktree add..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -q 'git commit'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 2; cd \"$ROOT/playwright/typescript\" || exit 2; OUT=$(npx tsc --noEmit 2>&1); TSC_EXIT=$?; if [ $TSC_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; OUT=$(npm run format:check 2>&1); FMT_EXIT=$?; if [ $FMT_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; fi",
+            "timeout": 60,
+            "statusMessage": "Verifying types and format before commit..."
+          },
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE '(^|[^a-zA-Z0-9_-])playwright[[:space:]]+test([^a-zA-Z0-9_-]|$)'; then echo 'BLOCKED: direct Playwright CLI is forbidden. Use mcp__playwright-report-mcp__run_tests instead (see CLAUDE.md MCP servers section). For multiple iterations, call the MCP tool repeatedly.' >&2; exit 2; fi",
+            "timeout": 10,
+            "statusMessage": "Checking for direct Playwright CLI..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -q 'git commit'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 2; cd \"$ROOT/playwright/typescript\" || exit 2; OUT=$(npx tsc --noEmit 2>&1); TSC_EXIT=$?; if [ $TSC_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; OUT=$(npm run format:check 2>&1); FMT_EXIT=$?; if [ $FMT_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; fi",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE '(^|;|&&|\\|\\|)[[:space:]]*(git[[:space:]]+commit)([[:space:]]|$)'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 2; cd \"$ROOT/playwright/typescript\" || exit 2; OUT=$(npx tsc --noEmit 2>&1); TSC_EXIT=$?; if [ $TSC_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; OUT=$(npm run format:check 2>&1); FMT_EXIT=$?; if [ $FMT_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; fi",
             "timeout": 60,
             "statusMessage": "Verifying types and format before commit..."
           },

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE '(^|;|&&|\\|\\|)[[:space:]]*(git[[:space:]]+commit)([[:space:]]|$)'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 2; cd \"$ROOT/playwright/typescript\" || exit 2; OUT=$(npx tsc --noEmit 2>&1); TSC_EXIT=$?; if [ $TSC_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; OUT=$(npm run format:check 2>&1); FMT_EXIT=$?; if [ $FMT_EXIT -ne 0 ]; then echo \"$OUT\" >&2; exit 2; fi; fi",
+            "command": "INPUT=$(cat); CMD=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.command // empty'); case \"$CMD\" in *git*|*commit*|*';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'$'*|*'('*|*')'*|*'{'*|*'}'*|*'='*|*'`'*) ;; *) exit 0;; esac; ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; SCRIPT=\"$ROOT/scripts/verify_commit_command_hook.py\"; EXPECTED='0c6d499e65f850b8066158c2d8ce548da0756c7f3c83acd5afb2ef453d6aaa95'; ACTUAL=$(shasum -a 256 \"$SCRIPT\" 2>/dev/null | awk '{print $1}') || exit 2; if [ \"$ACTUAL\" != \"$EXPECTED\" ]; then echo 'BLOCKED: commit hook helper hash mismatch; review scripts/verify_commit_command_hook.py and update the pinned hook hash deliberately.' >&2; exit 2; fi; printf '%s' \"$INPUT\" | python3 \"$SCRIPT\"",
             "timeout": 60,
             "statusMessage": "Verifying types and format before commit..."
           },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,15 @@ When Codex tooling does not enforce that file directly, apply it manually:
 - if Codex-specific runtime rules are looser than `.claude/settings.json`, still follow `.claude/settings.json` for work in this repository
 
 If [CLAUDE.md](./CLAUDE.md), [`.claude/settings.json`](./.claude/settings.json), or the documents they reference contain instructions that are specific to Claude tooling or Claude-only features, do not ignore them silently. Use the closest Codex-equivalent workflow or safety rule available, and explicitly warn the user about the substitution. State what Claude-specific instruction could not be followed literally, what you did instead, and any practical limitation or behavior difference that remains.
+
+## Codex references to Claude workflows
+
+`.claude/skills/` and `.claude/agents/` are the source of truth for project workflows and specialist reviewer prompts. Codex exposes the same skills through `.agents/skills/` symlinks and the same specialist agents through thin `.codex/agents/*.toml` wrappers. Do not duplicate the full skill or agent text into Codex-specific files.
+
+Use these substitutions when a Claude source file names Claude-only mechanics:
+
+- Claude `Skill` tool: load the referenced project skill through Codex's native skill discovery.
+- Claude `Task` tool: use Codex `spawn_agent` / `wait_agent` only when the user has explicitly authorized sub-agents; otherwise perform the bounded work locally.
+- Claude `Read`, `Grep`, and `Glob`: use Codex file inspection and `rg`-based search.
+- Claude hooks in `.claude/settings.json`: use `.codex/hooks.json` for supported command hooks and run any unsupported checks explicitly before committing or finishing.
+- Claude agent hook runners: Codex cannot run these literally; follow the same review workflow manually or via Codex sub-agents when explicitly authorized.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ Commit messages are always a **short, single-line description** with no body and
 
 The `#N` prefix must come first so `git log --oneline` and GitHub cross-references work at a glance.
 
+Run commits as a direct `git commit ...` command from the repository checkout. Avoid compound shell commands such as `cd repo && git commit`, `git commit && git status`, or `git commit; git status` so the configured commit hooks run consistently.
+
 ---
 
 ## Issue fix workflow

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ docs/
 scripts/
   generate-quality-metrics.py  # generates QUALITY_METRICS.md and updates quality-metrics-history.json
   self-healing.py              # self-healing selector fix: parses test artifacts, posts PR comments or creates draft PRs
+  verify_commit_command_hook.py # shared pinned Claude/Codex hook check for direct git commit commands
+  test_commit_hook_config.py   # unit tests for Claude/Codex git commit command hooks
   test_self_healing.py         # unit tests for self-healing.py (loop prevention, classification, LLM-bound redaction)
   setup-runners.sh             # registers and starts 8 self-hosted runner instances as launchd services
 playwright/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Multi-language, multi-framework end-to-end test suite for [Orwell Stat](https://orwellstat.hubertgajewski.com) — a Polish-language web analytics and statistics service.
 
-## Claude skills
+## Claude and Codex skills
 
 Six project-scoped skills are available in Claude Code (stored in `.claude/skills/`) and appear in the VSCode extension `/` menu:
 
@@ -14,6 +14,10 @@ Six project-scoped skills are available in Claude Code (stored in `.claude/skill
 | `/deep-review-next` | `/deep-review-next [arg]`     | Multi-agent code review orchestrator — dispatches every project-scoped specialist agent under `.claude/agents/` in parallel against a scope resolved from `arg`: empty (local diff, **US1**), a PR number with optional bias (`213` or `213 focus on race conditions`, **US2**), a git ref or range (`HEAD~3..HEAD`, **US3a**), a file or directory path (`./scripts/self-healing.py`, **US3b**), or any other freeform instruction (**US3c**); surfaces their findings together. The current roster (security / project-checklist / simplification / code / architecture / typescript / python / docs / ci / qa / unit-test) is documented in `.claude/skills/deep-review-next/SKILL.md`. Coexists with `/deep-review` until promoted by dir rename (#435) |
 | `/generate-stubs`   | `/generate-stubs`             | Reads `coverage-matrix.json`, finds uncovered page-category combinations (excluding `title` and `api`), and generates `test.fixme()` stubs in the appropriate spec files                                                |
 | `/generate-test`    | `/generate-test <page>`       | Scaffolds `test.fixme()` blocks for one page's content / accessibility / visual-regression gaps in `coverage-matrix.json`, appending to existing spec files (never overwriting) or creating new ones                    |
+
+Codex exposes the same project skills through `.agents/skills/`. Those entries are symlinks to `.claude/skills/`; do not edit them independently. `.claude/skills/` is the source of truth for workflow text.
+
+Codex specialist agents live under `.codex/agents/` as thin TOML wrappers. Each wrapper points back to the matching `.claude/agents/<name>.md` file, which remains the source of truth for the agent prompt. Keep `.codex/` as the canonical Codex config directory; do not add a second `.Codex/` copy.
 
 ## Project board
 
@@ -75,6 +79,12 @@ Size is a coarse roadmap guess for epics, not a mechanical sum of children's poi
 .claude/
   skills/                   # project-scoped slash commands (fix-issue, create-issue, deep-review, deep-review-next, generate-stubs, generate-test)
   agents/                   # project-scoped sub-agents dispatched by skills (current roster lives in .claude/skills/deep-review-next/SKILL.md)
+.agents/
+  skills/                   # Codex project-skill symlinks to .claude/skills (references only, no duplicate workflow text)
+.codex/
+  agents/                   # Codex thin agent wrappers that reference .claude/agents/*.md
+  config.toml               # Codex MCP server configuration
+  hooks.json                # Codex hook equivalents for supported command hooks from .claude/settings.json
 .github/workflows/          # CI workflows (one per sub-project)
 CLAUDE.md                   # repository-specific behavioral guidance for Claude Code
 AGENTS.md                   # Codex entrypoint; delegates shared repository guidance to CLAUDE.md

--- a/scripts/test_commit_hook_config.py
+++ b/scripts/test_commit_hook_config.py
@@ -1,0 +1,432 @@
+"""Unit tests for the Claude/Codex git commit command hooks.
+
+Usage:
+    python3 scripts/test_commit_hook_config.py
+"""
+
+from __future__ import annotations
+
+import json
+import importlib.util
+import io
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_FILES = (".claude/settings.json", ".codex/hooks.json")
+_SPEC = importlib.util.spec_from_file_location(
+    "verify_commit_command_hook", REPO_ROOT / "scripts" / "verify_commit_command_hook.py"
+)
+hook = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(hook)
+
+
+class CommandDecisionTests(unittest.TestCase):
+    def test_allows_direct_commit_forms(self):
+        for command in (
+            "git commit -m test",
+            'git commit -m "test && docs; still direct"',
+            "git commit -m test\\;docs",
+            'git commit -m "$MSG"',
+        ):
+            with self.subTest(command=command):
+                self.assertEqual(hook.command_decision(command), "allow")
+
+    def test_blocks_non_direct_commit_forms(self):
+        for command in (
+            "cd /tmp && git commit -m test",
+            "git commit -m test && git status",
+            "git commit -m test; git status",
+            "git commit -m test || git status",
+            "git -C . commit -m test",
+            "git --git-dir . commit -m test",
+            "git --work-tree . commit -m test",
+            "git --config-env foo=bar commit -m test",
+            "git --unknown commit -m test",
+            "git ci -m test",
+            "git cherry-pick abc123",
+            "git merge feature",
+            "git rebase main",
+            "git rebase --continue",
+            "git pull",
+            "git -c alias.ci=commit ci -m test",
+            "git -calias.ci=commit ci -m test",
+            "git -c include.path=/tmp/gitconfig ci -m test",
+            "git -c includeIf.gitdir:/path/.git.path=/tmp/gitconfig ci -m test",
+            "git --config-env alias.ci=GIT_ALIAS ci -m test",
+            "git --config-env includeIf.gitdir:/path/.git.path=GIT_INCLUDE ci -m test",
+            "git --config-env=alias.ci=GIT_ALIAS ci -m test",
+            "git commit -m ok -F <(git add bad.py)",
+            "echo $(git -C . commit -m test)",
+            "echo $(git -c alias.ci=commit ci -m test)",
+            "echo $(git --config-env alias.ci=GIT_ALIAS ci -m test)",
+            "git commit -m \"$(date)\"",
+            'git "commit" -m test',
+            "git 'commit' -m test",
+            "git comm\\it -m test",
+            "true\ngit commit -m test",
+            "GIT_AUTHOR_NAME=test git commit -m test",
+            "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.ci GIT_CONFIG_VALUE_0=commit git ci -m test",
+            "GIT_CONFIG_GLOBAL=/tmp/gitconfig git ci -m test",
+            "env GIT_CONFIG_GLOBAL=/tmp/gitconfig git ci -m test",
+            "$'git' commit -m test",
+            "`printf git` commit --no-verify -m test",
+            "`printf /usr/bin/git` commit --no-verify -m test",
+            "`printf git` -c alias.ci=commit ci -m test",
+            "$(printf git) -c alias.ci=commit ci -m test",
+            "$'git' -c alias.ci=commit ci -m test",
+            "git${IFS}commit --no-verify",
+            "G=git; $G commit -m test",
+            "G=git; C=commit; $G $C -m test",
+            "env git commit -m test",
+            "env -- git commit -m test",
+            "env FOO=bar git commit -m test",
+            "env -i git commit -m test",
+            "env -u FOO git commit -m test",
+            "env -C /tmp git commit -m test",
+            "env -P /usr/bin git commit -m test",
+            "env -P/usr/bin git commit -m test",
+            "env -S 'git commit -m test'",
+            "env -S'git commit -m test'",
+            "env -Sgit commit -m test",
+            "env --split-string='git commit -m test'",
+            "command env -S 'git commit -m test'",
+            "exec env -S 'git commit -m test'",
+            "command env -Sgit commit -m test",
+            "env -S \"env -S 'env -S \\'env -S \\\\\\'git commit -m test\\\\\\'\\''\"",
+            "command git commit -m test",
+            "command -- bash -c 'git commit -m test'",
+            "command -p git -c alias.ci=commit ci -m test",
+            "command -p env -S 'git commit -m test'",
+            "command eval 'git commit -m test'",
+            "exec git commit -m test",
+            "exec -a name git -c alias.ci=commit ci -m test",
+            "exec -a name env -S 'git commit -m test'",
+            "exec -c git -c alias.ci=commit ci -m test",
+            "exec -l git -c alias.ci=commit ci -m test",
+            "exec -cl git -c alias.ci=commit ci -m test",
+            "exec -lc git -c alias.ci=commit ci -m test",
+            "exec -la name git -c alias.ci=commit ci -m test",
+            'eval "git commit -m test"',
+            'cmd="git commit -m test"; eval "$cmd"',
+            "printf 'commit -m test' | xargs git",
+            "printf 'commit -m test' | xargs /usr/bin/git",
+            "xargs -a /tmp/args sh -c 'git commit -m test'",
+            "xargs -a /tmp/args git",
+            "xargs -a /tmp/args -I{} git {} -m test",
+            "xargs --arg-file=/tmp/args -I{} git {} -m test",
+            "xargs -a /tmp/args git -C . commit -m test",
+            "printf 'commit --no-verify' | xargs git -C .",
+            "xargs -a /tmp/args git -c alias.ci=commit ci -m test",
+            "xargs -a /tmp/args env GIT_CONFIG_GLOBAL=/tmp/gitconfig git ci -m test",
+            "printf 'commit -m test' | xargs env git",
+            "xargs -a /tmp/args env git",
+            "printf 'commit -m test' | xargs env -S git",
+            "xargs -a /tmp/args env -S git",
+            "printf 'commit -m test' | xargs env -Sgit",
+            "xargs -a /tmp/args env --split-string=git",
+            'xargs -a /tmp/args -I{} sh -c "{}"',
+            'xargs -a /tmp/args -I{} env sh -c "{}"',
+            'xargs --replace={} sh -c "{}"',
+            "xargs -i sh -c '{}'",
+            "xargs -i git {} -m test",
+            "xargs sh -c < /tmp/args",
+            "printf 'git commit -m test' | sh",
+            'printf "git commit -m test" | xargs -I{} sh -c "{}"',
+            "printf git | xargs -I{} {} commit -m test",
+            "printf git | xargs -I{} {} -c alias.ci=commit ci -m test",
+            "printf git | xargs -I{} /usr/bin/{} -c alias.ci=commit ci -m test",
+            "printf git | xargs --replace=G /usr/bin/G -c alias.ci=commit ci -m test",
+            "printf git | xargs -I{} /usr/bin/env {} -c alias.ci=commit ci -m test",
+            "dash -c 'git commit -m test'",
+            "python3 -c 'import os; os.system(\"git commit -m test\")'",
+            "python3 -c 'import os; os.system(\"git\"+\" commit -m test\")'",
+            "node -e 'require(\"child_process\").execSync(\"git commit -m test\")'",
+            "node -e 'require(\"child_process\").execSync(\"git\"+\" commit -m test\")'",
+            "node --eval='require(\"child_process\").execSync(\"git commit -m test\")'",
+            "node --print='require(\"child_process\").execSync(\"git commit -m test\")'",
+            "node --eval='require(\"child_process\").execSync(\"git\"+\" commit -m test\")'",
+            "node -p'require(\"child_process\").execSync(\"git commit -m test\")'",
+            "node -p -e 'require(\"child_process\").execSync(\"git commit -m test\")'",
+            "node --print --eval 'require(\"child_process\").execSync(\"git commit -m test\")'",
+            "node -pe'require(\"child_process\").execSync(\"git commit -m test\")'",
+            "bash -c 'git commit -m test'",
+            "bash -lc 'git commit -m test'",
+            "bash --rcfile /tmp/x -c 'git commit -m test'",
+            "bash <<EOF\ngit commit -m test\nEOF",
+            "true\nbash <<EOF\ngit commit -m test\nEOF",
+            "sh <<EOF-1\ngit commit -m test\nEOF-1",
+            "env bash -c 'git commit -m test'",
+            "sh -c 'git commit -m test'",
+            "zsh -c 'git commit -m test'",
+            "zsh --no-rcs -c 'git commit -m test'",
+            "/usr/bin/git commit -m test",
+            "/usr/bin/env -- git commit -m test",
+            "(git commit -m test)",
+            "{ git commit -m test; }",
+            "if true; then git commit -m test; fi",
+            "echo git commit",
+            "echo $(git commit -m test)",
+            "echo `git commit -m test`",
+            'python3 - <<X\nprint("echo $(printf \'git commit\')")\nX',
+            "python3 - <<X\ngit commit -m test\nX",
+            "python3 - <<'EOF-1'\ngit commit -m test\nEOF-1\ngit status",
+            "git com$(printf mit) -m test",
+            "git 'commit",
+        ):
+            with self.subTest(command=command):
+                self.assertEqual(hook.command_decision(command), "block")
+
+    def test_recursion_limit_blocks_commit_payload(self):
+        self.assertEqual(
+            hook.command_decision("git commit -m test", hook.MAX_ENV_SPLIT_DEPTH + 1),
+            "block",
+        )
+
+    def test_ignores_non_commit_commands(self):
+        for command in (
+            'echo "; git commit --amend"',
+            "git help commit",
+            "git show commit",
+            'git show :README.md | rg -n "commit hook"',
+            "git commit-graph verify",
+            "GIT_CONFIG_NOSYSTEM=1 git status",
+            "GIT_CONFIG_NOSYSTEM=1 git branch",
+            "GIT_CONFIG_GLOBAL=/tmp/gitconfig echo git",
+            "xargs -a /tmp/args git status",
+            "xargs -a /tmp/args git -C . status",
+            "xargs -a /tmp/args env -S 'git status'",
+            "git config --get user.name",
+            "git config get user.name",
+            "git tag -l",
+            "git submodule status",
+            "git blame README.md",
+            "git version",
+            "git gc",
+            "git worktree add /tmp/wt HEAD",
+            "git worktree list",
+            "git diff",
+            "git mv old new",
+            "git rm --cached file",
+            "git apply patch.diff",
+            "git reflog",
+            "git rebase --abort",
+            "git rebase --quit",
+            "git merge --abort",
+            "git merge --quit",
+            "git cherry-pick --abort",
+            "git cherry-pick --quit",
+            "git reset --soft HEAD~1",
+            "git ls-tree HEAD",
+            "git describe --tags",
+            "git show-ref --heads",
+            "git diff | xargs echo commit",
+            "python3 scripts/foo.py git commit",
+            "command -v git commit -m test",
+            "command -V git commit -m test",
+            "command -pv git commit -m test",
+            "command -pV git commit -m test",
+            "git status | xargs echo commit",
+            "bash <<EOF\necho hi\nEOF",
+            "git status | xargs echo",
+            "echo $PATH | xargs echo",
+            "echo $PATH | xargs echo commit",
+            "sh /tmp/setup.sh",
+            "bash scripts/setup-runners.sh",
+            "node scripts/setup.js",
+            "git status",
+        ):
+            with self.subTest(command=command):
+                self.assertEqual(hook.command_decision(command), "none")
+
+    def test_main_returns_none_block_and_allow_decisions(self):
+        payload = json.dumps({"tool_input": {"command": "git status"}})
+        with patch("sys.argv", ["hook", "codex"]), patch("sys.stdin", io.StringIO(payload)):
+            self.assertEqual(hook.main(), 0)
+
+        for payload in ("", "{}", json.dumps({"tool_input": {}})):
+            with self.subTest(payload=payload):
+                with patch("sys.argv", ["hook", "codex"]), patch("sys.stdin", io.StringIO(payload)):
+                    self.assertEqual(hook.main(), 0)
+
+        payload = json.dumps({"tool_input": {"command": "env git commit -m test"}})
+        with (
+            patch("sys.argv", ["hook", "codex"]),
+            patch("sys.stdin", io.StringIO(payload)),
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(hook.main(), 2)
+
+        root = MagicMock(returncode=0, stdout=f"{REPO_ROOT}\n", stderr="")
+        with (
+            patch("sys.argv", ["hook", "codex"]),
+            patch("sys.stdin", io.StringIO(json.dumps({"tool_input": {"command": "git commit -m test"}}))),
+            patch.object(hook.subprocess, "run", return_value=root),
+        ):
+            self.assertEqual(hook.main(), 0)
+
+    def test_main_and_check_error_paths(self):
+        with patch("sys.argv", ["hook", "unknown"]), redirect_stderr(io.StringIO()):
+            self.assertEqual(hook.main(), 2)
+
+        failed_root = MagicMock(returncode=1, stdout="", stderr="not a repo\n")
+        with (
+            patch("sys.argv", ["hook", "codex"]),
+            patch("sys.stdin", io.StringIO(json.dumps({"tool_input": {"command": "git commit -m test"}}))),
+            patch.object(hook.subprocess, "run", return_value=failed_root),
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(hook.main(), 2)
+
+        failed_check = MagicMock(returncode=1, stdout="type output\n", stderr="type error\n")
+        with patch.object(hook.subprocess, "run", return_value=failed_check), redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                hook.run_check(["npx", "tsc", "--noEmit"], REPO_ROOT)
+
+
+class CommitCommandHookTests(unittest.TestCase):
+    def run_hook_command(self, hook_command: str, command: str) -> tuple[int, list[str], str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            calls_path = Path(tmpdir) / "calls.log"
+            for executable in ("npx", "npm"):
+                wrapper = Path(tmpdir) / executable
+                wrapper.write_text(
+                    textwrap.dedent(
+                        f"""\
+                        #!/bin/sh
+                        echo "{executable} $*" >> "{calls_path}"
+                        exit 0
+                        """
+                    ),
+                    encoding="utf-8",
+                )
+                wrapper.chmod(0o755)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{tmpdir}{os.pathsep}{env['PATH']}"
+            result = subprocess.run(
+                ["/bin/sh", "-c", hook_command],
+                cwd=REPO_ROOT,
+                env=env,
+                input=json.dumps({"tool_input": {"command": command}}),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            calls = calls_path.read_text(encoding="utf-8").splitlines() if calls_path.exists() else []
+            return result.returncode, calls, result.stderr
+
+    def run_hook(self, hook_file: str, command: str) -> tuple[int, list[str], str]:
+        return self.run_hook_command(self.commit_hook_command(hook_file), command)
+
+    def commit_hook_command(self, hook_file: str) -> str:
+        hook_config = json.loads((REPO_ROOT / hook_file).read_text(encoding="utf-8"))
+        for group in hook_config["hooks"]["PreToolUse"]:
+            if group.get("matcher") != "Bash":
+                continue
+            for hook in group["hooks"]:
+                command = hook.get("command", "")
+                if "verify_commit_command_hook.py" in command:
+                    return command
+        raise AssertionError(f"commit verifier hook not found in {hook_file}")
+
+    def assert_hook_case(
+        self,
+        command: str,
+        expected_status: int,
+        expected_calls: list[str],
+        expected_stderr: str | None = None,
+    ) -> None:
+        for hook_file in HOOK_FILES:
+            with self.subTest(hook_file=hook_file, command=command):
+                status, calls, stderr = self.run_hook(hook_file, command)
+                self.assertEqual(status, expected_status)
+                self.assertEqual(calls, expected_calls)
+                if expected_stderr is not None:
+                    self.assertIn(expected_stderr, stderr)
+
+    def test_direct_commit_runs_type_and_format_checks(self):
+        self.assert_hook_case(
+            "git commit -m test",
+            0,
+            ["npx tsc --noEmit", "npm run format:check"],
+        )
+
+    def test_irrelevant_commands_skip_verifier_before_hash_check(self):
+        for hook_file in HOOK_FILES:
+            with self.subTest(hook_file=hook_file):
+                hook_command = self.commit_hook_command(hook_file).replace("EXPECTED='", "EXPECTED='000")
+                status, calls, stderr = self.run_hook_command(hook_command, "date")
+                self.assertEqual(status, 0)
+                self.assertEqual(calls, [])
+                self.assertEqual(stderr, "")
+
+    def test_dynamic_commands_do_not_skip_verifier_prefilter(self):
+        for hook_file in HOOK_FILES:
+            with self.subTest(hook_file=hook_file):
+                hook_command = self.commit_hook_command(hook_file).replace("EXPECTED='", "EXPECTED='000")
+                status, calls, stderr = self.run_hook_command(
+                    hook_command,
+                    "G=g; I=it; C=com; M=mit; $G$I $C$M --no-verify",
+                )
+                self.assertEqual(status, 2)
+                self.assertEqual(calls, [])
+                self.assertIn("hash mismatch", stderr)
+
+    def test_compound_commit_forms_are_blocked(self):
+        for command in (
+            "cd /tmp && git commit -m test",
+            "git commit -m test && git status",
+            "git commit -m test; git status",
+            "git commit -m test || git status",
+            "git -C . commit -m test",
+            "true\ngit commit -m test",
+            "GIT_AUTHOR_NAME=test git commit -m test",
+            "env git commit -m test",
+            "command git commit -m test",
+            "/usr/bin/git commit -m test",
+            "(git commit -m test)",
+            "echo $(git commit -m test)",
+            "echo `git commit -m test`",
+            "G=g; I=it; C=com; M=mit; $G$I $C$M --no-verify",
+            "printf git | xargs -I{} {} -c alias.ci=commit ci -m test",
+            "printf git | xargs -I{} /usr/bin/{} -c alias.ci=commit ci -m test",
+            "printf git | xargs --replace=G /usr/bin/G -c alias.ci=commit ci -m test",
+            "printf git | xargs -I{} /usr/bin/env {} -c alias.ci=commit ci -m test",
+        ):
+            with self.subTest(command=command):
+                self.assert_hook_case(command, 2, [], "BLOCKED:")
+
+    def test_quoted_or_non_executable_commit_text_is_ignored(self):
+        for command in (
+            'echo "; git commit --amend"',
+            "git help commit",
+            "git show commit",
+            "git commit-graph verify",
+            "git status",
+        ):
+            with self.subTest(command=command):
+                self.assert_hook_case(command, 0, [])
+
+    def test_quoted_or_escaped_control_chars_in_direct_commit_are_allowed(self):
+        for command in (
+            'git commit -m "test && docs; still direct"',
+            "git commit -m test\\;docs",
+        ):
+            with self.subTest(command=command):
+                self.assert_hook_case(
+                    command,
+                    0,
+                    ["npx tsc --noEmit", "npm run format:check"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_commit_hook_config.py
+++ b/scripts/test_commit_hook_config.py
@@ -380,6 +380,18 @@ class CommitCommandHookTests(unittest.TestCase):
                 self.assertEqual(calls, [])
                 self.assertIn("hash mismatch", stderr)
 
+    def test_blocked_commands_use_platform_specific_messages(self):
+        expectations = {
+            ".claude/settings.json": hook.BLOCK_MESSAGES["claude"],
+            ".codex/hooks.json": hook.BLOCK_MESSAGES["codex"],
+        }
+        for hook_file, expected_message in expectations.items():
+            with self.subTest(hook_file=hook_file):
+                status, calls, stderr = self.run_hook(hook_file, "env git commit -m test")
+                self.assertEqual(status, 2)
+                self.assertEqual(calls, [])
+                self.assertIn(expected_message, stderr)
+
     def test_compound_commit_forms_are_blocked(self):
         for command in (
             "cd /tmp && git commit -m test",

--- a/scripts/verify_commit_command_hook.py
+++ b/scripts/verify_commit_command_hook.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+"""Shared Claude/Codex hook for direct git commit commands."""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Literal
+
+
+Decision = Literal["none", "block", "allow"]
+MAX_ENV_SPLIT_DEPTH = 3
+
+BLOCK_MESSAGES = {
+    "claude": 'BLOCKED: use a direct git commit command so the /deep-review agent hook runs (avoid compound commands like "cd repo && git commit").',
+    "codex": 'BLOCKED: use a direct git commit command so commit hooks run consistently (avoid compound commands like "cd repo && git commit").',
+}
+
+
+def scan_command(command: str) -> tuple[bool, str]:
+    state = "none"
+    escaped = False
+    forbidden = False
+    normalized: list[str] = []
+
+    for index, char in enumerate(command):
+        if escaped:
+            normalized.append(char)
+            escaped = False
+            continue
+
+        if state == "single":
+            normalized.append(char)
+            if char == "'":
+                state = "none"
+            continue
+
+        if state == "double":
+            normalized.append(char)
+            if char == '"':
+                state = "none"
+            elif char == "\\":
+                escaped = True
+            elif char == "`" or (char == "$" and command[index + 1 : index + 2] == "("):
+                forbidden = True
+            continue
+
+        if char == "\\":
+            normalized.append(char)
+            escaped = True
+        elif char == "'":
+            normalized.append(char)
+            state = "single"
+        elif char == '"':
+            normalized.append(char)
+            state = "double"
+        elif char == "\n":
+            forbidden = True
+            normalized.append(" ; ")
+        elif char in ";&|<>`" or (char in "$<>" and command[index + 1 : index + 2] == "("):
+            forbidden = True
+            normalized.append(char)
+        else:
+            normalized.append(char)
+
+    return forbidden, "".join(normalized)
+
+
+def shell_tokens(normalized_command: str) -> list[str] | None:
+    lexer = shlex.shlex(normalized_command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    try:
+        return list(lexer)
+    except ValueError:
+        return None
+
+
+def split_segments(tokens: list[str]) -> list[list[str]]:
+    segments: list[list[str]] = [[]]
+    for token in tokens:
+        if token and all(char in ";&|" for char in token):
+            segments.append([])
+        else:
+            segments[-1].append(token)
+    return [segment for segment in segments if segment]
+
+
+ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+GIT_OPTIONS_WITH_VALUES = {
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--exec-path",
+    "--config-env",
+}
+SUBSTITUTION_COMMIT_RE = re.compile(
+    r"(`|\$\(|<\(|>\()\s*(/\S*/)?git\b(?:\s+(?:-[A-Za-z]|--[A-Za-z-]+)(?:[=\s]\S+)*)*\s+commit\b",
+    re.DOTALL,
+)
+DYNAMIC_COMMIT_RE = re.compile(r"\bgit\s*\$[({A-Za-z_].*\bcommit\b", re.DOTALL)
+SHELL_INTERPRETERS = {"bash", "dash", "sh", "zsh"}
+INLINE_RUNTIME_FLAGS = {"-c", "-e", "--eval", "-p", "--print"}
+XARGS_OPTIONS_WITH_VALUES = {
+    "-a",
+    "--arg-file",
+    "-d",
+    "--delimiter",
+    "-E",
+    "-I",
+    "-L",
+    "--max-lines",
+    "-n",
+    "--max-args",
+    "-P",
+    "--max-procs",
+    "-s",
+    "--max-chars",
+}
+KNOWN_NON_COMMIT_GIT_SUBCOMMANDS = {
+    "add",
+    "apply",
+    "blame",
+    "branch",
+    "checkout",
+    "commit-graph",
+    "config",
+    "describe",
+    "diff",
+    "fetch",
+    "gc",
+    "grep",
+    "help",
+    "log",
+    "ls-files",
+    "ls-tree",
+    "mv",
+    "push",
+    "remote",
+    "reflog",
+    "restore",
+    "rev-parse",
+    "reset",
+    "rm",
+    "show",
+    "show-ref",
+    "stash",
+    "status",
+    "submodule",
+    "switch",
+    "tag",
+    "version",
+    "worktree",
+}
+ALIAS_CAPABLE_GIT_CONFIG_ENV = {
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_SYSTEM",
+}
+ENV_OPTIONS_WITH_VALUES = {
+    "-u",
+    "--unset",
+    "-C",
+    "--chdir",
+    "-P",
+    "--path",
+}
+ENV_FLAGS_WITHOUT_VALUES = {"-i", "-", "--ignore-environment"}
+
+
+def config_value_defines_commit_alias(value: str) -> bool:
+    return bool(re.match(r"^alias\.[^.]+=.*\bcommit\b", value, re.IGNORECASE))
+
+
+def config_value_can_define_alias(value: str) -> bool:
+    return bool(
+        config_value_defines_commit_alias(value)
+        or re.match(r"^include(?:If\..+)?\.path=", value, re.IGNORECASE)
+        or re.match(r"^alias\.[^.]+$", value, re.IGNORECASE)
+    )
+
+
+def config_env_key_can_define_alias(value: str) -> bool:
+    key = value.split("=", 1)[0]
+    return bool(
+        re.match(r"^alias\.[^.]+$", key, re.IGNORECASE)
+        or re.match(r"^include(?:If\..+)?\.path$", key, re.IGNORECASE)
+    )
+
+
+def is_git_executable(token: str) -> bool:
+    return token == "git" or token.endswith("/git")
+
+
+def is_git_config_assignment(token: str) -> bool:
+    key = token.split("=", 1)[0]
+    return (
+        key in ALIAS_CAPABLE_GIT_CONFIG_ENV
+        or key.startswith("GIT_CONFIG_KEY_")
+        or key.startswith("GIT_CONFIG_VALUE_")
+    )
+
+
+def first_token_basename(segment: list[str]) -> str:
+    return Path(segment[0]).name if segment else ""
+
+
+def scan_env_prefix(segment: list[str], index: int) -> tuple[int, bool, list[str]]:
+    index += 1
+    has_git_config_assignment = False
+    split_payloads: list[str] = []
+    while index < len(segment):
+        token = segment[index]
+        if ASSIGNMENT_RE.match(token):
+            has_git_config_assignment = has_git_config_assignment or is_git_config_assignment(token)
+            index += 1
+        elif token == "--":
+            index += 1
+            break
+        elif token in {"-S", "--split-string"}:
+            if index + 1 < len(segment):
+                split_payloads.append(" ".join(segment[index + 1 :]))
+            index += 2
+        elif token.startswith("-S") and len(token) > 2:
+            split_payloads.append(" ".join([token[2:], *segment[index + 1 :]]))
+            index += 1
+        elif token.startswith("--split-string="):
+            split_payloads.append(" ".join([token.split("=", 1)[1], *segment[index + 1 :]]))
+            index += 1
+        elif token in ENV_OPTIONS_WITH_VALUES:
+            index += 2
+        elif (
+            token in ENV_FLAGS_WITHOUT_VALUES
+            or token.startswith("-u")
+            or token.startswith("--unset=")
+            or token.startswith("--path=")
+            or token.startswith("-P")
+        ):
+            index += 1
+        else:
+            break
+    return index, has_git_config_assignment, split_payloads
+
+
+def skip_env_prefix(segment: list[str], index: int) -> int:
+    return scan_env_prefix(segment, index)[0]
+
+
+def env_prefix_has_git_config_assignment(segment: list[str], index: int) -> bool:
+    return scan_env_prefix(segment, index)[1]
+
+
+def env_split_string_contains_commit(segment: list[str], index: int, depth: int) -> bool:
+    return any(command_decision(payload, depth + 1) != "none" for payload in scan_env_prefix(segment, index)[2])
+
+
+def env_split_payloads(segment: list[str]) -> list[str]:
+    return scan_env_prefix(segment, 0)[2]
+
+
+def env_split_payload_allows_xargs_input(payload: str, depth: int) -> bool:
+    if command_decision(payload, depth + 1) != "none":
+        return True
+    tokens = shell_tokens(scan_command(payload)[1])
+    if not tokens:
+        return False
+    segments = split_segments(tokens)
+    return any(len(segment) == 1 and is_git_executable(segment[0]) for segment in segments)
+
+
+def skip_command_prefix(segment: list[str], index: int) -> int | None:
+    index += 1
+    while index < len(segment):
+        token = segment[index]
+        if token == "--":
+            return index + 1
+        if token.startswith("-") and not token.startswith("--") and any(flag in token for flag in {"v", "V"}):
+            return None
+        if token == "-p" or (token.startswith("-") and set(token[1:]) <= {"p"}):
+            index += 1
+            continue
+        break
+    return index
+
+
+def skip_exec_prefix(segment: list[str], index: int) -> int:
+    index += 1
+    while index < len(segment):
+        token = segment[index]
+        if token == "--":
+            return index + 1
+        if token == "-a" and index + 1 < len(segment):
+            index += 2
+            continue
+        if token.startswith("-") and not token.startswith("--") and "a" in token[1:] and index + 1 < len(segment):
+            index += 2
+            continue
+        if token in {"-c", "-l"} or (token.startswith("-") and not token.startswith("--") and set(token[1:]) <= {"c", "l"}):
+            index += 1
+            continue
+        break
+    return index
+
+
+def interpreter_string_contains_commit(segment: list[str], depth: int) -> bool:
+    if not segment:
+        return False
+
+    interpreter = Path(segment[0]).name
+    if interpreter not in SHELL_INTERPRETERS:
+        return False
+
+    for index, token in enumerate(segment[1:], start=1):
+        if token == "-c":
+            return index + 1 < len(segment) and command_decision(segment[index + 1], depth + 1) != "none"
+        if token.startswith("-c") and len(token) > 2 and not token.startswith("--"):
+            return command_decision(token[2:], depth + 1) != "none"
+        if token.startswith("-") and not token.startswith("--") and "c" in token[1:]:
+            return index + 1 < len(segment) and command_decision(segment[index + 1], depth + 1) != "none"
+        if token in {"--rcfile", "--init-file"}:
+            continue
+
+    return False
+
+
+def python_string_contains_commit(segment: list[str]) -> bool:
+    if not segment or not re.match(r"^python(?:\d+(?:\.\d+)?)?$", Path(segment[0]).name):
+        return False
+
+    for index, token in enumerate(segment[1:], start=1):
+        if token == "-c":
+            return index + 1 < len(segment) and re.search(r"\bgit\b.*\bcommit\b", segment[index + 1], re.DOTALL) is not None
+        if token.startswith("-c") and len(token) > 2:
+            return re.search(r"\bgit\b.*\bcommit\b", token[2:], re.DOTALL) is not None
+    return False
+
+
+def node_string_contains_commit(segment: list[str]) -> bool:
+    if not segment or Path(segment[0]).name != "node":
+        return False
+
+    for index, token in enumerate(segment[1:], start=1):
+        if token in INLINE_RUNTIME_FLAGS:
+            if token in {"-p", "--print"} and index + 1 < len(segment) and segment[index + 1].startswith("-"):
+                continue
+            return index + 1 < len(segment) and re.search(r"\bgit\b.*\bcommit\b", segment[index + 1], re.DOTALL) is not None
+        if token.startswith("--eval=") or token.startswith("--print="):
+            return re.search(r"\bgit\b.*\bcommit\b", token.split("=", 1)[1], re.DOTALL) is not None
+        if token.startswith("-") and not token.startswith("--") and "e" in token[1:] and len(token) > 2:
+            inline = token[token.index("e") + 1 :]
+            if inline:
+                return re.search(r"\bgit\b.*\bcommit\b", inline, re.DOTALL) is not None
+            return index + 1 < len(segment) and re.search(r"\bgit\b.*\bcommit\b", segment[index + 1], re.DOTALL) is not None
+        if token.startswith("-p") and len(token) > 2:
+            return re.search(r"\bgit\b.*\bcommit\b", token[2:], re.DOTALL) is not None
+    return False
+
+
+def substitution_contains_commit(command: str, depth: int) -> bool:
+    substitution_re = re.compile(r"\$\(([^)]*)\)|`([^`]*)`|[<>]\(([^)]*)\)", re.DOTALL)
+    for match in substitution_re.finditer(command):
+        body = next(group for group in match.groups() if group is not None)
+        if body and command_decision(body, depth + 1) != "none":
+            return True
+    return False
+
+
+def xargs_utility_index(segment: list[str]) -> int | None:
+    index = 1
+    while index < len(segment):
+        token = segment[index]
+        if token == "--":
+            return index + 1 if index + 1 < len(segment) else None
+        if token == "-i":
+            index += 1
+            continue
+        if token in XARGS_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if token.startswith("--") and "=" in token:
+            index += 1
+            continue
+        if token.startswith("-") and token != "-":
+            index += 1
+            continue
+        return index
+    return None
+
+
+def xargs_input_info(segment: list[str]) -> tuple[bool, set[str]]:
+    index = 1
+    has_external_input = False
+    replacement_tokens: set[str] = set()
+    while index < len(segment):
+        token = segment[index]
+        if token == "--":
+            return has_external_input, replacement_tokens
+        if token in {"-a", "--arg-file"}:
+            has_external_input = True
+            index += 2
+            continue
+        if token.startswith("--arg-file="):
+            has_external_input = True
+            index += 1
+            continue
+        if token == "-I":
+            has_external_input = True
+            if index + 1 < len(segment):
+                replacement_tokens.add(segment[index + 1])
+            index += 2
+            continue
+        if token == "-i":
+            has_external_input = True
+            replacement_tokens.add("{}")
+            index += 1
+            continue
+        if token == "--replace":
+            has_external_input = True
+            replacement_tokens.add("{}")
+            index += 1
+            continue
+        if token.startswith("--replace="):
+            has_external_input = True
+            replacement_tokens.add(token.split("=", 1)[1] or "{}")
+            index += 1
+            continue
+        if token.startswith("-I") and len(token) > 2:
+            has_external_input = True
+            replacement_tokens.add(token[2:])
+            index += 1
+            continue
+        if token.startswith("-i") and len(token) > 2:
+            has_external_input = True
+            replacement_tokens.add(token[2:])
+            index += 1
+            continue
+        if token in XARGS_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if token.startswith("--") and "=" in token:
+            index += 1
+            continue
+        if token.startswith("-") and token != "-":
+            index += 1
+            continue
+        return has_external_input, replacement_tokens
+    return has_external_input, replacement_tokens
+
+
+def xargs_utility_contains_commit(current: list[str], utility_index: int, depth: int) -> bool:
+    utility = current[utility_index:]
+    has_external_or_replacement_input, replacement_tokens = xargs_input_info(current)
+    if has_external_or_replacement_input and utility and any(token == "commit" for token in utility[1:]):
+        return True
+    if has_external_or_replacement_input and utility and any(
+        marker and marker in token and any(config_value_can_define_alias(arg) for arg in utility)
+        for marker in replacement_tokens
+        for token in utility
+    ):
+        return any(config_value_can_define_alias(token) for token in utility[1:])
+    if is_git_executable(utility[0]) and len(utility) == 1:
+        return True
+    if git_invocation(utility, depth)[0]:
+        return True
+    if is_git_executable(utility[0]) and git_invocation([*utility, "commit"], depth)[0]:
+        return True
+    if first_token_basename(utility) == "env":
+        if env_split_string_contains_commit(utility, 0, depth) or any(
+            env_split_payload_allows_xargs_input(payload, depth) for payload in env_split_payloads(utility)
+        ):
+            return True
+        utility = utility[skip_env_prefix(utility, 0) :]
+    if utility and is_git_executable(utility[0]) and len(utility) == 1:
+        return True
+    if utility and git_invocation(utility, depth)[0]:
+        return True
+    if utility and is_git_executable(utility[0]) and git_invocation([*utility, "commit"], depth)[0]:
+        return True
+    if has_external_or_replacement_input and utility and first_token_basename(utility) in {"eval", *SHELL_INTERPRETERS}:
+        return True
+    if utility and first_token_basename(utility) in SHELL_INTERPRETERS and any(token in {"<", "<<"} for token in current):
+        return True
+    return command_builder_contains_commit(current, utility_index, depth)
+
+
+def command_builder_contains_commit(segment: list[str], index: int, depth: int) -> bool:
+    current = segment[index:]
+    if interpreter_string_contains_commit(current, depth) or python_string_contains_commit(current) or node_string_contains_commit(current):
+        return True
+    if current and first_token_basename(current) in SHELL_INTERPRETERS:
+        return any(re.search(r"\bgit\b.*\bcommit\b", token, re.DOTALL) for token in current[1:])
+    if current and first_token_basename(current) == "eval":
+        nested = " ".join(current[1:])
+        return bool(nested and command_decision(nested, depth + 1) != "none")
+    if current and first_token_basename(current) == "env":
+        if env_split_string_contains_commit(current, 0, depth) or any(
+            env_split_payload_allows_xargs_input(payload, depth) for payload in env_split_payloads(current)
+        ):
+            return True
+        env_index = skip_env_prefix(current, 0)
+        return env_index < len(current) and command_builder_contains_commit(current, env_index, depth)
+    if current and first_token_basename(current) == "xargs":
+        utility_index = xargs_utility_index(current)
+        if utility_index is None:
+            return False
+        return xargs_utility_contains_commit(current, utility_index, depth)
+    return False
+
+
+def git_invocation(segment: list[str], depth: int) -> tuple[bool, bool]:
+    index = 0
+    while index < len(segment) and segment[index] == "(":
+        index += 1
+    has_git_config_assignment = False
+    while index < len(segment) and ASSIGNMENT_RE.match(segment[index]):
+        has_git_config_assignment = has_git_config_assignment or is_git_config_assignment(segment[index])
+        index += 1
+    if command_builder_contains_commit(segment, index, depth):
+        return True, False
+    if index < len(segment) and first_token_basename(segment[index:]) == "env":
+        if env_split_string_contains_commit(segment, index, depth):
+            return True, False
+        has_git_config_assignment = has_git_config_assignment or env_prefix_has_git_config_assignment(segment, index)
+        index = skip_env_prefix(segment, index)
+    if index < len(segment) and segment[index] == "command":
+        next_index = skip_command_prefix(segment, index)
+        if next_index is None:
+            return False, False
+        index = next_index
+    if index < len(segment) and segment[index] == "exec":
+        index = skip_exec_prefix(segment, index)
+    if command_builder_contains_commit(segment, index, depth):
+        return True, False
+
+    if index < len(segment) and "$" in segment[index] and any(
+        "$" in token or token == "commit" or config_value_can_define_alias(token) for token in segment[index + 1 :]
+    ):
+        return True, False
+
+    if index >= len(segment) or not is_git_executable(segment[index]):
+        return False, False
+
+    git_index = index
+    index += 1
+    while index < len(segment):
+        token = segment[index]
+        if token == "--":
+            index += 1
+            break
+        if token in GIT_OPTIONS_WITH_VALUES:
+            if token == "-c" and index + 1 < len(segment) and config_value_can_define_alias(segment[index + 1]):
+                return True, False
+            if token == "--config-env" and index + 1 < len(segment) and config_env_key_can_define_alias(segment[index + 1]):
+                return True, False
+            index += 2
+            continue
+        if token.startswith("-c") and config_value_can_define_alias(token[2:]):
+            return True, False
+        if token.startswith("--config-env=") and config_env_key_can_define_alias(token.split("=", 1)[1]):
+            return True, False
+        if token.startswith("--") and "=" in token:
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+
+    is_commit = index < len(segment) and segment[index] == "commit"
+    if index < len(segment) and segment[index] in {"cherry-pick", "merge", "rebase"}:
+        return not any(token in {"--abort", "--quit"} for token in segment[index + 1 :]), False
+    if index < len(segment) and not is_commit and segment[index] not in KNOWN_NON_COMMIT_GIT_SUBCOMMANDS:
+        return True, False
+    if (
+        has_git_config_assignment
+        and git_index == index - 1
+        and index < len(segment)
+        and not is_commit
+        and segment[index] not in KNOWN_NON_COMMIT_GIT_SUBCOMMANDS
+    ):
+        return True, False
+    if not is_commit and index < len(segment) and any("$" in token or token in {"(", ")"} for token in segment[index:]):
+        return True, False
+    is_direct = (
+        len(segment) >= 2
+        and segment[0] == "git"
+        and segment[1] == "commit"
+        and git_index == 0
+        and index == 1
+    )
+    return is_commit, is_direct
+
+
+def segment_has_embedded_git_commit(segment: list[str]) -> bool:
+    if segment and segment[0] == "command" and any(
+        token.startswith("-") and not token.startswith("--") and any(flag in token for flag in {"v", "V"})
+        for token in segment[1:]
+    ):
+        return False
+    if segment and re.match(r"^python(?:\d+(?:\.\d+)?)?$", first_token_basename(segment)) and len(segment) > 1 and segment[1] != "-":
+        return False
+    for index in range(len(segment) - 1):
+        if is_git_executable(segment[index]) and segment[index + 1] == "commit":
+            return True
+    return False
+
+
+def segment_has_dynamic_git_commit(segment: list[str]) -> bool:
+    return any(re.search(r"\bgit\s*\$.*commit\b|\bgit\$\{[^}]+\}commit\b", token) for token in segment)
+
+
+def command_decision(command: str, depth: int = 0) -> Decision:
+    if depth > MAX_ENV_SPLIT_DEPTH:
+        return "block" if re.search(r"\bgit\b.*\bcommit\b", command, re.DOTALL) else "none"
+
+    forbidden, normalized_command = scan_command(command)
+    tokens = shell_tokens(normalized_command)
+
+    if tokens is None:
+        return "block" if re.search(r"\bgit\b.*\bcommit\b", command, re.DOTALL) else "none"
+
+    segments = split_segments(tokens)
+    invocations = [git_invocation(segment, depth) for segment in segments]
+    commit_invocations = [invocation for invocation in invocations if invocation[0]]
+    direct_invocations = [invocation for invocation in commit_invocations if invocation[1]]
+    if not commit_invocations:
+        if any(segment_has_embedded_git_commit(segment) for segment in segments):
+            return "block"
+        if any(segment_has_dynamic_git_commit(segment) for segment in segments):
+            return "block"
+        if any(
+            segment
+            and (segment[0].startswith("`") or segment[0].startswith("$(") or segment[0].startswith("$"))
+            and any("commit" in token or config_value_can_define_alias(token) for token in segment[1:])
+            for segment in segments
+        ):
+            return "block"
+        if any(segment and first_token_basename(segment) == "eval" for segment in segments) and re.search(
+            r"\bgit\b.*\bcommit\b", command, re.DOTALL
+        ):
+            return "block"
+        if any(segment and first_token_basename(segment) in SHELL_INTERPRETERS for segment in segments) and re.search(
+            r"\bgit\b.*\bcommit\b", command, re.DOTALL
+        ):
+            return "block"
+        if any(segment and first_token_basename(segment) == "python3" and len(segment) > 1 and segment[1] == "-" for segment in segments) and re.search(
+            r"\bgit\b.*\bcommit\b", command, re.DOTALL
+        ):
+            return "block"
+        if forbidden and (
+            substitution_contains_commit(command, depth)
+            or SUBSTITUTION_COMMIT_RE.search(command)
+            or DYNAMIC_COMMIT_RE.search(command)
+        ):
+            return "block"
+        return "none"
+
+    direct = (
+        len(segments) == 1
+        and len(direct_invocations) == 1
+        and re.match(r"^\s*git\s+commit(?:\s|$)", command) is not None
+    )
+    if direct and not forbidden:
+        return "allow"
+    return "block"
+
+
+def run_check(command: list[str], cwd: Path) -> None:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise SystemExit(2)
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "codex"
+    if mode not in BLOCK_MESSAGES:
+        print(f"Unknown commit hook mode: {mode}", file=sys.stderr)
+        return 2
+
+    payload = json.loads(sys.stdin.read() or "{}")
+    command = payload.get("tool_input", {}).get("command", "")
+    decision = command_decision(command)
+    if decision == "none":
+        return 0
+    if decision == "block":
+        print(BLOCK_MESSAGES[mode], file=sys.stderr)
+        return 2
+
+    root_result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if root_result.returncode != 0:
+        sys.stderr.write(root_result.stderr)
+        return 2
+
+    playwright_dir = Path(root_result.stdout.strip()) / "playwright" / "typescript"
+    run_check(["npx", "tsc", "--noEmit"], playwright_dir)
+    run_check(["npm", "run", "format:check"], playwright_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #510

## Summary

- Add Codex project-skill symlinks that reference the authoritative .claude/skills workflows.
- Add thin Codex specialist-agent wrappers that point back to .claude/agents prompts.
- Document the Claude-source / Codex-reference model and Claude-to-Codex substitutions.

## Test plan

- [x] Verified .agents/skills symlinks resolve to matching .claude/skills/SKILL.md files.
- [x] Parsed .codex agent TOML, .codex/config.toml, and .codex/hooks.json successfully.
- [x] Verified deep-review-next references 11 specialist agents and .codex/agents provides 11 matching wrappers.
- [x] Ran git diff --check and git diff --cached --check.
- [x] Ran npx tsc --noEmit from playwright/typescript.
- [x] Ran npm run format:check from playwright/typescript.
- [x] CI completes on the PR branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed Codex access to existing skills via thin platform adapters/symlinks.
* **Chores**
  * Added multiple specialist agent configurations, workspace-level runtime config, and execution hooks including a commit-verifier gate and worktree provisioning.
* **Tests**
  * Added unit and integration tests validating commit-hook verification, blocking/allow paths, and hook-driven tooling calls.
* **Documentation**
  * Updated docs to explain cross-tool workflow mappings, skill sourcing, and new configuration/hooks usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->