### PR TITLE
#539 Add MCP tool approval config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -12,6 +12,15 @@ command = "docker"
 args = ["mcp/coverage-matrix/dist/index.js"]
 command = "node"
 
+[mcp_servers.coverage-matrix.tools.get_coverage_gaps]
+approval_mode = "approve"
+
+[mcp_servers.coverage-matrix.tools.get_coverage_summary]
+approval_mode = "approve"
+
+[mcp_servers.coverage-matrix.tools.mark_covered]
+approval_mode = "approve"
+
 [mcp_servers.playwright]
 args = ["@playwright/mcp@0.0.68"]
 command = "npx"
@@ -41,3 +50,12 @@ approval_mode = "approve"
 [mcp_servers.quality-metrics]
 args = ["mcp/quality-metrics/dist/index.js"]
 command = "node"
+
+[mcp_servers.quality-metrics.tools.get_defect_escape_rate]
+approval_mode = "approve"
+
+[mcp_servers.quality-metrics.tools.get_mttr]
+approval_mode = "approve"
+
+[mcp_servers.quality-metrics.tools.get_metrics_history]
+approval_mode = "approve"


### PR DESCRIPTION
## Summary

- Adds explicit Codex approval entries for the `coverage-matrix` MCP tools.
- Adds explicit Codex approval entries for the `quality-metrics` MCP tools.

Closes #539

## Test plan

- [x] Parsed `.codex/config.toml` successfully with Python `tomllib`.
- [x] Ran `git diff --check`.
- [x] Called `coverage-matrix.get_coverage_summary`.
- [x] Called `coverage-matrix.get_coverage_gaps`.
- [x] Called `coverage-matrix.mark_covered` with a fake URL and confirmed the expected validation error without changing a real coverage cell.
- [x] Called `quality-metrics.get_defect_escape_rate`.
- [x] Called `quality-metrics.get_mttr`.
- [x] Called `quality-metrics.get_metrics_history`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated approval settings for coverage analysis and quality metrics tools to enhance workflow management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/orwellstat/pull/540)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->