### PR TITLE
#564 Remove invalid Playwright auth regeneration flags

### DIFF
--- a/.github/workflows/playwright-run.yml
+++ b/.github/workflows/playwright-run.yml
@@ -177,7 +177,7 @@ jobs:
 
           trap cleanup_auth_regeneration_artifacts EXIT
           cleanup_auth_regeneration_artifacts
-          npx playwright test --project=setup --reporter=line --trace=off --screenshot=off --video=off --output=.auth-regeneration-results
+          npx playwright test --project=setup --reporter=line --trace=off --output=.auth-regeneration-results
         working-directory: playwright/typescript
         env:
           ENV: ${{ vars.ENV }}


### PR DESCRIPTION
## Summary

- Remove unsupported `--screenshot=off` and `--video=off` flags from the stale-auth regeneration Playwright command.
- Keep the supported setup-project command options and shard flow unchanged.

Closes #564

## Test plan

- [x] `rg --line-number -- '--screenshot=off|--video=off' .github/workflows/playwright-run.yml` returns no matches.
- [x] `node node_modules/playwright/cli.js test --project=setup --reporter=line --trace=off --output=.auth-regeneration-results --help`
- [x] `npx prettier --check ../../.github/workflows/playwright-run.yml`
- [x] `npm run tsc`
- [x] `npm run test:unit`
- [x] `act -n`
- [x] GitHub Actions `Playwright Typescript Tests` passed on PR #565; the `test (chromium 2/2) / tests` log shows fresh auth metadata was used without regeneration.
