### PR TITLE
#517 Update playwright-report-mcp to 3.1.1

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -19,12 +19,24 @@ command = "npx"
 [mcp_servers.playwright-report-mcp]
 args = [
     "--min-release-age=0",
-    "playwright-report-mcp@3.1.0",
+    "playwright-report-mcp@3.1.1",
 ]
 command = "npx"
 
 [mcp_servers.playwright-report-mcp.env]
 PW_ALLOWED_DIRS = ".."
+
+[mcp_servers.playwright-report-mcp.tools.run_tests]
+approval_mode = "approve"
+
+[mcp_servers.playwright-report-mcp.tools.list_tests]
+approval_mode = "approve"
+
+[mcp_servers.playwright-report-mcp.tools.get_failed_tests]
+approval_mode = "approve"
+
+[mcp_servers.playwright-report-mcp.tools.get_test_attachment]
+approval_mode = "approve"
 
 [mcp_servers.quality-metrics]
 args = ["mcp/quality-metrics/dist/index.js"]

--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
     },
     "playwright-report-mcp": {
       "command": "npx",
-      "args": ["--min-release-age=0", "playwright-report-mcp@3.1.0"],
+      "args": ["--min-release-age=0", "playwright-report-mcp@3.1.1"],
       "type": "stdio",
       "env": {
         "PW_ALLOWED_DIRS": ".."

--- a/README.md
+++ b/README.md
@@ -432,7 +432,9 @@ Five MCP servers are declared in `.mcp.json` and loaded automatically by any MCP
 
 An MCP server that runs the Playwright test suite and returns structured JSON results, enabling agentic workflows (self-healing, test generation verification) to act on test outcomes without parsing shell output.
 
-**Setup:** No setup required — runs via `npx playwright-report-mcp@3.1.0` from the official npm registry. The version is pinned in `.mcp.json` so upstream releases don't silently change behavior between runs.
+**Setup:** No setup required — runs via `npx playwright-report-mcp@3.1.1` from the official npm registry. The version is pinned in `.mcp.json` so upstream releases don't silently change behavior between runs.
+
+`playwright-report-mcp@3.1.1` declares `node >=22`, so agents running this MCP server need Node.js 22 or newer even though the Playwright test project itself supports Node.js 18+.
 
 **Configuration:** Each tool call accepts an optional `workingDirectory` argument naming the Playwright project directory; the `PW_ALLOWED_DIRS` environment variable in `.mcp.json` defines which paths that argument is allowed to resolve to:
 
@@ -446,7 +448,7 @@ This repo sets `PW_ALLOWED_DIRS` to `..` so the repo root's parent and every sib
 ```json
 "playwright-report-mcp": {
   "command": "npx",
-  "args": ["--min-release-age=0", "playwright-report-mcp@3.1.0"],
+  "args": ["--min-release-age=0", "playwright-report-mcp@3.1.1"],
   "type": "stdio",
   "env": {
     "PW_ALLOWED_DIRS": ".."


### PR DESCRIPTION
## Summary

- Bump `playwright-report-mcp` from `3.1.0` to `3.1.1` in `.mcp.json` and `.codex/config.toml`.
- Approve all four `playwright-report-mcp` Codex tools explicitly in `.codex/config.toml`.
- Document the `node >=22` engine requirement for `playwright-report-mcp@3.1.1` in README.

Closes #517

## Test plan

- [x] `node -e "JSON.parse(require('node:fs').readFileSync('.mcp.json', 'utf8')); console.log('.mcp.json valid')"`
- [x] `python3 -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('.codex/config.toml').read_text()); print('.codex/config.toml valid')"`
- [x] `git diff --cached --check`
- [x] `node /private/tmp/probe-playwright-report-mcp-3-1-1.js` (MCP initialize returned `playwright-report-mcp@3.1.1`, `list_tests` returned 130 tests, and `run_tests` passed `tests/navigation.spec.ts` on Chromium with `exitCode: 0`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded playwright-report-mcp dependency to version 3.1.1
  * Updated MCP server tool configurations

* **Documentation**
  * Updated MCP documentation with latest version information and Node.js 22+ requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->