### PR TITLE
[enhancement] Move assistant review gate from commit commands to push commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -185,9 +185,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); CMD=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.command // empty'); case \"$CMD\" in *git*|*commit*|*';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'$'*|*'('*|*')'*|*'{'*|*'}'*|*'='*|*'`'*) ;; *) exit 0;; esac; ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; SCRIPT=\"$ROOT/scripts/verify_commit_command_hook.py\"; EXPECTED='0c6d499e65f850b8066158c2d8ce548da0756c7f3c83acd5afb2ef453d6aaa95'; ACTUAL=$(shasum -a 256 \"$SCRIPT\" 2>/dev/null | awk '{print $1}') || exit 2; if [ \"$ACTUAL\" != \"$EXPECTED\" ]; then echo 'BLOCKED: commit hook helper hash mismatch; review scripts/verify_commit_command_hook.py and update the pinned hook hash deliberately.' >&2; exit 2; fi; printf '%s' \"$INPUT\" | python3 \"$SCRIPT\" claude",
+            "command": "INPUT=$(cat); CMD=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.command // empty'); case \"$CMD\" in *git*|*send-pack*|*\\'*|*\\\"*|*\\\\*|*';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'$'*|*'('*|*')'*|*'{'*|*'}'*|*'='*|*'`'*) ;; *) exit 0;; esac; ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; SCRIPT=\"$ROOT/scripts/verify_commit_command_hook.py\"; EXPECTED='f5c8549116a0de826c12cfeb8e39b7a593fa333577ceb6e987e8c5ea3eeac161'; ACTUAL=$(shasum -a 256 \"$SCRIPT\" 2>/dev/null | awk '{print $1}') || exit 2; if [ \"$ACTUAL\" != \"$EXPECTED\" ]; then echo 'BLOCKED: publish hook helper hash mismatch; review scripts/verify_commit_command_hook.py and update the pinned hook hash deliberately.' >&2; exit 2; fi; printf '%s' \"$INPUT\" | python3 \"$SCRIPT\" claude",
             "timeout": 60,
-            "statusMessage": "Verifying types and format before commit..."
+            "statusMessage": "Verifying types and format before push..."
           },
           {
             "type": "command",
@@ -197,11 +197,11 @@
           },
           {
             "type": "agent",
-            "if": "Bash(git commit*)",
-            "prompt": "A git commit is about to run in the orwellstat repo. Execute the project's deep code review by following .claude/skills/deep-review-lite/SKILL.md exactly (run /security-review, /simplify, then the project checklist against `git diff HEAD`). If any blocking issues remain after the skill's 3-cycle loop, return decision 'block' with the prioritised failure list as the reason so the commit is aborted. If the skill finishes with no blocking failures, return decision 'allow'. Input: $ARGUMENTS",
+            "if": "Bash(git push*)",
+            "prompt": "A git push is about to publish refs from the orwellstat repo. Execute the project's deep code review by following .claude/skills/deep-review-lite/SKILL.md exactly (run /security-review, /simplify, then the project checklist against `git diff HEAD`). If any blocking issues remain after the skill's 3-cycle loop, return decision 'block' with the prioritised failure list as the reason so the push is aborted. If the skill finishes with no blocking failures, return decision 'allow'. Input: $ARGUMENTS",
             "model": "claude-sonnet-4-6",
             "timeout": 600,
-            "statusMessage": "Running /deep-review-lite before commit..."
+            "statusMessage": "Running /deep-review-lite before push..."
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -41,9 +41,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); CMD=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.command // empty'); case \"$CMD\" in *git*|*commit*|*';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'$'*|*'('*|*')'*|*'{'*|*'}'*|*'='*|*'`'*) ;; *) exit 0;; esac; ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; SCRIPT=\"$ROOT/scripts/verify_commit_command_hook.py\"; EXPECTED='0c6d499e65f850b8066158c2d8ce548da0756c7f3c83acd5afb2ef453d6aaa95'; ACTUAL=$(shasum -a 256 \"$SCRIPT\" 2>/dev/null | awk '{print $1}') || exit 2; if [ \"$ACTUAL\" != \"$EXPECTED\" ]; then echo 'BLOCKED: commit hook helper hash mismatch; review scripts/verify_commit_command_hook.py and update the pinned hook hash deliberately.' >&2; exit 2; fi; printf '%s' \"$INPUT\" | python3 \"$SCRIPT\"",
+            "command": "INPUT=$(cat); CMD=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.command // empty'); case \"$CMD\" in *git*|*send-pack*|*\\'*|*\\\"*|*\\\\*|*';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'$'*|*'('*|*')'*|*'{'*|*'}'*|*'='*|*'`'*) ;; *) exit 0;; esac; ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; SCRIPT=\"$ROOT/scripts/verify_commit_command_hook.py\"; EXPECTED='f5c8549116a0de826c12cfeb8e39b7a593fa333577ceb6e987e8c5ea3eeac161'; ACTUAL=$(shasum -a 256 \"$SCRIPT\" 2>/dev/null | awk '{print $1}') || exit 2; if [ \"$ACTUAL\" != \"$EXPECTED\" ]; then echo 'BLOCKED: publish hook helper hash mismatch; review scripts/verify_commit_command_hook.py and update the pinned hook hash deliberately.' >&2; exit 2; fi; printf '%s' \"$INPUT\" | python3 \"$SCRIPT\"",
             "timeout": 60,
-            "statusMessage": "Verifying types and format before commit..."
+            "statusMessage": "Verifying types and format before push..."
           },
           {
             "type": "command",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Commit messages are always a **short, single-line description** with no body and
 
 The `#N` prefix must come first so `git log --oneline` and GitHub cross-references work at a glance.
 
-Run commits as a direct `git commit ...` command from the repository checkout. Avoid compound shell commands such as `cd repo && git commit`, `git commit && git status`, or `git commit; git status` so the configured commit hooks run consistently.
+Run commits as a direct `git commit ...` command from the repository checkout so local Git hooks run consistently. The assistant review and verification gate runs at publication time: use a direct `git push ...` command and avoid compound or wrapped publication commands such as `cd repo && git push`, `env git push`, or alias-only push forms so the publish gate runs before refs are published.
 
 ---
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -35,19 +35,19 @@ Use [CI_LOCAL.md](CI_LOCAL.md) for self-hosted runner setup, security model, and
 
 Root scripts support CI workflows, hooks, and generated reports:
 
-| Script                                     | Purpose                                                                                   |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| `scripts/generate-quality-metrics.py`      | Generates `QUALITY_METRICS.md` and appends `quality-metrics-history.json` data points     |
-| `scripts/self-healing.py`                  | Parses Playwright failure artifacts and posts selector-fix comments or creates draft PRs  |
-| `scripts/provision-worktree-env.sh`        | Symlinks or copies gitignored env files into per-issue worktrees                          |
-| `scripts/setup-runners.sh`                 | Registers and starts the self-hosted runner pool as launchd services                      |
-| `scripts/remove-runners.sh`                | De-registers and stops the self-hosted runner pool                                        |
-| `scripts/runner-lib.sh`                    | Shared helpers for the self-hosted runner setup/removal scripts                           |
-| `scripts/verify_commit_command_hook.py`    | Shared pinned-hook check that rejects indirect or multi-line `git commit` command forms   |
-| `scripts/test_generate_quality_metrics.py` | Unit tests for generated quality-metrics behavior                                         |
-| `scripts/test_self_healing.py`             | Unit tests for self-healing loop prevention, classification, redaction, and AI boundaries |
-| `scripts/test_runner_scripts.py`           | Unit tests for self-hosted runner setup/removal scripts                                   |
-| `scripts/test_commit_hook_config.py`       | Unit tests for Claude/Codex commit-hook configuration                                     |
+| Script                                     | Purpose                                                                                          |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `scripts/generate-quality-metrics.py`      | Generates `QUALITY_METRICS.md` and appends `quality-metrics-history.json` data points            |
+| `scripts/self-healing.py`                  | Parses Playwright failure artifacts and posts selector-fix comments or creates draft PRs         |
+| `scripts/provision-worktree-env.sh`        | Symlinks or copies gitignored env files into per-issue worktrees                                 |
+| `scripts/setup-runners.sh`                 | Registers and starts the self-hosted runner pool as launchd services                             |
+| `scripts/remove-runners.sh`                | De-registers and stops the self-hosted runner pool                                               |
+| `scripts/runner-lib.sh`                    | Shared helpers for the self-hosted runner setup/removal scripts                                  |
+| `scripts/verify_commit_command_hook.py`    | Shared pinned-hook check that verifies direct `git push` commands and rejects wrapped push forms |
+| `scripts/test_generate_quality_metrics.py` | Unit tests for generated quality-metrics behavior                                                |
+| `scripts/test_self_healing.py`             | Unit tests for self-healing loop prevention, classification, redaction, and AI boundaries        |
+| `scripts/test_runner_scripts.py`           | Unit tests for self-hosted runner setup/removal scripts                                          |
+| `scripts/test_commit_hook_config.py`       | Unit tests for Claude/Codex publish-time hook configuration                                      |
 
 ## Playwright Typescript Tests
 
@@ -138,6 +138,12 @@ npm run test:unit
 ```
 
 Add `lint-and-types` to required branch-protection checks on `main` so local `git commit --no-verify` cannot bypass formatting, type, or unit-test failures.
+
+## Assistant Publish Gate
+
+Claude and Codex run the local assistant gate at publish time, not commit time. Direct `git push` commands run the pinned `scripts/verify_commit_command_hook.py` helper before refs are published; the helper runs the TypeScript check and Prettier format check for `playwright/typescript/`. Claude additionally runs the deep review agent hook before allowing the push.
+
+Wrapped or indirect publication commands such as `cd repo && git push`, `env git push`, alias-configured push commands, and `send-pack` are blocked with an actionable message. Local history-maintenance commands such as `git rebase origin/main`, `git rebase --continue`, `git merge`, `git cherry-pick`, and local `git commit` commands do not trigger the publish gate.
 
 ## Standalone Baseline Update
 

--- a/docs/PLAYWRIGHT.md
+++ b/docs/PLAYWRIGHT.md
@@ -19,7 +19,7 @@ npx playwright install --with-deps
 1. `lint-staged` formats staged `*.{ts,tsx,js,json,md,yml,yaml,html,xhtml}` files under `playwright/typescript/` with Prettier and re-stages them.
 2. `npx tsc --noEmit` blocks commits with TypeScript errors.
 
-`git commit --no-verify` bypasses the local hook, but CI still runs the same backstop checks.
+`git commit --no-verify` bypasses the local hook, but CI still runs the same backstop checks. Claude/Codex assistant hooks also run the TypeScript and format checks before direct `git push` publication commands; see [CI.md](CI.md#assistant-publish-gate).
 
 ## Running Tests
 

--- a/scripts/test_commit_hook_config.py
+++ b/scripts/test_commit_hook_config.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Claude/Codex git commit command hooks.
+"""Unit tests for the Claude/Codex publish-time Git command hooks.
 
 Usage:
     python3 scripts/test_commit_hook_config.py
@@ -6,9 +6,9 @@ Usage:
 
 from __future__ import annotations
 
-import json
 import importlib.util
 import io
+import json
 import os
 import subprocess
 import tempfile
@@ -29,173 +29,170 @@ _SPEC.loader.exec_module(hook)
 
 
 class CommandDecisionTests(unittest.TestCase):
-    def test_allows_direct_commit_forms(self):
+    def test_allows_direct_push_forms(self):
         for command in (
-            "git commit -m test",
-            'git commit -m "test && docs; still direct"',
-            "git commit -m test\\;docs",
-            'git commit -m "$MSG"',
+            "git push",
+            "git push origin HEAD",
+            "git push --force-with-lease origin HEAD",
+            "git push origin HEAD:refs/heads/main",
         ):
             with self.subTest(command=command):
                 self.assertEqual(hook.command_decision(command), "allow")
 
-    def test_blocks_non_direct_commit_forms(self):
+    def test_blocks_non_direct_push_forms(self):
         for command in (
-            "cd /tmp && git commit -m test",
-            "git commit -m test && git status",
-            "git commit -m test; git status",
-            "git commit -m test || git status",
-            "git -C . commit -m test",
-            "git --git-dir . commit -m test",
-            "git --work-tree . commit -m test",
-            "git --config-env foo=bar commit -m test",
-            "git --unknown commit -m test",
-            "git ci -m test",
-            "git cherry-pick abc123",
-            "git merge feature",
-            "git rebase main",
-            "git rebase --continue",
-            "git pull",
-            "git -c alias.ci=commit ci -m test",
-            "git -calias.ci=commit ci -m test",
-            "git -c include.path=/tmp/gitconfig ci -m test",
-            "git -c includeIf.gitdir:/path/.git.path=/tmp/gitconfig ci -m test",
-            "git --config-env alias.ci=GIT_ALIAS ci -m test",
-            "git --config-env includeIf.gitdir:/path/.git.path=GIT_INCLUDE ci -m test",
-            "git --config-env=alias.ci=GIT_ALIAS ci -m test",
-            "git commit -m ok -F <(git add bad.py)",
-            "echo $(git -C . commit -m test)",
-            "echo $(git -c alias.ci=commit ci -m test)",
-            "echo $(git --config-env alias.ci=GIT_ALIAS ci -m test)",
-            "git commit -m \"$(date)\"",
-            'git "commit" -m test',
-            "git 'commit' -m test",
-            "git comm\\it -m test",
-            "true\ngit commit -m test",
-            "GIT_AUTHOR_NAME=test git commit -m test",
-            "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.ci GIT_CONFIG_VALUE_0=commit git ci -m test",
-            "GIT_CONFIG_GLOBAL=/tmp/gitconfig git ci -m test",
-            "env GIT_CONFIG_GLOBAL=/tmp/gitconfig git ci -m test",
-            "$'git' commit -m test",
-            "`printf git` commit --no-verify -m test",
-            "`printf /usr/bin/git` commit --no-verify -m test",
-            "`printf git` -c alias.ci=commit ci -m test",
-            "$(printf git) -c alias.ci=commit ci -m test",
-            "$'git' -c alias.ci=commit ci -m test",
-            "git${IFS}commit --no-verify",
-            "G=git; $G commit -m test",
-            "G=git; C=commit; $G $C -m test",
-            "env git commit -m test",
-            "env -- git commit -m test",
-            "env FOO=bar git commit -m test",
-            "env -i git commit -m test",
-            "env -u FOO git commit -m test",
-            "env -C /tmp git commit -m test",
-            "env -P /usr/bin git commit -m test",
-            "env -P/usr/bin git commit -m test",
-            "env -S 'git commit -m test'",
-            "env -S'git commit -m test'",
-            "env -Sgit commit -m test",
-            "env --split-string='git commit -m test'",
-            "command env -S 'git commit -m test'",
-            "exec env -S 'git commit -m test'",
-            "command env -Sgit commit -m test",
-            "env -S \"env -S 'env -S \\'env -S \\\\\\'git commit -m test\\\\\\'\\''\"",
-            "command git commit -m test",
-            "command -- bash -c 'git commit -m test'",
-            "command -p git -c alias.ci=commit ci -m test",
-            "command -p env -S 'git commit -m test'",
-            "command eval 'git commit -m test'",
-            "exec git commit -m test",
-            "exec -a name git -c alias.ci=commit ci -m test",
-            "exec -a name env -S 'git commit -m test'",
-            "exec -c git -c alias.ci=commit ci -m test",
-            "exec -l git -c alias.ci=commit ci -m test",
-            "exec -cl git -c alias.ci=commit ci -m test",
-            "exec -lc git -c alias.ci=commit ci -m test",
-            "exec -la name git -c alias.ci=commit ci -m test",
-            'eval "git commit -m test"',
-            'cmd="git commit -m test"; eval "$cmd"',
-            "printf 'commit -m test' | xargs git",
-            "printf 'commit -m test' | xargs /usr/bin/git",
-            "xargs -a /tmp/args sh -c 'git commit -m test'",
+            "cd /tmp && git push",
+            "git push && git status",
+            "git push; git status",
+            "git push || git status",
+            "git -C . push",
+            "git --git-dir . push",
+            "git --work-tree . push",
+            "git --unknown push",
+            "git send-pack origin refs/heads/main",
+            "git-send-pack origin refs/heads/main",
+            "git -c alias.pub=push pub origin HEAD",
+            "git -calias.pub=push pub origin HEAD",
+            "git -c include.path=/tmp/gitconfig pub origin HEAD",
+            "git -c includeIf.gitdir:/path/.git.path=/tmp/gitconfig pub origin HEAD",
+            "git --config-env alias.pub=GIT_ALIAS pub origin HEAD",
+            "git --config-env includeIf.gitdir:/path/.git.path=GIT_INCLUDE pub origin HEAD",
+            "git --config-env=alias.pub=GIT_ALIAS pub origin HEAD",
+            "echo $(git -C . push)",
+            "echo $(git -c alias.pub=push pub origin HEAD)",
+            "echo $(git --config-env alias.pub=GIT_ALIAS pub origin HEAD)",
+            "git push origin \"$(date)\"",
+            'git "push" origin HEAD',
+            "git 'push' origin HEAD",
+            "git pu\\sh origin HEAD",
+            "true\ngit push",
+            "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.pub GIT_CONFIG_VALUE_0=push git pub origin HEAD",
+            "GIT_CONFIG_GLOBAL=/tmp/gitconfig git pub origin HEAD",
+            "env GIT_CONFIG_GLOBAL=/tmp/gitconfig git pub origin HEAD",
+            "$'git' push origin HEAD",
+            "`printf git` push origin HEAD",
+            "`printf /usr/bin/git` push origin HEAD",
+            "`printf git` -c alias.pub=push pub origin HEAD",
+            "$(printf git) -c alias.pub=push pub origin HEAD",
+            "$'git' -c alias.pub=push pub origin HEAD",
+            "git${IFS}push origin HEAD",
+            "G=git; $G push origin HEAD",
+            "G=git; C=push; $G $C origin HEAD",
+            "env git push origin HEAD",
+            "env -- git push origin HEAD",
+            "env FOO=bar git push origin HEAD",
+            "env -i git push origin HEAD",
+            "env -u FOO git push origin HEAD",
+            "env -C /tmp git push origin HEAD",
+            "env -P /usr/bin git push origin HEAD",
+            "env -P/usr/bin git push origin HEAD",
+            "env -S 'git push origin HEAD'",
+            "env -S'git push origin HEAD'",
+            "env -Sgit push origin HEAD",
+            "env --split-string='git push origin HEAD'",
+            "command env -S 'git push origin HEAD'",
+            "exec env -S 'git push origin HEAD'",
+            "command env -Sgit push origin HEAD",
+            "command git push origin HEAD",
+            "command -- bash -c 'git push origin HEAD'",
+            "command -p git -c alias.pub=push pub origin HEAD",
+            "command -p env -S 'git push origin HEAD'",
+            "command eval 'git push origin HEAD'",
+            "exec git push origin HEAD",
+            "exec -a name git -c alias.pub=push pub origin HEAD",
+            "exec -a name env -S 'git push origin HEAD'",
+            "exec -c git -c alias.pub=push pub origin HEAD",
+            "exec -l git -c alias.pub=push pub origin HEAD",
+            "exec -cl git -c alias.pub=push pub origin HEAD",
+            "exec -lc git -c alias.pub=push pub origin HEAD",
+            "exec -la name git -c alias.pub=push pub origin HEAD",
+            'eval "git push origin HEAD"',
+            'cmd="git push origin HEAD"; eval "$cmd"',
+            "printf 'push origin HEAD' | xargs git",
+            "printf 'push origin HEAD' | xargs /usr/bin/git",
+            "xargs -a /tmp/args sh -c 'git push origin HEAD'",
             "xargs -a /tmp/args git",
-            "xargs -a /tmp/args -I{} git {} -m test",
-            "xargs --arg-file=/tmp/args -I{} git {} -m test",
-            "xargs -a /tmp/args git -C . commit -m test",
-            "printf 'commit --no-verify' | xargs git -C .",
-            "xargs -a /tmp/args git -c alias.ci=commit ci -m test",
-            "xargs -a /tmp/args env GIT_CONFIG_GLOBAL=/tmp/gitconfig git ci -m test",
-            "printf 'commit -m test' | xargs env git",
+            "xargs -a /tmp/args -I{} git {} origin HEAD",
+            "xargs --arg-file=/tmp/args -I{} git {} origin HEAD",
+            "xargs -a /tmp/args git -C . push origin HEAD",
+            "printf 'push --force' | xargs git -C .",
+            "xargs -a /tmp/args git -c alias.pub=push pub origin HEAD",
+            "xargs -a /tmp/args env GIT_CONFIG_GLOBAL=/tmp/gitconfig git pub origin HEAD",
+            "printf 'push origin HEAD' | xargs env git",
             "xargs -a /tmp/args env git",
-            "printf 'commit -m test' | xargs env -S git",
+            "printf 'push origin HEAD' | xargs env -S git",
             "xargs -a /tmp/args env -S git",
-            "printf 'commit -m test' | xargs env -Sgit",
+            "printf 'push origin HEAD' | xargs env -Sgit",
             "xargs -a /tmp/args env --split-string=git",
             'xargs -a /tmp/args -I{} sh -c "{}"',
             'xargs -a /tmp/args -I{} env sh -c "{}"',
             'xargs --replace={} sh -c "{}"',
             "xargs -i sh -c '{}'",
-            "xargs -i git {} -m test",
+            "xargs -i git {} origin HEAD",
             "xargs sh -c < /tmp/args",
-            "printf 'git commit -m test' | sh",
-            'printf "git commit -m test" | xargs -I{} sh -c "{}"',
-            "printf git | xargs -I{} {} commit -m test",
-            "printf git | xargs -I{} {} -c alias.ci=commit ci -m test",
-            "printf git | xargs -I{} /usr/bin/{} -c alias.ci=commit ci -m test",
-            "printf git | xargs --replace=G /usr/bin/G -c alias.ci=commit ci -m test",
-            "printf git | xargs -I{} /usr/bin/env {} -c alias.ci=commit ci -m test",
-            "dash -c 'git commit -m test'",
-            "python3 -c 'import os; os.system(\"git commit -m test\")'",
-            "python3 -c 'import os; os.system(\"git\"+\" commit -m test\")'",
-            "node -e 'require(\"child_process\").execSync(\"git commit -m test\")'",
-            "node -e 'require(\"child_process\").execSync(\"git\"+\" commit -m test\")'",
-            "node --eval='require(\"child_process\").execSync(\"git commit -m test\")'",
-            "node --print='require(\"child_process\").execSync(\"git commit -m test\")'",
-            "node --eval='require(\"child_process\").execSync(\"git\"+\" commit -m test\")'",
-            "node -p'require(\"child_process\").execSync(\"git commit -m test\")'",
-            "node -p -e 'require(\"child_process\").execSync(\"git commit -m test\")'",
-            "node --print --eval 'require(\"child_process\").execSync(\"git commit -m test\")'",
-            "node -pe'require(\"child_process\").execSync(\"git commit -m test\")'",
-            "bash -c 'git commit -m test'",
-            "bash -lc 'git commit -m test'",
-            "bash --rcfile /tmp/x -c 'git commit -m test'",
-            "bash <<EOF\ngit commit -m test\nEOF",
-            "true\nbash <<EOF\ngit commit -m test\nEOF",
-            "sh <<EOF-1\ngit commit -m test\nEOF-1",
-            "env bash -c 'git commit -m test'",
-            "sh -c 'git commit -m test'",
-            "zsh -c 'git commit -m test'",
-            "zsh --no-rcs -c 'git commit -m test'",
-            "/usr/bin/git commit -m test",
-            "/usr/bin/env -- git commit -m test",
-            "(git commit -m test)",
-            "{ git commit -m test; }",
-            "if true; then git commit -m test; fi",
-            "echo git commit",
-            "echo $(git commit -m test)",
-            "echo `git commit -m test`",
-            'python3 - <<X\nprint("echo $(printf \'git commit\')")\nX',
-            "python3 - <<X\ngit commit -m test\nX",
-            "python3 - <<'EOF-1'\ngit commit -m test\nEOF-1\ngit status",
-            "git com$(printf mit) -m test",
-            "git 'commit",
+            "printf 'git push origin HEAD' | sh",
+            'printf "git push origin HEAD" | xargs -I{} sh -c "{}"',
+            "printf git | xargs -I{} {} push origin HEAD",
+            "printf git | xargs -I{} {} -c alias.pub=push pub origin HEAD",
+            "printf git | xargs -I{} /usr/bin/{} -c alias.pub=push pub origin HEAD",
+            "printf git | xargs --replace=G /usr/bin/G -c alias.pub=push pub origin HEAD",
+            "printf git | xargs -I{} /usr/bin/env {} -c alias.pub=push pub origin HEAD",
+            "dash -c 'git push origin HEAD'",
+            "python3 -c 'import os; os.system(\"git push origin HEAD\")'",
+            "python3 -c 'import os; os.system(\"git\"+\" push origin HEAD\")'",
+            "node -e 'require(\"child_process\").execSync(\"git push origin HEAD\")'",
+            "node -e 'require(\"child_process\").execSync(\"git\"+\" push origin HEAD\")'",
+            "node --eval='require(\"child_process\").execSync(\"git push origin HEAD\")'",
+            "node --print='require(\"child_process\").execSync(\"git push origin HEAD\")'",
+            "node --eval='require(\"child_process\").execSync(\"git\"+\" push origin HEAD\")'",
+            "node -p'require(\"child_process\").execSync(\"git push origin HEAD\")'",
+            "node -p -e 'require(\"child_process\").execSync(\"git push origin HEAD\")'",
+            "node --print --eval 'require(\"child_process\").execSync(\"git push origin HEAD\")'",
+            "node -pe'require(\"child_process\").execSync(\"git push origin HEAD\")'",
+            "bash -c 'git push origin HEAD'",
+            "bash -lc 'git push origin HEAD'",
+            "bash --rcfile /tmp/x -c 'git push origin HEAD'",
+            "bash <<EOF\ngit push origin HEAD\nEOF",
+            "true\nbash <<EOF\ngit push origin HEAD\nEOF",
+            "sh <<EOF-1\ngit push origin HEAD\nEOF-1",
+            "env bash -c 'git push origin HEAD'",
+            "sh -c 'git push origin HEAD'",
+            "zsh -c 'git push origin HEAD'",
+            "zsh --no-rcs -c 'git push origin HEAD'",
+            "/usr/bin/git push origin HEAD",
+            "/usr/bin/env -- git push origin HEAD",
+            "(git push origin HEAD)",
+            "{ git push origin HEAD; }",
+            "if true; then git push origin HEAD; fi",
+            "echo git push",
+            "echo $(git push origin HEAD)",
+            "echo `git push origin HEAD`",
+            'python3 - <<X\nprint("echo $(printf \'git push\')")\nX',
+            "python3 - <<X\ngit push origin HEAD\nX",
+            "python3 - <<'EOF-1'\ngit push origin HEAD\nEOF-1\ngit status",
+            "git pu$(printf sh) origin HEAD",
+            "git 'push",
         ):
             with self.subTest(command=command):
                 self.assertEqual(hook.command_decision(command), "block")
 
-    def test_recursion_limit_blocks_commit_payload(self):
+    def test_recursion_limit_blocks_push_payload(self):
         self.assertEqual(
-            hook.command_decision("git commit -m test", hook.MAX_ENV_SPLIT_DEPTH + 1),
+            hook.command_decision("git push origin HEAD", hook.MAX_ENV_SPLIT_DEPTH + 1),
             "block",
         )
 
-    def test_ignores_non_commit_commands(self):
+    def test_ignores_non_push_commands(self):
         for command in (
-            'echo "; git commit --amend"',
-            "git help commit",
-            "git show commit",
-            'git show :README.md | rg -n "commit hook"',
+            'echo "; git push --force"',
+            "git help push",
+            "git show push",
+            'git show :README.md | rg -n "push hook"',
+            "git commit -m test",
+            'git commit -m "push docs"',
+            "bash -c 'git commit -m push'",
+            "python3 -c 'import os; os.system(\"git commit -m push\")'",
+            "node -e 'require(\"child_process\").execSync(\"git commit -m push\")'",
             "git commit-graph verify",
             "GIT_CONFIG_NOSYSTEM=1 git status",
             "GIT_CONFIG_NOSYSTEM=1 git branch",
@@ -212,32 +209,38 @@ class CommandDecisionTests(unittest.TestCase):
             "git gc",
             "git worktree add /tmp/wt HEAD",
             "git worktree list",
+            "git check-ignore -q .worktrees",
             "git diff",
             "git mv old new",
             "git rm --cached file",
             "git apply patch.diff",
             "git reflog",
+            "git rebase origin/main",
+            "git rebase --continue",
             "git rebase --abort",
             "git rebase --quit",
+            "git merge feature",
             "git merge --abort",
             "git merge --quit",
+            "git cherry-pick abc123",
             "git cherry-pick --abort",
             "git cherry-pick --quit",
             "git reset --soft HEAD~1",
             "git ls-tree HEAD",
+            "git ls-remote --heads origin feature/563",
             "git describe --tags",
             "git show-ref --heads",
-            "git diff | xargs echo commit",
-            "python3 scripts/foo.py git commit",
-            "command -v git commit -m test",
-            "command -V git commit -m test",
-            "command -pv git commit -m test",
-            "command -pV git commit -m test",
-            "git status | xargs echo commit",
+            "git diff | xargs echo push",
+            "python3 scripts/foo.py git push",
+            "command -v git push origin HEAD",
+            "command -V git push origin HEAD",
+            "command -pv git push origin HEAD",
+            "command -pV git push origin HEAD",
+            "git status | xargs echo push",
             "bash <<EOF\necho hi\nEOF",
             "git status | xargs echo",
             "echo $PATH | xargs echo",
-            "echo $PATH | xargs echo commit",
+            "echo $PATH | xargs echo push",
             "sh /tmp/setup.sh",
             "bash scripts/setup-runners.sh",
             "node scripts/setup.js",
@@ -256,7 +259,7 @@ class CommandDecisionTests(unittest.TestCase):
                 with patch("sys.argv", ["hook", "codex"]), patch("sys.stdin", io.StringIO(payload)):
                     self.assertEqual(hook.main(), 0)
 
-        payload = json.dumps({"tool_input": {"command": "env git commit -m test"}})
+        payload = json.dumps({"tool_input": {"command": "env git push origin HEAD"}})
         with (
             patch("sys.argv", ["hook", "codex"]),
             patch("sys.stdin", io.StringIO(payload)),
@@ -267,7 +270,7 @@ class CommandDecisionTests(unittest.TestCase):
         root = MagicMock(returncode=0, stdout=f"{REPO_ROOT}\n", stderr="")
         with (
             patch("sys.argv", ["hook", "codex"]),
-            patch("sys.stdin", io.StringIO(json.dumps({"tool_input": {"command": "git commit -m test"}}))),
+            patch("sys.stdin", io.StringIO(json.dumps({"tool_input": {"command": "git push origin HEAD"}}))),
             patch.object(hook.subprocess, "run", return_value=root),
         ):
             self.assertEqual(hook.main(), 0)
@@ -279,7 +282,7 @@ class CommandDecisionTests(unittest.TestCase):
         failed_root = MagicMock(returncode=1, stdout="", stderr="not a repo\n")
         with (
             patch("sys.argv", ["hook", "codex"]),
-            patch("sys.stdin", io.StringIO(json.dumps({"tool_input": {"command": "git commit -m test"}}))),
+            patch("sys.stdin", io.StringIO(json.dumps({"tool_input": {"command": "git push origin HEAD"}}))),
             patch.object(hook.subprocess, "run", return_value=failed_root),
             redirect_stderr(io.StringIO()),
         ):
@@ -291,7 +294,7 @@ class CommandDecisionTests(unittest.TestCase):
                 hook.run_check(["npx", "tsc", "--noEmit"], REPO_ROOT)
 
 
-class CommitCommandHookTests(unittest.TestCase):
+class PublishCommandHookTests(unittest.TestCase):
     def run_hook_command(self, hook_command: str, command: str) -> tuple[int, list[str], str]:
         with tempfile.TemporaryDirectory() as tmpdir:
             calls_path = Path(tmpdir) / "calls.log"
@@ -324,18 +327,18 @@ class CommitCommandHookTests(unittest.TestCase):
             return result.returncode, calls, result.stderr
 
     def run_hook(self, hook_file: str, command: str) -> tuple[int, list[str], str]:
-        return self.run_hook_command(self.commit_hook_command(hook_file), command)
+        return self.run_hook_command(self.publish_hook_command(hook_file), command)
 
-    def commit_hook_command(self, hook_file: str) -> str:
+    def publish_hook_command(self, hook_file: str) -> str:
         hook_config = json.loads((REPO_ROOT / hook_file).read_text(encoding="utf-8"))
         for group in hook_config["hooks"]["PreToolUse"]:
             if group.get("matcher") != "Bash":
                 continue
-            for hook in group["hooks"]:
-                command = hook.get("command", "")
+            for hook_config_entry in group["hooks"]:
+                command = hook_config_entry.get("command", "")
                 if "verify_commit_command_hook.py" in command:
                     return command
-        raise AssertionError(f"commit verifier hook not found in {hook_file}")
+        raise AssertionError(f"publish verifier hook not found in {hook_file}")
 
     def assert_hook_case(
         self,
@@ -352,33 +355,35 @@ class CommitCommandHookTests(unittest.TestCase):
                 if expected_stderr is not None:
                     self.assertIn(expected_stderr, stderr)
 
-    def test_direct_commit_runs_type_and_format_checks(self):
+    def test_direct_push_runs_type_and_format_checks(self):
         self.assert_hook_case(
-            "git commit -m test",
+            "git push origin HEAD",
             0,
             ["npx tsc --noEmit", "npm run format:check"],
         )
 
-    def test_irrelevant_commands_skip_verifier_before_hash_check(self):
-        for hook_file in HOOK_FILES:
-            with self.subTest(hook_file=hook_file):
-                hook_command = self.commit_hook_command(hook_file).replace("EXPECTED='", "EXPECTED='000")
-                status, calls, stderr = self.run_hook_command(hook_command, "date")
-                self.assertEqual(status, 0)
-                self.assertEqual(calls, [])
-                self.assertEqual(stderr, "")
+    def test_commit_and_rebase_do_not_run_publish_checks(self):
+        for command in ("git commit -m test", "git rebase origin/main"):
+            with self.subTest(command=command):
+                self.assert_hook_case(command, 0, [])
 
-    def test_dynamic_commands_do_not_skip_verifier_prefilter(self):
-        for hook_file in HOOK_FILES:
-            with self.subTest(hook_file=hook_file):
-                hook_command = self.commit_hook_command(hook_file).replace("EXPECTED='", "EXPECTED='000")
-                status, calls, stderr = self.run_hook_command(
-                    hook_command,
-                    "G=g; I=it; C=com; M=mit; $G$I $C$M --no-verify",
-                )
-                self.assertEqual(status, 2)
-                self.assertEqual(calls, [])
-                self.assertIn("hash mismatch", stderr)
+    def test_dynamic_push_commands_do_not_skip_verifier_prefilter(self):
+        for command in (
+            "G=g; I=it; C=pu; H=sh; $G$I $C$H origin HEAD",
+            "g''it push origin HEAD",
+            'g""it push origin HEAD',
+            "g\\it push origin HEAD",
+            "git pub origin HEAD",
+            "git pu''sh origin HEAD",
+            "git pu\\sh origin HEAD",
+        ):
+            for hook_file in HOOK_FILES:
+                with self.subTest(hook_file=hook_file, command=command):
+                    hook_command = self.publish_hook_command(hook_file).replace("EXPECTED='", "EXPECTED='000")
+                    status, calls, stderr = self.run_hook_command(hook_command, command)
+                    self.assertEqual(status, 2)
+                    self.assertEqual(calls, [])
+                    self.assertIn("hash mismatch", stderr)
 
     def test_blocked_commands_use_platform_specific_messages(self):
         expectations = {
@@ -387,57 +392,54 @@ class CommitCommandHookTests(unittest.TestCase):
         }
         for hook_file, expected_message in expectations.items():
             with self.subTest(hook_file=hook_file):
-                status, calls, stderr = self.run_hook(hook_file, "env git commit -m test")
+                status, calls, stderr = self.run_hook(hook_file, "env git push origin HEAD")
                 self.assertEqual(status, 2)
                 self.assertEqual(calls, [])
                 self.assertIn(expected_message, stderr)
 
-    def test_compound_commit_forms_are_blocked(self):
+    def test_compound_push_forms_are_blocked(self):
         for command in (
-            "cd /tmp && git commit -m test",
-            "git commit -m test && git status",
-            "git commit -m test; git status",
-            "git commit -m test || git status",
-            "git -C . commit -m test",
-            "true\ngit commit -m test",
-            "GIT_AUTHOR_NAME=test git commit -m test",
-            "env git commit -m test",
-            "command git commit -m test",
-            "/usr/bin/git commit -m test",
-            "(git commit -m test)",
-            "echo $(git commit -m test)",
-            "echo `git commit -m test`",
-            "G=g; I=it; C=com; M=mit; $G$I $C$M --no-verify",
-            "printf git | xargs -I{} {} -c alias.ci=commit ci -m test",
-            "printf git | xargs -I{} /usr/bin/{} -c alias.ci=commit ci -m test",
-            "printf git | xargs --replace=G /usr/bin/G -c alias.ci=commit ci -m test",
-            "printf git | xargs -I{} /usr/bin/env {} -c alias.ci=commit ci -m test",
+            "cd /tmp && git push",
+            "git push && git status",
+            "git push; git status",
+            "git push || git status",
+            "git -C . push",
+            "true\ngit push",
+            "env git push origin HEAD",
+            "command git push origin HEAD",
+            "/usr/bin/git push origin HEAD",
+            "(git push origin HEAD)",
+            "echo $(git push origin HEAD)",
+            "echo `git push origin HEAD`",
+            "G=g; I=it; C=pu; H=sh; $G$I $C$H origin HEAD",
+            "printf git | xargs -I{} {} -c alias.pub=push pub origin HEAD",
+            "printf git | xargs -I{} /usr/bin/{} -c alias.pub=push pub origin HEAD",
+            "printf git | xargs --replace=G /usr/bin/G -c alias.pub=push pub origin HEAD",
+            "printf git | xargs -I{} /usr/bin/env {} -c alias.pub=push pub origin HEAD",
         ):
             with self.subTest(command=command):
                 self.assert_hook_case(command, 2, [], "BLOCKED:")
 
-    def test_quoted_or_non_executable_commit_text_is_ignored(self):
+    def test_quoted_or_non_executable_push_text_is_ignored(self):
         for command in (
-            'echo "; git commit --amend"',
-            "git help commit",
-            "git show commit",
-            "git commit-graph verify",
+            'echo "; git push --force"',
+            "git help push",
+            "git show push",
+            "git commit -m push",
+            "bash -c 'git commit -m push'",
             "git status",
         ):
             with self.subTest(command=command):
                 self.assert_hook_case(command, 0, [])
 
-    def test_quoted_or_escaped_control_chars_in_direct_commit_are_allowed(self):
-        for command in (
-            'git commit -m "test && docs; still direct"',
-            "git commit -m test\\;docs",
-        ):
-            with self.subTest(command=command):
-                self.assert_hook_case(
-                    command,
-                    0,
-                    ["npx tsc --noEmit", "npm run format:check"],
-                )
+    def test_hook_configs_keep_publish_gate_in_sync(self):
+        commands = [self.publish_hook_command(hook_file) for hook_file in HOOK_FILES]
+        normalized = [command.replace(" python3 \"$SCRIPT\" claude", " python3 \"$SCRIPT\"") for command in commands]
+        self.assertEqual(normalized[0], normalized[1])
+        for command in commands:
+            self.assertIn("*git*", command)
+            self.assertIn("*send-pack*", command)
+            self.assertIn("verify_commit_command_hook.py", command)
 
 
 if __name__ == "__main__":

--- a/scripts/verify_commit_command_hook.py
+++ b/scripts/verify_commit_command_hook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Shared Claude/Codex hook for direct git commit commands."""
+"""Shared Claude/Codex hook for direct git push commands."""
 
 from __future__ import annotations
 
@@ -16,8 +16,8 @@ Decision = Literal["none", "block", "allow"]
 MAX_ENV_SPLIT_DEPTH = 3
 
 BLOCK_MESSAGES = {
-    "claude": 'BLOCKED: use a direct git commit command so the /deep-review agent hook runs (avoid compound commands like "cd repo && git commit").',
-    "codex": 'BLOCKED: use a direct git commit command so commit hooks run consistently (avoid compound commands like "cd repo && git commit").',
+    "claude": 'BLOCKED: use a direct git push command so the /deep-review agent hook runs before publication (avoid wrappers like "cd repo && git push").',
+    "codex": 'BLOCKED: use a direct git push command so verification runs before publication (avoid wrappers like "cd repo && git push").',
 }
 
 
@@ -99,11 +99,33 @@ GIT_OPTIONS_WITH_VALUES = {
     "--exec-path",
     "--config-env",
 }
-SUBSTITUTION_COMMIT_RE = re.compile(
-    r"(`|\$\(|<\(|>\()\s*(/\S*/)?git\b(?:\s+(?:-[A-Za-z]|--[A-Za-z-]+)(?:[=\s]\S+)*)*\s+commit\b",
+PUBLISH_SUBCOMMANDS = {"push", "send-pack"}
+PUBLISH_SUBCOMMAND_PATTERN = "|".join(
+    re.escape(subcommand) for subcommand in sorted(PUBLISH_SUBCOMMANDS, key=len, reverse=True)
+)
+SUBSTITUTION_PUBLISH_RE = re.compile(
+    rf"(`|\$\(|<\(|>\()\s*(/\S*/)?git\b(?:\s+(?:-[A-Za-z]|--[A-Za-z-]+)(?:[=\s]\S+)*)*\s+(?:{PUBLISH_SUBCOMMAND_PATTERN})\b",
     re.DOTALL,
 )
-DYNAMIC_COMMIT_RE = re.compile(r"\bgit\s*\$[({A-Za-z_].*\bcommit\b", re.DOTALL)
+DYNAMIC_PUBLISH_RE = re.compile(
+    rf"\bgit\s*\$[({{A-Za-z_].*\b(?:{PUBLISH_SUBCOMMAND_PATTERN})\b|"
+    rf"\bgit\$\{{[^}}]+\}}(?:{PUBLISH_SUBCOMMAND_PATTERN})\b",
+    re.DOTALL,
+)
+GIT_PUBLISH_RE = re.compile(
+    rf"\bgit\b(?:\s+(?:-[A-Za-z]|--[A-Za-z-]+)(?:[=\s]\S+)*)*\s+(?:{PUBLISH_SUBCOMMAND_PATTERN})\b|\bgit-send-pack\b",
+    re.DOTALL,
+)
+RAW_PUBLISH_RE = re.compile(
+    rf"\bgit\b.*\b(?:{PUBLISH_SUBCOMMAND_PATTERN})\b|\bgit-send-pack\b",
+    re.DOTALL,
+)
+RUNTIME_PUBLISH_RE = re.compile(
+    rf"\bgit\b(?:\s+(?:-[A-Za-z]|--[A-Za-z-]+)(?:[=\s]\S+)*)*\s+(?:{PUBLISH_SUBCOMMAND_PATTERN})\b|"
+    rf"[\"']git[\"']\s*\+\s*[\"']\s+(?:{PUBLISH_SUBCOMMAND_PATTERN})\b|"
+    r"\bgit-send-pack\b",
+    re.DOTALL,
+)
 SHELL_INTERPRETERS = {"bash", "dash", "sh", "zsh"}
 INLINE_RUNTIME_FLAGS = {"-c", "-e", "--eval", "-p", "--print"}
 XARGS_OPTIONS_WITH_VALUES = {
@@ -122,12 +144,15 @@ XARGS_OPTIONS_WITH_VALUES = {
     "-s",
     "--max-chars",
 }
-KNOWN_NON_COMMIT_GIT_SUBCOMMANDS = {
+KNOWN_NON_PUBLISH_GIT_SUBCOMMANDS = {
     "add",
     "apply",
     "blame",
     "branch",
     "checkout",
+    "cherry-pick",
+    "check-ignore",
+    "commit",
     "commit-graph",
     "config",
     "describe",
@@ -138,11 +163,14 @@ KNOWN_NON_COMMIT_GIT_SUBCOMMANDS = {
     "help",
     "log",
     "ls-files",
+    "ls-remote",
     "ls-tree",
+    "merge",
     "mv",
-    "push",
+    "pull",
     "remote",
     "reflog",
+    "rebase",
     "restore",
     "rev-parse",
     "reset",
@@ -174,13 +202,13 @@ ENV_OPTIONS_WITH_VALUES = {
 ENV_FLAGS_WITHOUT_VALUES = {"-i", "-", "--ignore-environment"}
 
 
-def config_value_defines_commit_alias(value: str) -> bool:
-    return bool(re.match(r"^alias\.[^.]+=.*\bcommit\b", value, re.IGNORECASE))
+def config_value_defines_publish_alias(value: str) -> bool:
+    return bool(re.match(rf"^alias\.[^.]+=.*\b(?:{PUBLISH_SUBCOMMAND_PATTERN})\b", value, re.IGNORECASE))
 
 
 def config_value_can_define_alias(value: str) -> bool:
     return bool(
-        config_value_defines_commit_alias(value)
+        config_value_defines_publish_alias(value)
         or re.match(r"^include(?:If\..+)?\.path=", value, re.IGNORECASE)
         or re.match(r"^alias\.[^.]+$", value, re.IGNORECASE)
     )
@@ -196,6 +224,10 @@ def config_env_key_can_define_alias(value: str) -> bool:
 
 def is_git_executable(token: str) -> bool:
     return token == "git" or token.endswith("/git")
+
+
+def is_git_send_pack_executable(token: str) -> bool:
+    return Path(token).name == "git-send-pack" or token.endswith("/git-send-pack")
 
 
 def is_git_config_assignment(token: str) -> bool:
@@ -256,7 +288,7 @@ def env_prefix_has_git_config_assignment(segment: list[str], index: int) -> bool
     return scan_env_prefix(segment, index)[1]
 
 
-def env_split_string_contains_commit(segment: list[str], index: int, depth: int) -> bool:
+def env_split_string_contains_publish(segment: list[str], index: int, depth: int) -> bool:
     return any(command_decision(payload, depth + 1) != "none" for payload in scan_env_prefix(segment, index)[2])
 
 
@@ -308,7 +340,7 @@ def skip_exec_prefix(segment: list[str], index: int) -> int:
     return index
 
 
-def interpreter_string_contains_commit(segment: list[str], depth: int) -> bool:
+def interpreter_string_contains_publish(segment: list[str], depth: int) -> bool:
     if not segment:
         return False
 
@@ -329,19 +361,19 @@ def interpreter_string_contains_commit(segment: list[str], depth: int) -> bool:
     return False
 
 
-def python_string_contains_commit(segment: list[str]) -> bool:
+def python_string_contains_publish(segment: list[str]) -> bool:
     if not segment or not re.match(r"^python(?:\d+(?:\.\d+)?)?$", Path(segment[0]).name):
         return False
 
     for index, token in enumerate(segment[1:], start=1):
         if token == "-c":
-            return index + 1 < len(segment) and re.search(r"\bgit\b.*\bcommit\b", segment[index + 1], re.DOTALL) is not None
+            return index + 1 < len(segment) and RUNTIME_PUBLISH_RE.search(segment[index + 1]) is not None
         if token.startswith("-c") and len(token) > 2:
-            return re.search(r"\bgit\b.*\bcommit\b", token[2:], re.DOTALL) is not None
+            return RUNTIME_PUBLISH_RE.search(token[2:]) is not None
     return False
 
 
-def node_string_contains_commit(segment: list[str]) -> bool:
+def node_string_contains_publish(segment: list[str]) -> bool:
     if not segment or Path(segment[0]).name != "node":
         return False
 
@@ -349,20 +381,20 @@ def node_string_contains_commit(segment: list[str]) -> bool:
         if token in INLINE_RUNTIME_FLAGS:
             if token in {"-p", "--print"} and index + 1 < len(segment) and segment[index + 1].startswith("-"):
                 continue
-            return index + 1 < len(segment) and re.search(r"\bgit\b.*\bcommit\b", segment[index + 1], re.DOTALL) is not None
+            return index + 1 < len(segment) and RUNTIME_PUBLISH_RE.search(segment[index + 1]) is not None
         if token.startswith("--eval=") or token.startswith("--print="):
-            return re.search(r"\bgit\b.*\bcommit\b", token.split("=", 1)[1], re.DOTALL) is not None
+            return RUNTIME_PUBLISH_RE.search(token.split("=", 1)[1]) is not None
         if token.startswith("-") and not token.startswith("--") and "e" in token[1:] and len(token) > 2:
             inline = token[token.index("e") + 1 :]
             if inline:
-                return re.search(r"\bgit\b.*\bcommit\b", inline, re.DOTALL) is not None
-            return index + 1 < len(segment) and re.search(r"\bgit\b.*\bcommit\b", segment[index + 1], re.DOTALL) is not None
+                return RUNTIME_PUBLISH_RE.search(inline) is not None
+            return index + 1 < len(segment) and RUNTIME_PUBLISH_RE.search(segment[index + 1]) is not None
         if token.startswith("-p") and len(token) > 2:
-            return re.search(r"\bgit\b.*\bcommit\b", token[2:], re.DOTALL) is not None
+            return RUNTIME_PUBLISH_RE.search(token[2:]) is not None
     return False
 
 
-def substitution_contains_commit(command: str, depth: int) -> bool:
+def substitution_contains_publish(command: str, depth: int) -> bool:
     substitution_re = re.compile(r"\$\(([^)]*)\)|`([^`]*)`|[<>]\(([^)]*)\)", re.DOTALL)
     for match in substitution_re.finditer(command):
         body = next(group for group in match.groups() if group is not None)
@@ -453,10 +485,10 @@ def xargs_input_info(segment: list[str]) -> tuple[bool, set[str]]:
     return has_external_input, replacement_tokens
 
 
-def xargs_utility_contains_commit(current: list[str], utility_index: int, depth: int) -> bool:
+def xargs_utility_contains_publish(current: list[str], utility_index: int, depth: int) -> bool:
     utility = current[utility_index:]
     has_external_or_replacement_input, replacement_tokens = xargs_input_info(current)
-    if has_external_or_replacement_input and utility and any(token == "commit" for token in utility[1:]):
+    if has_external_or_replacement_input and utility and any(token in PUBLISH_SUBCOMMANDS for token in utility[1:]):
         return True
     if has_external_or_replacement_input and utility and any(
         marker and marker in token and any(config_value_can_define_alias(arg) for arg in utility)
@@ -468,10 +500,10 @@ def xargs_utility_contains_commit(current: list[str], utility_index: int, depth:
         return True
     if git_invocation(utility, depth)[0]:
         return True
-    if is_git_executable(utility[0]) and git_invocation([*utility, "commit"], depth)[0]:
+    if is_git_executable(utility[0]) and git_invocation([*utility, "push"], depth)[0]:
         return True
     if first_token_basename(utility) == "env":
-        if env_split_string_contains_commit(utility, 0, depth) or any(
+        if env_split_string_contains_publish(utility, 0, depth) or any(
             env_split_payload_allows_xargs_input(payload, depth) for payload in env_split_payloads(utility)
         ):
             return True
@@ -480,36 +512,36 @@ def xargs_utility_contains_commit(current: list[str], utility_index: int, depth:
         return True
     if utility and git_invocation(utility, depth)[0]:
         return True
-    if utility and is_git_executable(utility[0]) and git_invocation([*utility, "commit"], depth)[0]:
+    if utility and is_git_executable(utility[0]) and git_invocation([*utility, "push"], depth)[0]:
         return True
     if has_external_or_replacement_input and utility and first_token_basename(utility) in {"eval", *SHELL_INTERPRETERS}:
         return True
     if utility and first_token_basename(utility) in SHELL_INTERPRETERS and any(token in {"<", "<<"} for token in current):
         return True
-    return command_builder_contains_commit(current, utility_index, depth)
+    return command_builder_contains_publish(current, utility_index, depth)
 
 
-def command_builder_contains_commit(segment: list[str], index: int, depth: int) -> bool:
+def command_builder_contains_publish(segment: list[str], index: int, depth: int) -> bool:
     current = segment[index:]
-    if interpreter_string_contains_commit(current, depth) or python_string_contains_commit(current) or node_string_contains_commit(current):
+    if interpreter_string_contains_publish(current, depth) or python_string_contains_publish(current) or node_string_contains_publish(current):
         return True
     if current and first_token_basename(current) in SHELL_INTERPRETERS:
-        return any(re.search(r"\bgit\b.*\bcommit\b", token, re.DOTALL) for token in current[1:])
+        return any(GIT_PUBLISH_RE.search(token) for token in current[1:])
     if current and first_token_basename(current) == "eval":
         nested = " ".join(current[1:])
         return bool(nested and command_decision(nested, depth + 1) != "none")
     if current and first_token_basename(current) == "env":
-        if env_split_string_contains_commit(current, 0, depth) or any(
+        if env_split_string_contains_publish(current, 0, depth) or any(
             env_split_payload_allows_xargs_input(payload, depth) for payload in env_split_payloads(current)
         ):
             return True
         env_index = skip_env_prefix(current, 0)
-        return env_index < len(current) and command_builder_contains_commit(current, env_index, depth)
+        return env_index < len(current) and command_builder_contains_publish(current, env_index, depth)
     if current and first_token_basename(current) == "xargs":
         utility_index = xargs_utility_index(current)
         if utility_index is None:
             return False
-        return xargs_utility_contains_commit(current, utility_index, depth)
+        return xargs_utility_contains_publish(current, utility_index, depth)
     return False
 
 
@@ -521,10 +553,10 @@ def git_invocation(segment: list[str], depth: int) -> tuple[bool, bool]:
     while index < len(segment) and ASSIGNMENT_RE.match(segment[index]):
         has_git_config_assignment = has_git_config_assignment or is_git_config_assignment(segment[index])
         index += 1
-    if command_builder_contains_commit(segment, index, depth):
+    if command_builder_contains_publish(segment, index, depth):
         return True, False
     if index < len(segment) and first_token_basename(segment[index:]) == "env":
-        if env_split_string_contains_commit(segment, index, depth):
+        if env_split_string_contains_publish(segment, index, depth):
             return True, False
         has_git_config_assignment = has_git_config_assignment or env_prefix_has_git_config_assignment(segment, index)
         index = skip_env_prefix(segment, index)
@@ -535,12 +567,15 @@ def git_invocation(segment: list[str], depth: int) -> tuple[bool, bool]:
         index = next_index
     if index < len(segment) and segment[index] == "exec":
         index = skip_exec_prefix(segment, index)
-    if command_builder_contains_commit(segment, index, depth):
+    if command_builder_contains_publish(segment, index, depth):
         return True, False
 
     if index < len(segment) and "$" in segment[index] and any(
-        "$" in token or token == "commit" or config_value_can_define_alias(token) for token in segment[index + 1 :]
+        "$" in token or token in PUBLISH_SUBCOMMANDS or config_value_can_define_alias(token) for token in segment[index + 1 :]
     ):
+        return True, False
+
+    if index < len(segment) and is_git_send_pack_executable(segment[index]):
         return True, False
 
     if index >= len(segment) or not is_git_executable(segment[index]):
@@ -572,32 +607,30 @@ def git_invocation(segment: list[str], depth: int) -> tuple[bool, bool]:
             continue
         break
 
-    is_commit = index < len(segment) and segment[index] == "commit"
-    if index < len(segment) and segment[index] in {"cherry-pick", "merge", "rebase"}:
-        return not any(token in {"--abort", "--quit"} for token in segment[index + 1 :]), False
-    if index < len(segment) and not is_commit and segment[index] not in KNOWN_NON_COMMIT_GIT_SUBCOMMANDS:
+    is_publish = index < len(segment) and segment[index] in PUBLISH_SUBCOMMANDS
+    if index < len(segment) and not is_publish and segment[index] not in KNOWN_NON_PUBLISH_GIT_SUBCOMMANDS:
         return True, False
     if (
         has_git_config_assignment
         and git_index == index - 1
         and index < len(segment)
-        and not is_commit
-        and segment[index] not in KNOWN_NON_COMMIT_GIT_SUBCOMMANDS
+        and not is_publish
+        and segment[index] not in KNOWN_NON_PUBLISH_GIT_SUBCOMMANDS
     ):
         return True, False
-    if not is_commit and index < len(segment) and any("$" in token or token in {"(", ")"} for token in segment[index:]):
+    if not is_publish and index < len(segment) and any("$" in token or token in {"(", ")"} for token in segment[index:]):
         return True, False
     is_direct = (
         len(segment) >= 2
         and segment[0] == "git"
-        and segment[1] == "commit"
+        and segment[1] == "push"
         and git_index == 0
         and index == 1
     )
-    return is_commit, is_direct
+    return is_publish, is_direct
 
 
-def segment_has_embedded_git_commit(segment: list[str]) -> bool:
+def segment_has_embedded_git_publish(segment: list[str]) -> bool:
     if segment and segment[0] == "command" and any(
         token.startswith("-") and not token.startswith("--") and any(flag in token for flag in {"v", "V"})
         for token in segment[1:]
@@ -606,57 +639,53 @@ def segment_has_embedded_git_commit(segment: list[str]) -> bool:
     if segment and re.match(r"^python(?:\d+(?:\.\d+)?)?$", first_token_basename(segment)) and len(segment) > 1 and segment[1] != "-":
         return False
     for index in range(len(segment) - 1):
-        if is_git_executable(segment[index]) and segment[index + 1] == "commit":
+        if is_git_executable(segment[index]) and segment[index + 1] in PUBLISH_SUBCOMMANDS:
+            return True
+        if is_git_send_pack_executable(segment[index]):
             return True
     return False
 
 
-def segment_has_dynamic_git_commit(segment: list[str]) -> bool:
-    return any(re.search(r"\bgit\s*\$.*commit\b|\bgit\$\{[^}]+\}commit\b", token) for token in segment)
+def segment_has_dynamic_git_publish(segment: list[str]) -> bool:
+    return any(DYNAMIC_PUBLISH_RE.search(token) for token in segment)
 
 
 def command_decision(command: str, depth: int = 0) -> Decision:
     if depth > MAX_ENV_SPLIT_DEPTH:
-        return "block" if re.search(r"\bgit\b.*\bcommit\b", command, re.DOTALL) else "none"
+        return "block" if RAW_PUBLISH_RE.search(command) else "none"
 
     forbidden, normalized_command = scan_command(command)
     tokens = shell_tokens(normalized_command)
 
     if tokens is None:
-        return "block" if re.search(r"\bgit\b.*\bcommit\b", command, re.DOTALL) else "none"
+        return "block" if RAW_PUBLISH_RE.search(command) else "none"
 
     segments = split_segments(tokens)
     invocations = [git_invocation(segment, depth) for segment in segments]
-    commit_invocations = [invocation for invocation in invocations if invocation[0]]
-    direct_invocations = [invocation for invocation in commit_invocations if invocation[1]]
-    if not commit_invocations:
-        if any(segment_has_embedded_git_commit(segment) for segment in segments):
+    publish_invocations = [invocation for invocation in invocations if invocation[0]]
+    direct_invocations = [invocation for invocation in publish_invocations if invocation[1]]
+    if not publish_invocations:
+        if any(segment_has_embedded_git_publish(segment) for segment in segments):
             return "block"
-        if any(segment_has_dynamic_git_commit(segment) for segment in segments):
+        if any(segment_has_dynamic_git_publish(segment) for segment in segments):
             return "block"
         if any(
             segment
             and (segment[0].startswith("`") or segment[0].startswith("$(") or segment[0].startswith("$"))
-            and any("commit" in token or config_value_can_define_alias(token) for token in segment[1:])
+            and any(token in PUBLISH_SUBCOMMANDS or config_value_can_define_alias(token) for token in segment[1:])
             for segment in segments
         ):
             return "block"
-        if any(segment and first_token_basename(segment) == "eval" for segment in segments) and re.search(
-            r"\bgit\b.*\bcommit\b", command, re.DOTALL
-        ):
+        if any(segment and first_token_basename(segment) == "eval" for segment in segments) and GIT_PUBLISH_RE.search(command):
             return "block"
-        if any(segment and first_token_basename(segment) in SHELL_INTERPRETERS for segment in segments) and re.search(
-            r"\bgit\b.*\bcommit\b", command, re.DOTALL
-        ):
+        if any(segment and first_token_basename(segment) in SHELL_INTERPRETERS for segment in segments) and GIT_PUBLISH_RE.search(command):
             return "block"
-        if any(segment and first_token_basename(segment) == "python3" and len(segment) > 1 and segment[1] == "-" for segment in segments) and re.search(
-            r"\bgit\b.*\bcommit\b", command, re.DOTALL
-        ):
+        if any(segment and first_token_basename(segment) == "python3" and len(segment) > 1 and segment[1] == "-" for segment in segments) and GIT_PUBLISH_RE.search(command):
             return "block"
         if forbidden and (
-            substitution_contains_commit(command, depth)
-            or SUBSTITUTION_COMMIT_RE.search(command)
-            or DYNAMIC_COMMIT_RE.search(command)
+            substitution_contains_publish(command, depth)
+            or SUBSTITUTION_PUBLISH_RE.search(command)
+            or DYNAMIC_PUBLISH_RE.search(command)
         ):
             return "block"
         return "none"
@@ -664,7 +693,7 @@ def command_decision(command: str, depth: int = 0) -> Decision:
     direct = (
         len(segments) == 1
         and len(direct_invocations) == 1
-        and re.match(r"^\s*git\s+commit(?:\s|$)", command) is not None
+        and re.match(r"^\s*git\s+push(?:\s|$)", command) is not None
     )
     if direct and not forbidden:
         return "allow"
@@ -682,7 +711,7 @@ def run_check(command: list[str], cwd: Path) -> None:
 def main() -> int:
     mode = sys.argv[1] if len(sys.argv) > 1 else "codex"
     if mode not in BLOCK_MESSAGES:
-        print(f"Unknown commit hook mode: {mode}", file=sys.stderr)
+        print(f"Unknown hook mode: {mode}", file=sys.stderr)
         return 2
 
     payload = json.loads(sys.stdin.read() or "{}")


### PR DESCRIPTION
Closes #563

## Summary

- Moves the assistant review/verification gate to direct push commands.
- Keeps local maintenance commands such as commit, rebase, merge, and cherry-pick out of the publish gate.
- Adds regression coverage for direct pushes, wrapped pushes, aliases, dynamic command construction, quoted/escaped push forms, and safe non-push commands.
- Updates Claude/Codex hook config hashes and publish-time gate documentation.

## Test plan

- [x] `python3 scripts/test_commit_hook_config.py`
- [x] `python3 -m py_compile scripts/verify_commit_command_hook.py scripts/test_commit_hook_config.py`
- [x] `python3 -m coverage run scripts/test_commit_hook_config.py`
- [x] `python3 -m coverage report -m scripts/verify_commit_command_hook.py scripts/test_commit_hook_config.py`
- [x] `npx tsc --noEmit`
- [x] `npm run format:check`
- [x] `playwright/typescript/node_modules/.bin/prettier --check docs/CI.md docs/PLAYWRIGHT.md CLAUDE.md .claude/settings.json .codex/hooks.json`
- [x] `git diff --check`
- [x] `deep-review-pro` repeat review: security, project checklist, simplification, code, architecture, docs, Python, and unit-test reviewers returned 0 findings.
