### PR TITLE
#577 Update playwright-report-mcp to 3.2.2

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -28,7 +28,7 @@ command = "npx"
 [mcp_servers.playwright-report-mcp]
 args = [
     "--min-release-age=0",
-    "playwright-report-mcp@3.2.1",
+    "playwright-report-mcp@3.2.2",
 ]
 command = "npx"
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
     },
     "playwright-report-mcp": {
       "command": "npx",
-      "args": ["--min-release-age=0", "playwright-report-mcp@3.2.1"],
+      "args": ["--min-release-age=0", "playwright-report-mcp@3.2.2"],
       "type": "stdio",
       "env": {
         "PW_ALLOWED_DIRS": ".."

--- a/docs/AI_ASSISTANTS.md
+++ b/docs/AI_ASSISTANTS.md
@@ -77,9 +77,9 @@ Five MCP servers are declared in [`.mcp.json`](../.mcp.json) and loaded automati
 
 ### playwright-report-mcp
 
-Runs through `npx playwright-report-mcp@3.2.1`. The version is pinned in `.mcp.json`.
+Runs through `npx playwright-report-mcp@3.2.2`. The version is pinned in `.mcp.json`.
 
-`playwright-report-mcp@3.2.1` declares `node >=22`; use the repository baseline Node.js 26.x for local Playwright, Bruno, and MCP workflows.
+`playwright-report-mcp@3.2.2` declares `node >=22`; use the repository baseline Node.js 26.x for local Playwright, Bruno, and MCP workflows.
 
 Every tool call should pass `workingDirectory: "playwright/typescript"` in the main checkout, or a sibling worktree path such as `"../orwellstat-330/playwright/typescript"`. The default `.` points at the repo root, which has no Playwright config and will fail.
 


### PR DESCRIPTION
Closes #577

## Summary

Updates the repository's Playwright report MCP pin from `playwright-report-mcp@3.2.1` to `playwright-report-mcp@3.2.2` in both assistant MCP configs, and updates the MCP documentation to match.

`npm view playwright-report-mcp@3.2.2 version engines dist-tags time --json` confirms `3.2.2` exists, is the current `latest` dist-tag, and still declares `node >=22`.

## Test plan

- [x] `npm view playwright-report-mcp@3.2.2 version engines dist-tags time --json` confirms version `3.2.2`, `latest`, and `node >=22`.
- [x] `npx tsc --noEmit` from `playwright/typescript`.
- [x] `npm run format:check` from `playwright/typescript`.
- [x] `git diff --check`.
- [x] `.mcp.json` parses as valid JSON.
- [x] MCP `list_tests` with `workingDirectory: ".worktrees/feature-577/playwright/typescript"` returns 134 tests.
- [x] MCP `run_tests` for `tests/navigation.spec.ts` on Chromium exits 0 with 17 expected, 0 unexpected.
