### PR TITLE
#561 Regenerate stale Playwright auth state on reruns

### DIFF
--- a/.github/workflows/playwright-run.yml
+++ b/.github/workflows/playwright-run.yml
@@ -112,10 +112,83 @@ jobs:
         # here lets the test command pass `--no-deps`, which skips the in-leg `setup` project
         # so the matrix legs do not re-authenticate against staging on every shard.
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: auth-state-${{ inputs.id }}
           path: playwright/typescript/.auth/
+      - name: Validate auth state
+        id: validate-auth-state
+        # Failed-job reruns can reuse artifacts from an earlier attempt. Validate the downloaded
+        # storage state metadata before the shard starts; if it is missing or stale, regenerate
+        # locally so authenticated tests do not land on the public login page.
+        run: |
+          MAX_AUTH_STATE_AGE_SECONDS=3600
+
+          should_regenerate_auth_state() {
+            if [ ! -s .auth/populated.json ] || [ ! -s .auth/empty.json ] || [ ! -s .auth/metadata.json ]; then
+              echo "Auth state files or metadata are missing; regenerating before shard run."
+              return 0
+            fi
+
+            GENERATED_AT=$(jq -r '.generatedAt // empty' .auth/metadata.json 2>/dev/null || true)
+            if [ -z "$GENERATED_AT" ]; then
+              echo "Auth state metadata has no generatedAt value; regenerating before shard run."
+              return 0
+            fi
+
+            GENERATED_EPOCH=$(node --input-type=module -e "const ms = Date.parse(process.argv[1]); if (!Number.isFinite(ms)) process.exit(1); console.log(Math.floor(ms / 1000));" "$GENERATED_AT" 2>/dev/null || echo 0)
+            if [ "$GENERATED_EPOCH" -eq 0 ]; then
+              echo "Auth state metadata has an unparsable generatedAt value; regenerating before shard run."
+              return 0
+            fi
+
+            NOW_EPOCH=$(date +%s)
+            AUTH_STATE_AGE=$((NOW_EPOCH - GENERATED_EPOCH))
+
+            if [ "$AUTH_STATE_AGE" -gt "$MAX_AUTH_STATE_AGE_SECONDS" ]; then
+              echo "Auth state metadata is stale; regenerating before shard run."
+              return 0
+            fi
+
+            return 1
+          }
+
+          if should_regenerate_auth_state; then
+            echo "regenerate=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Auth state metadata is fresh; using downloaded state."
+            echo "regenerate=false" >> "$GITHUB_OUTPUT"
+          fi
+        working-directory: playwright/typescript
+      - name: Set up Playwright Chromium for auth regeneration
+        # The setup project uses Playwright's default Chromium browser. Non-Chromium shard legs
+        # normally install only their project browser, so install Chromium only when auth setup
+        # must be rerun locally.
+        if: ${{ steps.validate-auth-state.outputs.regenerate == 'true' && inputs.browser != 'chromium' }}
+        uses: ./.github/actions/setup-playwright-browser
+        with:
+          browser: chromium
+      - name: Regenerate auth state
+        if: ${{ steps.validate-auth-state.outputs.regenerate == 'true' }}
+        run: |
+          cleanup_auth_regeneration_artifacts() {
+            rm -rf .auth-regeneration-results blob-report playwright-report test-results
+          }
+
+          trap cleanup_auth_regeneration_artifacts EXIT
+          cleanup_auth_regeneration_artifacts
+          npx playwright test --project=setup --reporter=line --trace=off --screenshot=off --video=off --output=.auth-regeneration-results
+        working-directory: playwright/typescript
+        env:
+          ENV: ${{ vars.ENV }}
+          ORWELLSTAT_USER: ${{ secrets.ORWELLSTAT_USER }}
+          ORWELLSTAT_PASSWORD: ${{ secrets.ORWELLSTAT_PASSWORD }}
+          ORWELLSTAT_USER_EMPTY: ${{ secrets.ORWELLSTAT_USER_EMPTY }}
+          ORWELLSTAT_PASSWORD_EMPTY: ${{ secrets.ORWELLSTAT_PASSWORD_EMPTY }}
+          BASIC_AUTH_USER: ${{ inputs.env == 'staging' && secrets.BASIC_AUTH_USER || '' }}
+          BASIC_AUTH_PASSWORD: ${{ inputs.env == 'staging' && secrets.BASIC_AUTH_PASSWORD || '' }}
       - name: Run Playwright tests
+        id: run-playwright-tests
         run: |
           SHARD_ARGS=()
           if [ "${TOTAL_SHARDS}" -gt 1 ]; then
@@ -174,19 +247,19 @@ jobs:
             echo "running=true" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() && steps.detect-act.outputs.running != 'true' }}
+        if: ${{ !cancelled() && steps.detect-act.outputs.running != 'true' && steps.run-playwright-tests.outcome != 'skipped' }}
         with:
           name: playwright-report-${{ inputs.id }}-${{ inputs.shard }}
           path: playwright/typescript/playwright-report/
           retention-days: 30
       - uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() && steps.detect-act.outputs.running != 'true' }}
+        if: ${{ !cancelled() && steps.detect-act.outputs.running != 'true' && steps.run-playwright-tests.outcome != 'skipped' }}
         with:
           name: blob-report-${{ inputs.id }}-${{ inputs.shard }}
           path: playwright/typescript/blob-report/
           retention-days: 30
       - name: Collect self-healing data
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.run-playwright-tests.outcome == 'failure' }}
         working-directory: playwright/typescript
         run: |
           mkdir -p self-healing-data
@@ -204,7 +277,7 @@ jobs:
             done
           done
       - uses: actions/upload-artifact@v7
-        if: ${{ failure() && steps.detect-act.outputs.running != 'true' }}
+        if: ${{ failure() && steps.run-playwright-tests.outcome == 'failure' && steps.detect-act.outputs.running != 'true' }}
         with:
           name: self-healing-data-${{ inputs.id }}-${{ inputs.shard }}
           path: playwright/typescript/self-healing-data/

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -67,16 +67,17 @@ Auth setup details:
 
 - `auth-setup` runs `npx playwright test --project=setup` once per browser project.
 - Each setup leg logs in both populated and empty accounts, so normal runs perform 10 logins total, independent of shard count.
-- Auth state artifacts are named `auth-state-<id>` and retained for 1 day.
+- Auth state artifacts are named `auth-state-<id>` and retained for 1 day. Each artifact contains `.auth/populated.json`, `.auth/empty.json`, and `.auth/metadata.json` with non-secret generation time and GitHub run identifiers.
 - Downstream test legs depend on auth setup, so a setup failure skips tests instead of letting them pass with stale state.
 
 Reusable test job:
 
 - `playwright-run.yml` accepts matrix inputs (`project`, `browser`, `id`, `snap-token`, `shard`, `total-shards`) plus run-shape inputs (`update-visual-baselines`, `env`, `runner`, `ref`).
 - It inherits secrets.
-- Each leg installs only the browser it needs.
+- Each leg normally installs only the browser it needs.
+- It validates downloaded auth-state files and metadata before running the shard. Missing metadata, invalid timestamps, or metadata older than 1 hour triggers a local setup-project rerun in that leg; this protects failed-job reruns from reusing expired storage-state artifacts. Local auth regeneration reuses the shared browser setup action to install Chromium only for non-Chromium shard legs because the setup project uses Playwright's default browser.
 - It runs `npx playwright test --project=<project> --shard=<shard>/<total-shards>`.
-- Per-leg artifacts use `-<id>-<shard>` suffixes for reports, blob reports, self-healing data, and visual baselines.
+- Per-leg artifacts use `-<id>-<shard>` suffixes for reports, blob reports, self-healing data, and visual baselines. Report/blob uploads only run after the shard test step is reached, and self-healing data is collected/uploaded only when that shard test step fails.
 - Artifacts are retained for 30 days unless otherwise noted.
 
 Caching:

--- a/docs/CI_LOCAL.md
+++ b/docs/CI_LOCAL.md
@@ -169,16 +169,16 @@ docker container prune
 
 ### Docker RAM requirements for the Playwright matrix
 
-The matrix strategy runs 5 browser projects in parallel, each in its own container. Every container installs Chromium (required by the auth setup project) plus its own browser:
+The matrix strategy runs 5 browser projects in parallel, each in its own container. Auth setup containers install Chromium. Test containers normally install only their project browser, and non-Chromium test containers install Chromium on demand only if stale auth-state validation reruns the setup project locally:
 
-| Job           | Browsers installed | RAM                                        |
-| ------------- | ------------------ | ------------------------------------------ |
-| Chromium      | chromium           | ~1.0 GB                                    |
-| Mobile Chrome | chromium           | ~1.0 GB                                    |
-| Firefox       | chromium + firefox | ~1.4 GB                                    |
-| WebKit        | chromium + webkit  | ~1.2 GB                                    |
-| Mobile Safari | chromium + webkit  | ~1.2 GB                                    |
-| **Total**     |                    | **~5.8 GB active + ~2 GB Docker overhead** |
+| Job           | Test-container browsers                         | RAM                                        |
+| ------------- | ----------------------------------------------- | ------------------------------------------ |
+| Chromium      | chromium                                        | ~1.0 GB                                    |
+| Mobile Chrome | chromium                                        | ~1.0 GB                                    |
+| Firefox       | firefox (+ chromium if auth regenerates)        | ~1.4 GB                                    |
+| WebKit        | webkit (+ chromium if auth regenerates)         | ~1.2 GB                                    |
+| Mobile Safari | webkit (+ chromium if auth regenerates)         | ~1.2 GB                                    |
+| **Total**     | worst-case concurrent browser-install footprint | **~5.8 GB active + ~2 GB Docker overhead** |
 
 **8 GB Docker RAM (default) — run a single browser only**
 

--- a/docs/PLAYWRIGHT.md
+++ b/docs/PLAYWRIGHT.md
@@ -125,8 +125,11 @@ For what each spec covers, see [TEST_INVENTORY.md](TEST_INVENTORY.md).
 
 - `.auth/populated.json`
 - `.auth/empty.json`
+- `.auth/metadata.json`
 
-The setup project runs sequentially to avoid back-to-back login throttling. After login, it asserts that the rendered username matches the credential pair it just used, so swapped populated/empty credentials fail early.
+The setup project runs sequentially to avoid back-to-back login throttling. After login, it asserts that the rendered username matches the credential pair it just used, so swapped populated/empty credentials fail early. Metadata contains the generation timestamp, GitHub run identifiers, and storage-state labels only; it must not contain usernames, cookies, or credentials.
+
+CI test shards download the auth-state artifact and validate that all three files exist and that metadata is fresh before running with `--no-deps`. If a failed-job rerun reuses stale artifacts, the reusable test job reruns the setup project locally before starting the shard.
 
 Browser projects default to `storageState: '.auth/populated.json'`. Empty-state specs opt in per file:
 
@@ -150,25 +153,26 @@ Public page classes live under `pages/public/`; authenticated page classes live 
 
 ## Fixtures And Utilities
 
-| Path                                        | Purpose                                                                                                                                                 |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fixtures/base.fixture.ts`                  | Extends Playwright `test`, captures console logs and `dom.xhtml` on failure, attaches AI diagnosis when enabled, and re-exports common Playwright types |
-| `fixtures/api.fixture.ts`                   | Adds `unauthenticatedRequest` and `authenticatedRequest` API fixtures                                                                                   |
-| `fixtures/storage-state.ts`                 | Exports populated and empty storage-state paths                                                                                                         |
-| `utils/accessibility.util.ts`               | Axe WCAG checks                                                                                                                                         |
-| `utils/string.util.ts`                      | Heading visibility helper                                                                                                                               |
-| `utils/svg-chart.util.ts`                   | SVG chart loading, parsing, and chart/table comparison helpers                                                                                          |
-| `utils/svg-chart-table.util.ts`             | Fixture-free XHTML snapshot table extractor                                                                                                             |
-| `utils/svg-chart-percent.util.ts`           | Percentage normalization and chart/table tolerance helpers                                                                                              |
-| `utils/validation.util.ts`                  | XHTML and CSS validators with local and remote modes                                                                                                    |
-| `utils/track-hit.util.ts`                   | Tracking-hit seeding through live snippets and `/scripts/drain.php`                                                                                     |
-| `utils/env.util.ts`                         | `.env` loading and credential validation                                                                                                                |
-| `utils/diagnosis.util.ts`                   | AI diagnosis, selector-fix attachment, and redaction rules                                                                                              |
-| `utils/css-validator.util.ts`               | Pure helpers around `csstree-validator`                                                                                                                 |
-| `scripts/verify-coverage-matrix.ts`         | Cross-checks active tests against `coverage-matrix.json`                                                                                                |
-| `scripts/redact.ts`                         | stdin/stdout redaction CLI used by self-healing                                                                                                         |
-| `test-data/scripts/snippet-*.txt`           | Canonical HTML5, HTML4, and XHTML tracking snippets with `{{ORWELLSTAT_BASE}}` placeholders                                                             |
-| `test-data/scripts/tracking-*`              | HTML/HTML4/XHTML shells used by tracking E2E tests after inserting the matching live snippet                                                            |
+| Path                                | Purpose                                                                                                                                                 |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fixtures/base.fixture.ts`          | Extends Playwright `test`, captures console logs and `dom.xhtml` on failure, attaches AI diagnosis when enabled, and re-exports common Playwright types |
+| `fixtures/api.fixture.ts`           | Adds `unauthenticatedRequest` and `authenticatedRequest` API fixtures                                                                                   |
+| `fixtures/storage-state.ts`         | Exports populated and empty storage-state paths                                                                                                         |
+| `utils/accessibility.util.ts`       | Axe WCAG checks                                                                                                                                         |
+| `utils/string.util.ts`              | Heading visibility helper                                                                                                                               |
+| `utils/svg-chart.util.ts`           | SVG chart loading, parsing, and chart/table comparison helpers                                                                                          |
+| `utils/svg-chart-table.util.ts`     | Fixture-free XHTML snapshot table extractor                                                                                                             |
+| `utils/svg-chart-percent.util.ts`   | Percentage normalization and chart/table tolerance helpers                                                                                              |
+| `utils/validation.util.ts`          | XHTML and CSS validators with local and remote modes                                                                                                    |
+| `utils/track-hit.util.ts`           | Tracking-hit seeding through live snippets and `/scripts/drain.php`                                                                                     |
+| `utils/env.util.ts`                 | `.env` loading and credential validation                                                                                                                |
+| `utils/auth-state-metadata.util.ts` | Non-secret `.auth/metadata.json` writer for CI auth-state freshness checks                                                                              |
+| `utils/diagnosis.util.ts`           | AI diagnosis, selector-fix attachment, and redaction rules                                                                                              |
+| `utils/css-validator.util.ts`       | Pure helpers around `csstree-validator`                                                                                                                 |
+| `scripts/verify-coverage-matrix.ts` | Cross-checks active tests against `coverage-matrix.json`                                                                                                |
+| `scripts/redact.ts`                 | stdin/stdout redaction CLI used by self-healing                                                                                                         |
+| `test-data/scripts/snippet-*.txt`   | Canonical HTML5, HTML4, and XHTML tracking snippets with `{{ORWELLSTAT_BASE}}` placeholders                                                             |
+| `test-data/scripts/tracking-*`      | HTML/HTML4/XHTML shells used by tracking E2E tests after inserting the matching live snippet                                                            |
 
 Unit tests for pure utilities run through `npm run test:unit`.
 

--- a/docs/TEST_INVENTORY.md
+++ b/docs/TEST_INVENTORY.md
@@ -42,14 +42,15 @@ This file describes what each Playwright spec covers. For commands, tags, fixtur
 
 ## Unit Test Suites
 
-| Spec                                            | Scope                             | Coverage                                                                                                                                                                       |
-| ----------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `utils/svg-chart-table.util.test.ts`            | XHTML table extraction            | Parses captured XHTML as `application/xhtml+xml`, trims cells, respects row limits, and returns `[]` on parse error or missing table.                                          |
-| `utils/svg-chart-percent.util.test.ts`          | Chart/table percentage comparison | Covers bracket stripping, integer-hundredths gap math, tolerance boundaries, and empirical 4-hundredths gaps.                                                                  |
-| `utils/diagnosis.util.test.ts`                  | AI-diagnosis redaction            | Exercises cookie, set-cookie, bearer, API key, query token, JWT, email, mixed, no-match, char-budget, XHTML-structure, multiline, order-sensitivity, and bypass-attempt cases. |
-| `utils/css-validator.util.test.ts`              | CSS validation formatting         | Verifies intentionally broken CSS reports per-line errors with line numbers and source URL.                                                                                    |
-| `scripts/verify-coverage-matrix.test.ts`        | Coverage-matrix drift verifier    | Covers false-positive, false-negative, in-sync, matrix-edit regression, and parser edge cases.                                                                                 |
-| `scripts/redact.test.ts`                        | Redaction CLI                     | Runs the real stdin/stdout subprocess path for `scripts/redact.ts`.                                                                                                            |
+| Spec                                     | Scope                             | Coverage                                                                                                                                                                       |
+| ---------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `utils/svg-chart-table.util.test.ts`     | XHTML table extraction            | Parses captured XHTML as `application/xhtml+xml`, trims cells, respects row limits, and returns `[]` on parse error or missing table.                                          |
+| `utils/svg-chart-percent.util.test.ts`   | Chart/table percentage comparison | Covers bracket stripping, integer-hundredths gap math, tolerance boundaries, and empirical 4-hundredths gaps.                                                                  |
+| `utils/diagnosis.util.test.ts`           | AI-diagnosis redaction            | Exercises cookie, set-cookie, bearer, API key, query token, JWT, email, mixed, no-match, char-budget, XHTML-structure, multiline, order-sensitivity, and bypass-attempt cases. |
+| `utils/auth-state-metadata.util.test.ts` | Auth-state metadata               | Verifies `.auth/metadata.json` contains generation time, GitHub run identifiers, and account labels without writing credential values.                                         |
+| `utils/css-validator.util.test.ts`       | CSS validation formatting         | Verifies intentionally broken CSS reports per-line errors with line numbers and source URL.                                                                                    |
+| `scripts/verify-coverage-matrix.test.ts` | Coverage-matrix drift verifier    | Covers false-positive, false-negative, in-sync, matrix-edit regression, and parser edge cases.                                                                                 |
+| `scripts/redact.test.ts`                 | Redaction CLI                     | Runs the real stdin/stdout subprocess path for `scripts/redact.ts`.                                                                                                            |
 
 ## Coverage Matrix
 

--- a/playwright/typescript/auth.setup.ts
+++ b/playwright/typescript/auth.setup.ts
@@ -1,8 +1,10 @@
 import { test as setup, expect, type Page } from '@playwright/test';
 import { loadEnv, requireCredentials, type Account } from '@utils/env.util';
 import { AbstractPage } from '@pages/abstract.page';
+import { writeAuthStateMetadata } from '@utils/auth-state-metadata.util';
 
 loadEnv(import.meta.url, 2);
+const AUTH_STATE_DIR = new URL('.auth/', import.meta.url);
 
 // Run the two logins sequentially to avoid any login-throttling edge cases on the target
 // server. The setup project is also marked non-parallel in `playwright.config.ts`.
@@ -21,9 +23,7 @@ async function authenticate(page: Page, account: Account): Promise<void> {
   // produce two valid storage states pointed at the wrong accounts and
   // every downstream test would run mis-attributed.
   await expect(AbstractPage.loggedInUsername(page)).toHaveText(user);
-  await page
-    .context()
-    .storageState({ path: new URL(`.auth/${account}.json`, import.meta.url).pathname });
+  await page.context().storageState({ path: new URL(`${account}.json`, AUTH_STATE_DIR).pathname });
 }
 
 setup('authenticate populated', { tag: '@auth-populated' }, async ({ page }) => {
@@ -32,4 +32,8 @@ setup('authenticate populated', { tag: '@auth-populated' }, async ({ page }) => 
 
 setup('authenticate empty', { tag: '@auth-empty' }, async ({ page }) => {
   await authenticate(page, 'empty');
+});
+
+setup.afterAll(async () => {
+  await writeAuthStateMetadata(AUTH_STATE_DIR);
 });

--- a/playwright/typescript/auth.setup.ts
+++ b/playwright/typescript/auth.setup.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { test as setup, expect, type Page } from '@playwright/test';
 import { loadEnv, requireCredentials, type Account } from '@utils/env.util';
 import { AbstractPage } from '@pages/abstract.page';
@@ -23,7 +24,9 @@ async function authenticate(page: Page, account: Account): Promise<void> {
   // produce two valid storage states pointed at the wrong accounts and
   // every downstream test would run mis-attributed.
   await expect(AbstractPage.loggedInUsername(page)).toHaveText(user);
-  await page.context().storageState({ path: new URL(`${account}.json`, AUTH_STATE_DIR).pathname });
+  await page
+    .context()
+    .storageState({ path: fileURLToPath(new URL(`${account}.json`, AUTH_STATE_DIR)) });
 }
 
 setup('authenticate populated', { tag: '@auth-populated' }, async ({ page }) => {

--- a/playwright/typescript/fixtures/storage-state.ts
+++ b/playwright/typescript/fixtures/storage-state.ts
@@ -4,5 +4,9 @@
 // Never branch at runtime on which account is logged in — see the **Fixture usage** bullet
 // in `.claude/skills/deep-review/SKILL.md`.
 
-export const POPULATED_STORAGE_STATE = new URL('../.auth/populated.json', import.meta.url).pathname;
-export const EMPTY_STORAGE_STATE = new URL('../.auth/empty.json', import.meta.url).pathname;
+import { fileURLToPath } from 'node:url';
+
+export const POPULATED_STORAGE_STATE = fileURLToPath(
+  new URL('../.auth/populated.json', import.meta.url)
+);
+export const EMPTY_STORAGE_STATE = fileURLToPath(new URL('../.auth/empty.json', import.meta.url));

--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -1,7 +1,8 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig, devices } from '@playwright/test';
 import dotenv from 'dotenv';
 
-dotenv.config({ path: new URL('../../.env', import.meta.url).pathname, quiet: true });
+dotenv.config({ path: fileURLToPath(new URL('../../.env', import.meta.url)), quiet: true });
 
 const BASE_URLS: Record<string, string> = {
   production: 'https://orwellstat.hubertgajewski.com',
@@ -19,7 +20,7 @@ const baseURL = BASE_URLS[env];
 // opt into `.auth/empty.json` per file via `test.use({ storageState: EMPTY_STORAGE_STATE })`
 // from `@fixtures/storage-state`. This config cannot use path aliases — they're resolved by
 // tsconfig-paths after Playwright reads the config — so the URL is inlined here.
-const POPULATED_STORAGE_STATE = new URL('.auth/populated.json', import.meta.url).pathname;
+const POPULATED_STORAGE_STATE = fileURLToPath(new URL('.auth/populated.json', import.meta.url));
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/playwright/typescript/utils/auth-state-metadata.util.test.ts
+++ b/playwright/typescript/utils/auth-state-metadata.util.test.ts
@@ -1,0 +1,116 @@
+import { test, describe, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeAuthStateMetadata } from './auth-state-metadata.util.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  const dirs = tempDirs.splice(0);
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('writeAuthStateMetadata', () => {
+  test('writes non-secret generation metadata for both auth states', async () => {
+    const authDir = await mkdtemp(join(tmpdir(), 'orwellstat-auth-'));
+    tempDirs.push(authDir);
+
+    await writeAuthStateMetadata(new URL(`${authDir}/`, 'file://'), {
+      env: {
+        GITHUB_RUN_ID: '26586112920',
+        GITHUB_RUN_ATTEMPT: '3',
+        ORWELLSTAT_PASSWORD: 'must-not-be-written',
+      },
+      now: new Date('2026-05-29T05:10:00.000Z'),
+    });
+
+    const raw = await readFile(join(authDir, 'metadata.json'), 'utf8');
+
+    assert.deepEqual(JSON.parse(raw), {
+      generatedAt: '2026-05-29T05:10:00.000Z',
+      runId: '26586112920',
+      runAttempt: '3',
+      accounts: ['populated', 'empty'],
+    });
+    assert.doesNotMatch(raw, /must-not-be-written/);
+  });
+
+  test('writes null GitHub identifiers outside GitHub Actions', async () => {
+    const authDir = await mkdtemp(join(tmpdir(), 'orwellstat-auth-'));
+    tempDirs.push(authDir);
+
+    await writeAuthStateMetadata(new URL(`${authDir}/`, 'file://'), {
+      env: {},
+      now: new Date('2026-05-29T05:15:00.000Z'),
+    });
+
+    const raw = await readFile(join(authDir, 'metadata.json'), 'utf8');
+
+    assert.deepEqual(JSON.parse(raw), {
+      generatedAt: '2026-05-29T05:15:00.000Z',
+      runId: null,
+      runAttempt: null,
+      accounts: ['populated', 'empty'],
+    });
+  });
+
+  test('uses process environment and current time by default', async () => {
+    const authDir = await mkdtemp(join(tmpdir(), 'orwellstat-auth-'));
+    tempDirs.push(authDir);
+    const originalRunId = process.env.GITHUB_RUN_ID;
+    const originalRunAttempt = process.env.GITHUB_RUN_ATTEMPT;
+
+    try {
+      process.env.GITHUB_RUN_ID = 'default-run-id';
+      process.env.GITHUB_RUN_ATTEMPT = '4';
+      const before = Date.now();
+
+      await writeAuthStateMetadata(new URL(`${authDir}/`, 'file://'));
+
+      const after = Date.now();
+      const raw = await readFile(join(authDir, 'metadata.json'), 'utf8');
+      const metadata = JSON.parse(raw);
+      const generatedAt = Date.parse(metadata.generatedAt);
+
+      assert.equal(metadata.runId, 'default-run-id');
+      assert.equal(metadata.runAttempt, '4');
+      assert.deepEqual(metadata.accounts, ['populated', 'empty']);
+      assert.ok(Number.isFinite(generatedAt));
+      assert.ok(generatedAt >= before);
+      assert.ok(generatedAt <= after);
+    } finally {
+      if (originalRunId === undefined) {
+        delete process.env.GITHUB_RUN_ID;
+      } else {
+        process.env.GITHUB_RUN_ID = originalRunId;
+      }
+      if (originalRunAttempt === undefined) {
+        delete process.env.GITHUB_RUN_ATTEMPT;
+      } else {
+        process.env.GITHUB_RUN_ATTEMPT = originalRunAttempt;
+      }
+    }
+  });
+
+  test('creates the auth directory when it does not exist', async () => {
+    const parentDir = await mkdtemp(join(tmpdir(), 'orwellstat-auth-parent-'));
+    tempDirs.push(parentDir);
+    const authDir = join(parentDir, 'nested-auth');
+
+    await writeAuthStateMetadata(new URL(`${authDir}/`, 'file://'), {
+      env: {},
+      now: new Date('2026-05-29T05:20:00.000Z'),
+    });
+
+    const raw = await readFile(join(authDir, 'metadata.json'), 'utf8');
+
+    assert.deepEqual(JSON.parse(raw), {
+      generatedAt: '2026-05-29T05:20:00.000Z',
+      runId: null,
+      runAttempt: null,
+      accounts: ['populated', 'empty'],
+    });
+  });
+});

--- a/playwright/typescript/utils/auth-state-metadata.util.ts
+++ b/playwright/typescript/utils/auth-state-metadata.util.ts
@@ -1,0 +1,33 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import type { Account } from '@utils/env.util';
+
+export type AuthStateMetadata = {
+  readonly generatedAt: string;
+  readonly runId: string | null;
+  readonly runAttempt: string | null;
+  readonly accounts: readonly Account[];
+};
+
+export type WriteAuthStateMetadataOptions = {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly now?: Date;
+};
+
+const AUTH_STATE_ACCOUNTS = ['populated', 'empty'] as const satisfies readonly Account[];
+
+export async function writeAuthStateMetadata(
+  authDir: URL,
+  options: WriteAuthStateMetadataOptions = {}
+): Promise<void> {
+  const env = options.env ?? process.env;
+  const now = options.now ?? new Date();
+  const metadata = {
+    generatedAt: now.toISOString(),
+    runId: env.GITHUB_RUN_ID ?? null,
+    runAttempt: env.GITHUB_RUN_ATTEMPT ?? null,
+    accounts: AUTH_STATE_ACCOUNTS,
+  } satisfies AuthStateMetadata;
+
+  await mkdir(authDir, { recursive: true });
+  await writeFile(new URL('metadata.json', authDir), `${JSON.stringify(metadata, null, 2)}\n`);
+}


### PR DESCRIPTION
## Summary

- write non-secret `.auth/metadata.json` from `auth.setup.ts` with generation time, GitHub run identifiers, and auth-state labels
- validate downloaded auth-state artifacts in `playwright-run.yml`, tolerate missing downloads, and regenerate locally when files are missing, timestamps are invalid, or metadata is older than 1 hour
- harden local auth regeneration so setup-project artifacts are cleaned up and shard report/self-healing uploads only publish shard-test outputs
- document the auth metadata, CI regeneration behavior, conditional browser installs, and new utility/unit-test coverage

Closes #561

## Test plan

- [x] `node --test --experimental-strip-types --disable-warning=ExperimentalWarning utils/auth-state-metadata.util.test.ts`
- [x] `npm run test:unit`
- [x] `npx tsc --noEmit`
- [x] `npm run format:check`
- [x] `playwright/typescript/node_modules/.bin/prettier --check .github/workflows/playwright-run.yml docs/CI.md docs/CI_LOCAL.md docs/PLAYWRIGHT.md docs/TEST_INVENTORY.md`
- [x] `git diff --cached --check`
- [x] MCP Playwright run for `auth.setup.ts` on Chromium
- [x] `act workflow_call -C /Users/hubert/source/github/orwellstat/.worktrees/bugfix-561 --env-file /dev/null --secret-file /dev/null --var-file /dev/null --container-architecture linux/amd64 -W .github/workflows/playwright-run.yml --dryrun ...`

## Review

- [x] Deep review pro completed with security, CI, QA, docs, project checklist, simplification, code, architecture, TypeScript, and unit-test specialists
- [x] Python specialist skipped because this diff contains no Python changes

Note: `actionlint` and `shellcheck` were not installed locally, so CI workflow validation used `act --dryrun` plus the CI specialist review instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication-state metadata tracking, including generation timestamps and run identifiers for improved CI reliability.
  * Implemented auth-state validation in CI workflows that automatically regenerates stale authentication credentials.

* **Documentation**
  * Enhanced CI and local testing documentation with detailed auth-state handling and container resource requirements.
  * Updated Playwright setup documentation to clarify auth metadata structure and contents.

* **Tests**
  * Added comprehensive test coverage for auth-state metadata validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/orwellstat/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->