### PR TITLE
#574 Resolve Bruno axios audit advisory

### DIFF
--- a/bruno/package-lock.json
+++ b/bruno/package-lock.json
@@ -2619,14 +2619,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2643,6 +2644,19 @@
         "js-md4": "^0.3.2"
       }
     },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/axios/node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -2655,6 +2669,20 @@
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
         "node": ">= 6"

--- a/bruno/package.json
+++ b/bruno/package.json
@@ -7,7 +7,7 @@
     "test": "bru run --env production"
   },
   "overrides": {
-    "axios": ">=1.15.2",
+    "axios": ">=1.16.0",
     "fast-xml-parser": ">=5.7.0",
     "picomatch": ">=2.3.2",
     "protobufjs": "7.5.6",


### PR DESCRIPTION
## Summary

- Raise the Bruno axios override to `>=1.16.0`.
- Regenerate `bruno/package-lock.json` so the Bruno tree resolves `axios@1.16.1`.
- Clear the Bruno `npm audit --audit-level=high` gate while leaving existing moderate transitive Bruno advisories unchanged.

Closes #574

## Test plan

- [x] `cd bruno && npm ci`
- [x] `cd bruno && npm audit --audit-level=high`
- [x] `cd bruno && npm ls axios`
- [x] `cd playwright/typescript && npx tsc --noEmit`
- [x] `cd playwright/typescript && npm run format:check`
- [x] `cd bruno && npx bru run --env staging` with required GitHub/local credentials
- [x] Bruno Tests workflow passes on GitHub Actions
