### PR TITLE
#536 Require DoD checkbox verification

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -19,7 +19,7 @@ See the Epic / Story convention and scales in [docs/PROJECT_MANAGEMENT.md](../..
 2. **Context** — explanation of the current problem with exact file references
 3. **Acceptance Criteria** — Given/When/Then scenarios covering the happy path and the failure case
 4. **Implementation Hint** — concrete code snippet showing the fix
-5. **Definition of Done** — checklist of observable, verifiable outcomes
+5. **Definition of Done** — checklist of observable, verifiable outcomes that `/fix-issue` can later map to concrete evidence before ticking the GitHub issue checkbox
 
 **Epic title:** `[epic] Short imperative description`
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -120,9 +120,18 @@ gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" \
   --field-id "$HOURS_FIELD_ID" --number <hours>
 ```
 
-After recording Actual hours, update the GitHub issue body so every completed DoD checkbox is checked. Use the evidence map from Step 7 plus the post-merge evidence from this step (merge state, closed issue state, and Actual hours field). Leave any checkbox unchecked when evidence is missing, and report it as a remaining blocker instead of silently checking it.
+After recording Actual hours, update the GitHub issue body so every completed DoD checkbox is checked. Use the evidence map from Step 7 plus the post-merge evidence from this step (merge state, closed issue state, and Actual hours field). Fetch the current issue body, edit only the matching verified DoD bullets from `- [ ]` to `- [x]` by exact checkbox text, never use a blind global replacement, and write the edited body back:
 
-Re-read the issue body after editing and confirm the expected checkbox state:
+```bash
+ISSUE_BODY_FILE=/tmp/issue-$ISSUE-body.md
+gh issue view "$ISSUE" --json body --jq '.body' > "$ISSUE_BODY_FILE"
+# Edit $ISSUE_BODY_FILE so only verified DoD bullets are checked.
+gh issue edit "$ISSUE" --body-file "$ISSUE_BODY_FILE"
+```
+
+Leave any checkbox unchecked when evidence is missing. Add an issue comment listing each remaining blocker and reason, then either keep the issue open or create a follow-up issue for the missing work.
+
+Re-read the issue body after editing and confirm the expected checkbox state. Every completed checkbox in the evidence map must appear as `[x]`; every item without evidence must remain `[ ]`; checked and unchecked counts must match the expected evidence-map totals:
 
 ```bash
 gh issue view $ISSUE --json body --jq '.body'

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -92,7 +92,7 @@ Scripts calling external APIs (e.g. `gh issue list`, REST calls):
 - Avoid duplicate API calls across steps: if two steps fetch the same data, consolidate them.
 
 **Step 7 — Verify all acceptance criteria and the Definition of Done**
-Read every Given/When/Then scenario and every DoD checkbox in the issue. For each item, explicitly confirm it is satisfied or identify what is missing. Do not proceed to commit until all criteria pass.
+Read every Given/When/Then scenario and every DoD checkbox in the issue. For each item, explicitly confirm it is satisfied or identify what is missing. For every DoD checkbox, keep an evidence map from the checkbox text to the concrete proof that satisfies it: file path, diff hunk, command output, PR check, Project field, or GitHub issue/PR state. Do not proceed to commit until all pre-merge criteria pass. Do not mark unverifiable or incomplete DoD items as complete; report the exact missing evidence instead.
 
 **Step 8 — Commit**
 Stage changed files by name (never `git add -A`). Follow the **Commit message convention** in `CLAUDE.md`: prefix with `#$ISSUE`, single line, no body, no `Co-Authored-By` trailer.
@@ -107,7 +107,7 @@ Push the branch and run `gh pr create`. The PR body must include:
 **Step 10 — Verify the PR test plan**
 Re-read every test plan item. For each `[ ]` item that can be verified now, execute and confirm it, then update the PR body via `gh pr edit` to mark it `[x]`. For items that genuinely require a reviewer or CI, leave them as `[ ]` and note what is needed. If any item is found failing, implement a fix on the same branch: work through the code review checklist, run the affected tests, commit and push before considering the task done.
 
-**Step 11 — After merge: record Actual hours on the project item**
+**Step 11 — After merge: record Actual hours and update issue DoD checkboxes**
 See **Actual Hours** in [docs/PROJECT_MANAGEMENT.md](../../../docs/PROJECT_MANAGEMENT.md) for how to derive the value.
 
 ```bash
@@ -118,4 +118,12 @@ ITEM_ID=$(gh project item-list 1 --owner hubertgajewski --format json --limit 20
   | jq -r ".items[] | select(.content.number == $ISSUE) | .id")
 gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" \
   --field-id "$HOURS_FIELD_ID" --number <hours>
+```
+
+After recording Actual hours, update the GitHub issue body so every completed DoD checkbox is checked. Use the evidence map from Step 7 plus the post-merge evidence from this step (merge state, closed issue state, and Actual hours field). Leave any checkbox unchecked when evidence is missing, and report it as a remaining blocker instead of silently checking it.
+
+Re-read the issue body after editing and confirm the expected checkbox state:
+
+```bash
+gh issue view $ISSUE --json body --jq '.body'
 ```


### PR DESCRIPTION
## Summary

Require the issue-fix workflow to keep Definition of Done checkboxes aligned with verified evidence.

- Update `/fix-issue` Step 7 to build an evidence map for each DoD checkbox and forbid checking unverifiable or incomplete items.
- Update `/fix-issue` Step 11 to update the GitHub issue body after merge/post-merge work, then re-read the issue body to confirm checkbox state.
- Clarify `/create-issue` DoD wording so future issue checkboxes are observable and evidence-backed.

Closes #536

## Test plan

- [x] `npx prettier --check ../../.claude/skills/fix-issue/SKILL.md ../../.claude/skills/create-issue/SKILL.md`
- [x] `git diff --check`
- [x] Changed Markdown link check: `Checked changed Markdown links; all local links resolve.`
- [x] Manual security review: docs-only, no executable code, shell sinks, secret material, or permission changes.
- [x] Manual `deep-review-lite` checklist: docs-only items pass or are N/A.
- [x] Issue #536 Estimate is set to `2` in Project #1.
- [ ] CI checks pass on the PR.
- [ ] Post-merge: Actual hours recorded in Project #1.
- [ ] Post-merge: issue #536 DoD checkboxes updated and re-read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined Definition of Done checklist to require explicit mapping of outcomes to concrete, verifiable evidence.
  * Strengthened verification workflow to require item-by-item evidence and explicit approval gates before merging.
  * Improved post-merge issue handling to validate checkboxes against verified evidence maps and confirm updates; unresolved items remain open or get follow-up issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/orwellstat/pull/537)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->