### PR TITLE
#558 Patch Bruno uuid dependency

### DIFF
--- a/bruno/package-lock.json
+++ b/bruno/package-lock.json
@@ -5599,10 +5599,9 @@
       "license": "ISC"
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -5610,7 +5609,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {

--- a/bruno/package.json
+++ b/bruno/package.json
@@ -10,6 +10,7 @@
     "axios": ">=1.15.2",
     "fast-xml-parser": ">=5.7.0",
     "picomatch": ">=2.3.2",
-    "protobufjs": "7.5.6"
+    "protobufjs": "7.5.6",
+    "uuid": "11.1.1"
   }
 }


### PR DESCRIPTION
Closes #558

## Summary

- Add a Bruno npm override that forces `uuid` to `11.1.1`.
- Refresh `bruno/package-lock.json` so `@usebruno/js` resolves its transitive `uuid` dependency to the patched version.

## Test plan

- [x] `npm install --package-lock-only --ignore-scripts --audit=false --fund=false` from `bruno/`
- [x] `jq -r '.overrides.uuid' package.json` returns `11.1.1` from `bruno/`
- [x] `jq -r '.packages["node_modules/uuid"].version' package-lock.json` returns `11.1.1` from `bruno/`
- [x] `node -e "const uuid=require('uuid'); console.log(require('uuid/package.json').version); console.log(typeof uuid.v4, typeof uuid.v5, typeof uuid.v6, typeof uuid.v7); console.log(uuid.validate(uuid.v4()), uuid.validate(uuid.v5('x', uuid.v5.DNS)), uuid.validate(uuid.v6()), uuid.validate(uuid.v7()));"` from `bruno/`
- [x] `./node_modules/.bin/bru --version` from `bruno/`
- [x] `npm test` from `bruno/`
- [x] Dependabot alert 63 closes after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version pinning to improve stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/orwellstat/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
