### PR TITLE
#512 Add self-hosted runner deregistration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ scripts/
   self-healing.py              # self-healing selector fix: parses test artifacts, posts PR comments or creates draft PRs
   verify_commit_command_hook.py # shared pinned Claude/Codex hook check for direct git commit commands
   test_commit_hook_config.py   # unit tests for Claude/Codex git commit command hooks
+  test_runner_scripts.py       # unit tests for self-hosted runner setup/removal scripts
   test_self_healing.py         # unit tests for self-healing.py (loop prevention, classification, LLM-bound redaction)
+  remove-runners.sh            # de-registers and stops 4 self-hosted runner instances
+  runner-lib.sh                # shared helpers for self-hosted runner scripts
   setup-runners.sh             # registers and starts 4 self-hosted runner instances as launchd services
 playwright/
   typescript/               # Playwright tests in TypeScript

--- a/docs/CI_LOCAL.md
+++ b/docs/CI_LOCAL.md
@@ -44,20 +44,15 @@ The script copies the package into `~/actions-runner-1` … `~/actions-runner-4`
 
 The default of 4 workers anchors to the GitHub-hosted Linux runner hardware contract (4 vCPU) and leaves CPU and disk-cache headroom on a single Mac — every runner keeps its own `_work` checkout and Playwright browser cache (~600 MB), so adding more processes has diminishing returns once the host's I/O knee is reached.
 
-### Reducing the pool
+### Removing the runner pool
 
-`setup-runners.sh` only provisions runners 1 through `WORKERS`; it does not remove higher-numbered runners left over from a previous higher-`WORKERS` run. After lowering `WORKERS` (for example, from 8 to 4), stop and uninstall the orphans manually:
+To de-register and stop the 4 persistent runners created by `setup-runners.sh`, run:
 
 ```bash
-# Replace 5..8 with whichever indices became orphans for your transition
-for i in 5 6 7 8; do
-  cd "$HOME/actions-runner-$i" 2>/dev/null || continue
-  ./svc.sh stop || true
-  ./svc.sh uninstall || true
-done
+./scripts/remove-runners.sh
 ```
 
-Then de-register the orphans at **GitHub → Settings → Actions → Runners** so they no longer count against the runner roster, and optionally delete the `~/actions-runner-{5..8}` directories.
+The removal script handles `~/actions-runner-1` … `~/actions-runner-4`, stops and uninstalls any launchd service wrapper it finds, and runs `./config.sh remove --token <remove-token>` for directories that still have local runner configuration. It skips missing directories and warns about partial directories that no longer contain `config.sh`, so one broken runner does not block cleanup for the rest.
 
 ### Routing jobs to the self-hosted runner
 

--- a/docs/FORK.md
+++ b/docs/FORK.md
@@ -71,7 +71,7 @@ These are useful for Orwell Stat, but optional for a fork:
 - AI diagnosis in [diagnosis.util.ts](../playwright/typescript/utils/diagnosis.util.ts) if you do not want failed DOM snapshots sent to an external AI provider
 - visual regression snapshots in [tests/visual.spec.ts](../playwright/typescript/tests/visual.spec.ts) until your UI is stable
 - W3C validation checks in [tests/validation.spec.ts](../playwright/typescript/tests/validation.spec.ts) if your app is not XHTML/CSS-validator oriented
-- self-hosted runner automation in [setup-runners.sh](../scripts/setup-runners.sh) if you do not need push-back workflows
+- self-hosted runner automation in [setup-runners.sh](../scripts/setup-runners.sh) and [remove-runners.sh](../scripts/remove-runners.sh) if you do not need push-back workflows
 - quality metrics and issue-label reporting if your repo does not use the same bug taxonomy
 
 ### Workflow adjustments usually needed in a fork
@@ -83,7 +83,7 @@ The most common adjustments are:
 - repository identity guards in files under [.github/workflows](../.github/workflows), such as `github.repository == 'hubertgajewski/orwellstat'`
 - secret names and repository variables if your environment does not use `ORWELLSTAT_*`, `BASIC_AUTH_*`, `PLAYWRIGHT_TYPESCRIPT`, `BRUNO`, or `QUALITY_METRICS`
 - push-back workflows that commit generated files or visual baselines back to the repository
-- self-hosted runner configuration in [setup-runners.sh](../scripts/setup-runners.sh), which is currently hardcoded to this GitHub repository
+- self-hosted runner configuration in [setup-runners.sh](../scripts/setup-runners.sh), [remove-runners.sh](../scripts/remove-runners.sh), and [runner-lib.sh](../scripts/runner-lib.sh), which is currently hardcoded to this GitHub repository
 - optional AI integrations such as AI diagnosis (Anthropic or Gemini) and PR review if you do not want external AI services in your pipeline
 
 Review these files first:
@@ -95,6 +95,8 @@ Review these files first:
 - [update-visual-baselines.yml](../.github/workflows/update-visual-baselines.yml)
 - [claude-code-review.yml](../.github/workflows/claude-code-review.yml)
 - [setup-runners.sh](../scripts/setup-runners.sh)
+- [remove-runners.sh](../scripts/remove-runners.sh)
+- [runner-lib.sh](../scripts/runner-lib.sh)
 
 ### Recommended migration order
 

--- a/scripts/remove-runners.sh
+++ b/scripts/remove-runners.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# remove-runners.sh - stop, unregister, and uninstall local self-hosted runner instances
+#
+# Usage:
+#   ./scripts/remove-runners.sh
+#
+# Removes the 4 persistent runner services created by setup-runners.sh when their
+# local runner directories exist. Missing or partially removed directories are
+# reported and skipped so one broken runner does not block the rest.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/runner-lib.sh
+. "$SCRIPT_DIR/runner-lib.sh"
+
+for i in $(seq 1 "$WORKERS"); do
+  DIR="$HOME/actions-runner-$i"
+  NAME="mac-runner-$i"
+
+  echo ""
+  echo "=== $NAME ==="
+
+  if [ ! -d "$DIR" ]; then
+    echo "Skipping missing runner directory: $DIR"
+    continue
+  fi
+
+  cd "$DIR"
+
+  stop_runner_service
+  remove_configured_runner_best_effort "$DIR"
+done
+
+echo ""
+echo "Runner removal complete."

--- a/scripts/runner-lib.sh
+++ b/scripts/runner-lib.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Shared helpers for local self-hosted GitHub Actions runner scripts.
+
+WORKERS=4
+REPO_API="repos/hubertgajewski/orwellstat"
+RUNNER_TOKEN_RESULT=""
+REMOVE_TOKEN=""
+
+set_runner_token_result() {
+  local token_path="$1"
+  local description="$2"
+  local token
+
+  token=$(gh api -X POST "$REPO_API/actions/runners/$token_path" --jq '.token')
+  if [ -z "$token" ] || [ "$token" = "null" ]; then
+    echo "error: GitHub did not return $description token" >&2
+    exit 1
+  fi
+
+  RUNNER_TOKEN_RESULT="$token"
+}
+
+ensure_remove_token() {
+  if [ -z "$REMOVE_TOKEN" ]; then
+    echo "Fetching removal token..."
+    set_runner_token_result "remove-token" "a runner removal"
+    REMOVE_TOKEN="$RUNNER_TOKEN_RESULT"
+  fi
+}
+
+stop_runner_service() {
+  if [ -f svc.sh ]; then
+    echo "Stopping and uninstalling launchd service..."
+    ./svc.sh stop 2>/dev/null || true
+    ./svc.sh uninstall 2>/dev/null || true
+  else
+    echo "No service wrapper found; skipping service cleanup."
+  fi
+}
+
+remove_configured_runner() {
+  local dir="$1"
+
+  if [ ! -f .runner ] && [ ! -f .credentials ]; then
+    echo "No local runner configuration found; nothing to deregister."
+    return 0
+  fi
+
+  if [ ! -f config.sh ]; then
+    echo "warning: config.sh missing in $dir; cannot remove GitHub runner registration" >&2
+    return 0
+  fi
+
+  ensure_remove_token
+  echo "Removing runner registration..."
+  ./config.sh remove --token "$REMOVE_TOKEN"
+}
+
+remove_configured_runner_strict() {
+  local dir="$1"
+
+  if remove_configured_runner "$dir"; then
+    return 0
+  fi
+
+  echo "warning: failed to remove runner registration in $dir" >&2
+  return 1
+}
+
+remove_configured_runner_best_effort() {
+  local dir="$1"
+
+  if ! remove_configured_runner "$dir"; then
+    echo "warning: failed to remove runner registration in $dir" >&2
+  fi
+}

--- a/scripts/setup-runners.sh
+++ b/scripts/setup-runners.sh
@@ -9,11 +9,15 @@
 #               GitHub → Settings → Actions → Runners → New self-hosted runner
 #
 # Each runner is installed in ~/actions-runner-N and registered as mac-runner-N.
-# Re-running the script replaces existing registrations (--replace) and reinstalls the service.
+# Re-running the script removes existing local registrations, replaces GitHub-side
+# runners with matching names (--replace), and reinstalls the service.
 
 set -euo pipefail
 
-WORKERS=4
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/runner-lib.sh
+. "$SCRIPT_DIR/runner-lib.sh"
+
 REPO_URL="https://github.com/hubertgajewski/orwellstat"
 SRC="${1:-$HOME/actions-runner-src}"
 
@@ -24,7 +28,8 @@ if [ ! -f "$SRC/config.sh" ]; then
 fi
 
 echo "Fetching registration token..."
-TOKEN=$(gh api -X POST "repos/hubertgajewski/orwellstat/actions/runners/registration-token" --jq '.token')
+set_runner_token_result "registration-token" "a runner registration"
+TOKEN="$RUNNER_TOKEN_RESULT"
 
 for i in $(seq 1 "$WORKERS"); do
   DIR="$HOME/actions-runner-$i"
@@ -40,11 +45,8 @@ for i in $(seq 1 "$WORKERS"); do
 
   cd "$DIR"
 
-  # Stop and uninstall existing service before reconfiguring (no-op if not installed)
-  if [ -f svc.sh ]; then
-    ./svc.sh stop  2>/dev/null || true
-    ./svc.sh uninstall 2>/dev/null || true
-  fi
+  stop_runner_service
+  remove_configured_runner_strict "$DIR"
 
   echo "Configuring..."
   ./config.sh \

--- a/scripts/test_runner_scripts.py
+++ b/scripts/test_runner_scripts.py
@@ -1,0 +1,487 @@
+"""Regression tests for self-hosted runner helper scripts.
+
+Usage:
+    python3 scripts/test_runner_scripts.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SETUP_SCRIPT = REPO_ROOT / "scripts" / "setup-runners.sh"
+REMOVE_SCRIPT = REPO_ROOT / "scripts" / "remove-runners.sh"
+RUNNER_LIB = REPO_ROOT / "scripts" / "runner-lib.sh"
+CI_DOCS = REPO_ROOT / "docs" / "CI_LOCAL.md"
+
+
+class RunnerScriptTests(unittest.TestCase):
+    def test_setup_runner_count_and_docs_stay_at_four(self):
+        setup = SETUP_SCRIPT.read_text(encoding="utf-8")
+        runner_lib = RUNNER_LIB.read_text(encoding="utf-8")
+        docs = CI_DOCS.read_text(encoding="utf-8")
+
+        self.assertIn("WORKERS=4", runner_lib)
+        self.assertNotIn("WORKERS=8", setup)
+        self.assertNotIn("WORKERS=8", runner_lib)
+        self.assertIn("actions-runner-1` … `~/actions-runner-4", docs)
+        self.assertIn("mac-runner-1` … `mac-runner-4", docs)
+        self.assertNotIn("Replace 5..8", docs)
+        self.assertNotIn("for i in 5 6 7 8", docs)
+
+    def test_remove_runners_deregisters_configured_runners_and_tolerates_missing_ones(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            bin_dir = Path(tmpdir) / "bin"
+            home.mkdir()
+            bin_dir.mkdir()
+            log = Path(tmpdir) / "calls.log"
+
+            gh = bin_dir / "gh"
+            gh.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "gh $*" >> "{log}"
+                    case "$*" in
+                      *remove-token*) echo REMOVE_TOKEN ;;
+                      *) exit 1 ;;
+                    esac
+                    """
+                ),
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
+
+            configured = home / "actions-runner-1"
+            configured.mkdir()
+            (configured / ".runner").touch()
+            config = configured / "config.sh"
+            config.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "$(basename "$PWD") config $*" >> "{log}"
+                    if [ "$1" = remove ]; then
+                      [ "$3" = REMOVE_TOKEN ] || exit 7
+                      [ "$4" != "--unattended" ] || exit 9
+                      rm -f .runner
+                      exit 0
+                    fi
+                    exit 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            config.chmod(0o755)
+            svc = configured / "svc.sh"
+            svc.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "$(basename "$PWD") svc $*" >> "{log}"
+                    exit 0
+                    """
+                ),
+                encoding="utf-8",
+            )
+            svc.chmod(0o755)
+
+            partial = home / "actions-runner-2"
+            partial.mkdir()
+            (partial / ".credentials").touch()
+            skipped = home / "actions-runner-5"
+            skipped.mkdir()
+            (skipped / ".runner").touch()
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            result = subprocess.run(
+                ["bash", str(REMOVE_SCRIPT)],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Skipping missing runner directory", result.stdout)
+            self.assertNotIn("=== mac-runner-5 ===", result.stdout)
+            self.assertIn("config.sh missing", result.stderr)
+            calls = log.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(
+                calls.count(
+                    "gh api -X POST repos/hubertgajewski/orwellstat/actions/runners/remove-token --jq .token"
+                ),
+                1,
+            )
+            self.assertIn("actions-runner-1 svc stop", calls)
+            self.assertIn("actions-runner-1 svc uninstall", calls)
+            self.assertIn("actions-runner-1 config remove --token REMOVE_TOKEN", calls)
+            self.assertFalse(any("actions-runner-5" in call for call in calls))
+
+    def test_remove_runners_continues_when_one_runner_removal_fails(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            bin_dir = Path(tmpdir) / "bin"
+            home.mkdir()
+            bin_dir.mkdir()
+            log = Path(tmpdir) / "calls.log"
+
+            gh = bin_dir / "gh"
+            gh.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "gh $*" >> "{log}"
+                    echo REMOVE_TOKEN
+                    """
+                ),
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
+
+            for index in (1, 2):
+                runner = home / f"actions-runner-{index}"
+                runner.mkdir()
+                (runner / ".runner").touch()
+                config = runner / "config.sh"
+                exit_code = 6 if index == 1 else 0
+                config.write_text(
+                    textwrap.dedent(
+                        f"""\
+                        #!/bin/sh
+                        echo "$(basename "$PWD") config $*" >> "{log}"
+                        exit {exit_code}
+                        """
+                    ),
+                    encoding="utf-8",
+                )
+                config.chmod(0o755)
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            result = subprocess.run(
+                ["bash", str(REMOVE_SCRIPT)],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("failed to remove runner registration", result.stderr)
+            calls = log.read_text(encoding="utf-8").splitlines()
+            self.assertIn("actions-runner-1 config remove --token REMOVE_TOKEN", calls)
+            self.assertIn("actions-runner-2 config remove --token REMOVE_TOKEN", calls)
+
+    def test_setup_fails_when_registration_token_is_missing(self):
+        for token in ("", "null"):
+            with self.subTest(token=token):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    home = Path(tmpdir) / "home"
+                    bin_dir = Path(tmpdir) / "bin"
+                    src = home / "actions-runner-src"
+                    home.mkdir()
+                    bin_dir.mkdir()
+                    src.mkdir()
+                    (src / "config.sh").touch()
+
+                    gh = bin_dir / "gh"
+                    gh.write_text(
+                        textwrap.dedent(
+                            f"""\
+                            #!/bin/sh
+                            printf '%s\\n' "{token}"
+                            """
+                        ),
+                        encoding="utf-8",
+                    )
+                    gh.chmod(0o755)
+
+                    env = os.environ.copy()
+                    env["HOME"] = str(home)
+                    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+                    result = subprocess.run(
+                        ["bash", str(SETUP_SCRIPT), str(src)],
+                        cwd=REPO_ROOT,
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+
+                    self.assertEqual(result.returncode, 1)
+                    self.assertIn("GitHub did not return a runner registration token", result.stderr)
+
+    def test_setup_fails_when_removal_token_is_missing(self):
+        for token in ("", "null"):
+            with self.subTest(token=token):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    home = Path(tmpdir) / "home"
+                    bin_dir = Path(tmpdir) / "bin"
+                    src = home / "actions-runner-src"
+                    runner = home / "actions-runner-1"
+                    home.mkdir()
+                    bin_dir.mkdir()
+                    src.mkdir()
+                    runner.mkdir()
+                    (src / "config.sh").touch()
+                    (runner / "config.sh").touch()
+                    (runner / ".runner").touch()
+
+                    gh = bin_dir / "gh"
+                    gh.write_text(
+                        textwrap.dedent(
+                            f"""\
+                            #!/bin/sh
+                            case "$*" in
+                              *remove-token*) printf '%s\\n' "{token}" ;;
+                              *registration-token*) echo REGISTER_TOKEN ;;
+                              *) exit 1 ;;
+                            esac
+                            """
+                        ),
+                        encoding="utf-8",
+                    )
+                    gh.chmod(0o755)
+
+                    env = os.environ.copy()
+                    env["HOME"] = str(home)
+                    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+                    result = subprocess.run(
+                        ["bash", str(SETUP_SCRIPT), str(src)],
+                        cwd=REPO_ROOT,
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+
+                    self.assertEqual(result.returncode, 1)
+                    self.assertIn("GitHub did not return a runner removal token", result.stderr)
+
+    def test_setup_aborts_when_existing_runner_removal_fails(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            bin_dir = Path(tmpdir) / "bin"
+            src = home / "actions-runner-src"
+            runner = home / "actions-runner-1"
+            home.mkdir()
+            bin_dir.mkdir()
+            src.mkdir()
+            runner.mkdir()
+            log = Path(tmpdir) / "calls.log"
+
+            gh = bin_dir / "gh"
+            gh.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "gh $*" >> "{log}"
+                    case "$*" in
+                      *remove-token*) echo REMOVE_TOKEN ;;
+                      *registration-token*) echo REGISTER_TOKEN ;;
+                      *) exit 1 ;;
+                    esac
+                    """
+                ),
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
+
+            (src / "config.sh").write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "source config $*" >> "{log}"
+                    exit 0
+                    """
+                ),
+                encoding="utf-8",
+            )
+            (src / "config.sh").chmod(0o755)
+            (runner / ".runner").touch()
+            (runner / "config.sh").write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "$(basename "$PWD") config $*" >> "{log}"
+                    exit 6
+                    """
+                ),
+                encoding="utf-8",
+            )
+            (runner / "config.sh").chmod(0o755)
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            result = subprocess.run(
+                ["bash", str(SETUP_SCRIPT), str(src)],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("failed to remove runner registration", result.stderr)
+            calls = log.read_text(encoding="utf-8").splitlines()
+            self.assertIn("actions-runner-1 config remove --token REMOVE_TOKEN", calls)
+            self.assertFalse(
+                any("config --url https://github.com/hubertgajewski/orwellstat" in call for call in calls)
+            )
+
+    def test_remove_fails_when_removal_token_is_missing(self):
+        for token in ("", "null"):
+            with self.subTest(token=token):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    home = Path(tmpdir) / "home"
+                    bin_dir = Path(tmpdir) / "bin"
+                    runner = home / "actions-runner-1"
+                    home.mkdir()
+                    bin_dir.mkdir()
+                    runner.mkdir()
+                    (runner / "config.sh").touch()
+                    (runner / ".runner").touch()
+
+                    gh = bin_dir / "gh"
+                    gh.write_text(
+                        textwrap.dedent(
+                            f"""\
+                            #!/bin/sh
+                            printf '%s\\n' "{token}"
+                            """
+                        ),
+                        encoding="utf-8",
+                    )
+                    gh.chmod(0o755)
+
+                    env = os.environ.copy()
+                    env["HOME"] = str(home)
+                    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+                    result = subprocess.run(
+                        ["bash", str(REMOVE_SCRIPT)],
+                        cwd=REPO_ROOT,
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+
+                    self.assertEqual(result.returncode, 1)
+                    self.assertIn("GitHub did not return a runner removal token", result.stderr)
+
+    def test_setup_reconfigures_existing_runner_before_registering(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            bin_dir = Path(tmpdir) / "bin"
+            src = home / "actions-runner-src"
+            runner = home / "actions-runner-1"
+            home.mkdir()
+            bin_dir.mkdir()
+            src.mkdir()
+            runner.mkdir()
+            log = Path(tmpdir) / "calls.log"
+
+            gh = bin_dir / "gh"
+            gh.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "gh $*" >> "{log}"
+                    case "$*" in
+                      *remove-token*) echo REMOVE_TOKEN ;;
+                      *registration-token*) echo REGISTER_TOKEN ;;
+                      *) exit 1 ;;
+                    esac
+                    """
+                ),
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
+
+            config = src / "config.sh"
+            config.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "$(basename "$PWD") config $*" >> "{log}"
+                    if [ "$1" = remove ]; then
+                      [ "$3" = REMOVE_TOKEN ] || exit 7
+                      [ "$4" != "--unattended" ] || exit 9
+                      rm -f .runner
+                      exit 0
+                    fi
+                    if [ -f .runner ]; then
+                      echo "Cannot configure the runner because it is already configured." >&2
+                      exit 1
+                    fi
+                    [ "$4" = REGISTER_TOKEN ] || exit 8
+                    touch .runner
+                    cat > svc.sh <<'EOF'
+                    #!/bin/sh
+                    echo "$(basename "$PWD") svc $*" >> "{log}"
+                    exit 0
+                    EOF
+                    chmod +x svc.sh
+                    """
+                ),
+                encoding="utf-8",
+            )
+            config.chmod(0o755)
+
+            (runner / "config.sh").write_text(config.read_text(encoding="utf-8"), encoding="utf-8")
+            (runner / "config.sh").chmod(0o755)
+            (runner / ".runner").touch()
+            svc = runner / "svc.sh"
+            svc.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/bin/sh
+                    echo "$(basename "$PWD") svc $*" >> "{log}"
+                    exit 0
+                    """
+                ),
+                encoding="utf-8",
+            )
+            svc.chmod(0o755)
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            result = subprocess.run(
+                ["bash", str(SETUP_SCRIPT), str(src)],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("All 4 runners started.", result.stdout)
+            self.assertNotIn("=== mac-runner-5 ===", result.stdout)
+            calls = log.read_text(encoding="utf-8").splitlines()
+            self.assertLess(
+                calls.index("actions-runner-1 config remove --token REMOVE_TOKEN"),
+                calls.index(
+                    "actions-runner-1 config --url https://github.com/hubertgajewski/orwellstat --token REGISTER_TOKEN --name mac-runner-1 --unattended --replace"
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #512

## Summary

- Add `scripts/remove-runners.sh` for stopping, uninstalling, and deregistering the 4 local self-hosted runners.
- Share runner count, token validation, service cleanup, and deregistration logic through `scripts/runner-lib.sh`.
- Update local CI and fork docs for the 4-runner setup/removal flow and add regression coverage for setup/removal edge cases.

## Test plan

- [x] `python3 scripts/test_runner_scripts.py`
- [x] `bash -n scripts/setup-runners.sh`
- [x] `bash -n scripts/remove-runners.sh`
- [x] `bash -n scripts/runner-lib.sh`
- [x] `python3 -m unittest discover scripts`
- [x] `python3 -m coverage run scripts/test_runner_scripts.py`
- [x] `python3 -m coverage report -m scripts/test_runner_scripts.py` reports 100%.
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `/deep-review-next` applicable reviewers pass on `origin/main..HEAD`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added utility to de-register and stop local self-hosted GitHub Actions runner instances.

* **Documentation**
  * Updated guidance on managing and removing self-hosted runner pools.
  * Expanded fork migration documentation with runner management references.

* **Tests**
  * Added test suite validating runner setup, removal, and CI documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->