### PR TITLE
[dependencies] Replace Gemini Flash Lite preview defaults with GA model slug

### DIFF
--- a/.vars.example
+++ b/.vars.example
@@ -11,10 +11,10 @@ AI_DIAGNOSIS=
 # AI provider for test failure diagnosis. Accepted values: anthropic (default), gemini.
 AI_PROVIDER=
 # Override the fast-tier model used for diagnosis. Leave empty to use the provider default.
-# Defaults: anthropic -> claude-haiku-4-5, gemini -> gemini-3.1-flash-lite-preview.
+# Defaults: anthropic -> claude-haiku-4-5, gemini -> gemini-3.1-flash-lite.
 AI_MODEL_FAST=
 # Override the strong-tier model used for selector-fix proposals. Leave empty to use the provider default.
-# Defaults: anthropic -> claude-sonnet-4-6, gemini -> gemini-3.1-flash-lite-preview.
+# Defaults: anthropic -> claude-sonnet-4-6, gemini -> gemini-3.1-flash-lite.
 AI_MODEL_STRONG=
 # Base URL for the PR code review action (claude-code-review.yml).
 # Leave empty to use Anthropic's native API (requires ANTHROPIC_API_KEY secret, x-api-key auth).
@@ -54,4 +54,3 @@ RUNNER=
 # default local xmllint path. Set to "true" only on a periodic schedule or before a release
 # — every run sends rendered pages (including authenticated zones) to validator.w3.org.
 VALIDATE_REMOTE=
-

--- a/playwright/typescript/utils/diagnosis.util.test.ts
+++ b/playwright/typescript/utils/diagnosis.util.test.ts
@@ -1,7 +1,29 @@
 import { test, describe } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { execFileSync } from 'node:child_process';
-import { redactSensitive } from './diagnosis.util.ts';
+import { redactSensitive, resolveAiModels } from './diagnosis.util.ts';
+
+describe('resolveAiModels', () => {
+  test('defaults both Gemini tiers to the GA Flash Lite slug', () => {
+    assert.deepEqual(resolveAiModels('gemini', {}), {
+      fast: 'gemini-3.1-flash-lite',
+      strong: 'gemini-3.1-flash-lite',
+    });
+  });
+
+  test('preserves explicit Gemini model overrides', () => {
+    assert.deepEqual(
+      resolveAiModels('gemini', {
+        AI_MODEL_FAST: 'custom-fast',
+        AI_MODEL_STRONG: 'custom-strong',
+      }),
+      {
+        fast: 'custom-fast',
+        strong: 'custom-strong',
+      }
+    );
+  });
+});
 
 describe('redactSensitive', () => {
   test('redacts Cookie header value', () => {

--- a/playwright/typescript/utils/diagnosis.util.ts
+++ b/playwright/typescript/utils/diagnosis.util.ts
@@ -70,9 +70,8 @@ type AiCompletionFn = (opts: {
 
 const MODEL_MAP = {
   anthropic: { fast: 'claude-haiku-4-5', strong: 'claude-sonnet-4-6' },
-  // Both tiers use the same model: free-tier Pro access is unavailable,
-  // and gemini-3.1-flash-lite-preview has the best RPD quota (500 vs 20).
-  gemini: { fast: 'gemini-3.1-flash-lite-preview', strong: 'gemini-3.1-flash-lite-preview' },
+  // Both tiers use the same GA Flash Lite model for the free-tier default.
+  gemini: { fast: 'gemini-3.1-flash-lite', strong: 'gemini-3.1-flash-lite' },
 } as const;
 
 type AiProvider = keyof typeof MODEL_MAP;
@@ -90,6 +89,16 @@ const API_KEY_ENV: Record<AiProvider, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   gemini: 'GEMINI_API_KEY',
 };
+
+export function resolveAiModels(
+  provider: AiProvider,
+  env: NodeJS.ProcessEnv = process.env
+): Models {
+  return {
+    fast: env.AI_MODEL_FAST || MODEL_MAP[provider].fast,
+    strong: env.AI_MODEL_STRONG || MODEL_MAP[provider].strong,
+  };
+}
 
 type CompletionFactory = (apiKey: string) => Promise<AiCompletionFn>;
 
@@ -275,10 +284,7 @@ export async function attachAiDiagnosis(
 
   try {
     const complete = await PROVIDER_FACTORY[provider](apiKey);
-    const models = {
-      fast: process.env.AI_MODEL_FAST || MODEL_MAP[provider].fast,
-      strong: process.env.AI_MODEL_STRONG || MODEL_MAP[provider].strong,
-    };
+    const models = resolveAiModels(provider);
     console.log(`[AI diagnosis] provider=${provider} fast=${models.fast} strong=${models.strong}`);
 
     // Redact before truncation so cut-off tokens cannot leak their prefix.

--- a/scripts/self-healing.py
+++ b/scripts/self-healing.py
@@ -445,8 +445,8 @@ def _call_anthropic(api_key: str, user_content: str) -> str | None:
 
 
 def _call_gemini(api_key: str, user_content: str) -> str | None:
-    # Default matches diagnosis.util.ts — chosen for its free-tier RPD quota (500 vs 20).
-    model = os.environ.get("AI_MODEL_STRONG") or "gemini-3.1-flash-lite-preview"
+    # Default matches diagnosis.util.ts.
+    model = os.environ.get("AI_MODEL_STRONG") or "gemini-3.1-flash-lite"
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     body = json.dumps({
         "systemInstruction": {"parts": [{"text": _SELECTOR_FIX_SYSTEM_PROMPT}]},

--- a/scripts/test_self_healing.py
+++ b/scripts/test_self_healing.py
@@ -1368,6 +1368,24 @@ class TestYamlGuards(unittest.TestCase):
         self.assertIn("github.repository", self.workflow_content)
 
 
+class TestGeminiModelDefaults(unittest.TestCase):
+    @patch("self_healing.urllib.request.urlopen")
+    def test_call_gemini_defaults_to_ga_flash_lite_slug(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "candidates": [{"content": {"parts": [{"text": "ok"}]}}],
+        }).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = self_healing._call_gemini("fake-key", "prompt")
+
+        self.assertEqual(result, "ok")
+        request = mock_urlopen.call_args.args[0]
+        self.assertIn("/models/gemini-3.1-flash-lite:generateContent", request.full_url)
+        self.assertNotIn("gemini-3.1-flash-lite-" "preview", request.full_url)
+
+
 # ===================================================================
 # Redaction of LLM-bound artifacts (issue #402)
 #


### PR DESCRIPTION
## Summary

- Replace Gemini Flash Lite preview defaults with the GA `gemini-3.1-flash-lite` slug in TypeScript diagnosis and Python self-healing.
- Add unit coverage for TypeScript Gemini model resolution and Python selector-fix request defaults.
- Update `.vars.example` Gemini fast/strong default comments.

Closes #542

## Test plan

- [x] `npm run test:unit` from `playwright/typescript`
- [x] `npx tsc --noEmit` from `playwright/typescript`
- [x] `npm run format` from `playwright/typescript`
- [x] `npm run format:check` from `playwright/typescript`
- [x] `python3 -m unittest scripts.test_self_healing.TestGeminiModelDefaults.test_call_gemini_defaults_to_ga_flash_lite_slug`
- [x] `python3 -m coverage run --data-file=/private/tmp/orwellstat-542.coverage -m unittest scripts.test_self_healing`
- [x] `python3 -m coverage report --data-file=/private/tmp/orwellstat-542.coverage -m scripts/self-healing.py`
- [x] `rg "gemini-3.1-flash-lite-preview" scripts playwright/typescript .vars.example docs .github` returns no matches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI model configuration examples to use stable, general availability model versions.

* **New Features**
  * Introduced AI model resolution with environment variable override support.

* **Tests**
  * Added test coverage for AI model configuration defaults and environment-based overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/orwellstat/pull/545)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->