### PR TITLE
Update playwright-report-mcp to 3.2.1

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -28,7 +28,7 @@ command = "npx"
 [mcp_servers.playwright-report-mcp]
 args = [
     "--min-release-age=0",
-    "playwright-report-mcp@3.2.0",
+    "playwright-report-mcp@3.2.1",
 ]
 command = "npx"
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
     },
     "playwright-report-mcp": {
       "command": "npx",
-      "args": ["--min-release-age=0", "playwright-report-mcp@3.2.0"],
+      "args": ["--min-release-age=0", "playwright-report-mcp@3.2.1"],
       "type": "stdio",
       "env": {
         "PW_ALLOWED_DIRS": ".."

--- a/docs/AI_ASSISTANTS.md
+++ b/docs/AI_ASSISTANTS.md
@@ -77,9 +77,9 @@ Five MCP servers are declared in [`.mcp.json`](../.mcp.json) and loaded automati
 
 ### playwright-report-mcp
 
-Runs through `npx playwright-report-mcp@3.2.0`. The version is pinned in `.mcp.json`.
+Runs through `npx playwright-report-mcp@3.2.1`. The version is pinned in `.mcp.json`.
 
-`playwright-report-mcp@3.2.0` declares `node >=22`; use the repository baseline Node.js 26.x for local Playwright, Bruno, and MCP workflows.
+`playwright-report-mcp@3.2.1` declares `node >=22`; use the repository baseline Node.js 26.x for local Playwright, Bruno, and MCP workflows.
 
 Every tool call should pass `workingDirectory: "playwright/typescript"` in the main checkout, or a sibling worktree path such as `"../orwellstat-330/playwright/typescript"`. The default `.` points at the repo root, which has no Playwright config and will fail.
 


### PR DESCRIPTION
## Summary

- Bump `playwright-report-mcp` from 3.2.0 to 3.2.1 in `.mcp.json` and `.codex/config.toml`.
- Update `docs/AI_ASSISTANTS.md` to match the pinned version and retain the documented `node >=22` requirement.

Closes #569

## Test plan

- [x] `npm view playwright-report-mcp@3.2.1 version engines dist-tags time --json`
- [x] `jq empty .mcp.json`
- [x] `python3 -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path(".codex/config.toml").read_text())'`
- [x] `npx prettier --check .mcp.json docs/AI_ASSISTANTS.md`
- [x] `git diff --check`
- [x] MCP `list_tests` with `workingDirectory: "/Users/hubert/source/github/orwellstat/.worktrees/feature-569/playwright/typescript"` returned 134 tests.
- [x] MCP `run_tests` for `tests/navigation.spec.ts` on Chromium exited 0 with 17 expected tests and 0 unexpected failures.
