### PR TITLE
#566 Update playwright-report-mcp to 3.2.0

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -28,7 +28,7 @@ command = "npx"
 [mcp_servers.playwright-report-mcp]
 args = [
     "--min-release-age=0",
-    "playwright-report-mcp@3.1.3",
+    "playwright-report-mcp@3.2.0",
 ]
 command = "npx"
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
     },
     "playwright-report-mcp": {
       "command": "npx",
-      "args": ["--min-release-age=0", "playwright-report-mcp@3.1.3"],
+      "args": ["--min-release-age=0", "playwright-report-mcp@3.2.0"],
       "type": "stdio",
       "env": {
         "PW_ALLOWED_DIRS": ".."

--- a/docs/AI_ASSISTANTS.md
+++ b/docs/AI_ASSISTANTS.md
@@ -77,9 +77,9 @@ Five MCP servers are declared in [`.mcp.json`](../.mcp.json) and loaded automati
 
 ### playwright-report-mcp
 
-Runs through `npx playwright-report-mcp@3.1.3`. The version is pinned in `.mcp.json`.
+Runs through `npx playwright-report-mcp@3.2.0`. The version is pinned in `.mcp.json`.
 
-`playwright-report-mcp@3.1.3` declares `node >=22`; use the repository baseline Node.js 26.x for local Playwright, Bruno, and MCP workflows.
+`playwright-report-mcp@3.2.0` declares `node >=22`; use the repository baseline Node.js 26.x for local Playwright, Bruno, and MCP workflows.
 
 Every tool call should pass `workingDirectory: "playwright/typescript"` in the main checkout, or a sibling worktree path such as `"../orwellstat-330/playwright/typescript"`. The default `.` points at the repo root, which has no Playwright config and will fail.
 


### PR DESCRIPTION
Closes #566

## Summary

Updates the pinned `playwright-report-mcp` version from 3.1.3 to 3.2.0 in both assistant MCP config files and keeps the focused MCP documentation in sync.

The package metadata for `playwright-report-mcp@3.2.0` confirms it is the current `latest` dist-tag and still declares `node >=22`, so the existing Node requirement remains accurate.

## Review

- Manual security review: pass. The diff only changes pinned package strings; it adds no untrusted input handling, file I/O, secrets, or broader permissions.
- Manual simplification review: pass. The three version references intentionally stay explicit in their owner files.
- Fresh diff review: pass. The change is self-explanatory, has no dead code or debug artifacts, and updates the focused MCP owner doc alongside config.

## Test plan

- [x] `npm ci` in `playwright/typescript`.
- [x] Baseline `npm run tsc`.
- [x] Baseline `npm run format:check`.
- [x] `jq . .mcp.json`.
- [x] `python3 -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path(".codex/config.toml").read_text())'`.
- [x] `npm view playwright-report-mcp@3.2.0 version engines dist-tags --json` returns `version: 3.2.0`, `latest: 3.2.0`, and `node >=22`.
- [x] Post-change `npm run tsc`.
- [x] Post-change `npm run format:check`.
- [x] MCP `list_tests` with `workingDirectory: ".worktrees/feature-566/playwright/typescript"` returns 134 tests.
- [x] MCP `run_tests` with `workingDirectory: ".worktrees/feature-566/playwright/typescript"`, `spec: "tests/navigation.spec.ts"`, and `browser: "Chromium"` passes: 17 expected, 0 unexpected.
- [x] GitHub PR checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Playwright Report MCP server to version 3.2.0, including configuration and documentation updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hubertgajewski/orwellstat/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->