### PR TITLE
#525 Update playwright-report-mcp to 3.1.3

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -19,7 +19,7 @@ command = "npx"
 [mcp_servers.playwright-report-mcp]
 args = [
     "--min-release-age=0",
-    "playwright-report-mcp@3.1.1",
+    "playwright-report-mcp@3.1.3",
 ]
 command = "npx"
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
     },
     "playwright-report-mcp": {
       "command": "npx",
-      "args": ["--min-release-age=0", "playwright-report-mcp@3.1.1"],
+      "args": ["--min-release-age=0", "playwright-report-mcp@3.1.3"],
       "type": "stdio",
       "env": {
         "PW_ALLOWED_DIRS": ".."

--- a/README.md
+++ b/README.md
@@ -432,9 +432,9 @@ Five MCP servers are declared in `.mcp.json` and loaded automatically by any MCP
 
 An MCP server that runs the Playwright test suite and returns structured JSON results, enabling agentic workflows (self-healing, test generation verification) to act on test outcomes without parsing shell output.
 
-**Setup:** No setup required — runs via `npx playwright-report-mcp@3.1.1` from the official npm registry. The version is pinned in `.mcp.json` so upstream releases don't silently change behavior between runs.
+**Setup:** No setup required — runs via `npx playwright-report-mcp@3.1.3` from the official npm registry. The version is pinned in `.mcp.json` so upstream releases don't silently change behavior between runs.
 
-`playwright-report-mcp@3.1.1` declares `node >=22`, so agents running this MCP server need Node.js 22 or newer even though the Playwright test project itself supports Node.js 18+.
+`playwright-report-mcp@3.1.3` declares `node >=22`, so agents running this MCP server need Node.js 22 or newer even though the Playwright test project itself supports Node.js 18+.
 
 **Configuration:** Each tool call accepts an optional `workingDirectory` argument naming the Playwright project directory; the `PW_ALLOWED_DIRS` environment variable in `.mcp.json` defines which paths that argument is allowed to resolve to:
 
@@ -448,7 +448,7 @@ This repo sets `PW_ALLOWED_DIRS` to `..` so the repo root's parent and every sib
 ```json
 "playwright-report-mcp": {
   "command": "npx",
-  "args": ["--min-release-age=0", "playwright-report-mcp@3.1.1"],
+  "args": ["--min-release-age=0", "playwright-report-mcp@3.1.3"],
   "type": "stdio",
   "env": {
     "PW_ALLOWED_DIRS": ".."


### PR DESCRIPTION
## Summary

- Bump `playwright-report-mcp` from 3.1.1 to 3.1.3 in `.mcp.json` and `.codex/config.toml`.
- Update the README MCP setup docs and Node `>=22` package reference for 3.1.3.

Closes #525

## Test plan

- [x] `npm ci` in `playwright/typescript`.
- [x] `npm view playwright-report-mcp@3.1.3 version engines bin dist-tags --json`.
- [x] `jq . .mcp.json`.
- [x] `python3 -c "import tomllib; tomllib.load(open('.codex/config.toml','rb'))"`.
- [x] MCP `list_tests` with `workingDirectory: ".worktrees/feature-525/playwright/typescript"` returned 130 tests.
- [x] MCP `run_tests` for `tests/navigation.spec.ts` on Chromium passed with 17 expected and 0 unexpected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server configuration to use the latest version of playwright-report-mcp.
  * Synchronized system configuration files and documentation to ensure consistency across the platform.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/orwellstat/pull/526)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->