### PR TITLE
#579 Add deep-review-pro token benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ runner/
 
 # Python bytecode
 scripts/__pycache__/
+
+# Generated benchmark fixtures
+docs/deep-review-pro-benchmark/fixtures/high-lines.diff

--- a/docs/AI_ASSISTANTS.md
+++ b/docs/AI_ASSISTANTS.md
@@ -27,6 +27,8 @@ Claude specialist agents live under `.claude/agents/`. Codex wrappers live under
 
 The current `/deep-review-pro` roster is documented in `.claude/skills/deep-review-pro/SKILL.md`.
 
+Token benchmark fixtures and the before/after reporting workflow live in [deep-review-pro-benchmark](deep-review-pro-benchmark/README.md). Use them before and after `/deep-review-pro` prompt or dispatch optimizations so token savings are measured against stable scopes.
+
 ## Codex And Claude Substitutions
 
 When Claude-specific mechanics appear in project docs, use the closest Codex-equivalent workflow:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ This directory contains the long-form reference material for the orwellstat test
 | Understand GitHub Actions workflows                                | [CI.md](CI.md)                                 |
 | Run workflows locally or use self-hosted runners                   | [CI_LOCAL.md](CI_LOCAL.md)                     |
 | Run Bruno API checks                                               | [BRUNO.md](BRUNO.md)                           |
-| Use Claude/Codex/Gemini skills, MCP servers, or worktrees          | [AI_ASSISTANTS.md](AI_ASSISTANTS.md)           |
+| Use Claude/Codex/Gemini skills, MCP servers, worktrees, or benchmarks | [AI_ASSISTANTS.md](AI_ASSISTANTS.md)           |
 | Create issues, estimate work, or interpret project-board fields    | [PROJECT_MANAGEMENT.md](PROJECT_MANAGEMENT.md) |
 | Adapt this repository to another deployment target                 | [FORK.md](FORK.md)                             |
 | Review security policy and AI diagnosis data egress                | [../SECURITY.md](../SECURITY.md)               |
@@ -25,7 +25,7 @@ This directory contains the long-form reference material for the orwellstat test
 - `docs/CI.md` owns workflow behavior, triggers, gates, artifacts, and root automation-script summaries.
 - `docs/CI_LOCAL.md` owns self-hosted runner setup, local `act` usage, local CI compatibility, and related credential hygiene.
 - `docs/BRUNO.md` owns Bruno setup, request behavior, and Bruno CI notes.
-- `docs/AI_ASSISTANTS.md` owns project skills, MCP server setup, and worktree guidance.
+- `docs/AI_ASSISTANTS.md` owns project skills, MCP server setup, worktree guidance, and `/deep-review-pro` benchmark references.
 - `docs/PROJECT_MANAGEMENT.md` owns Project #1 conventions, estimate scales, epic/story rules, dates, and actual hours.
 
 When a change affects a documented behavior, update the focused owner file and only add or adjust the root README summary when the top-level navigation changes.

--- a/docs/deep-review-pro-benchmark/README.md
+++ b/docs/deep-review-pro-benchmark/README.md
@@ -13,8 +13,16 @@ This directory contains repeatable benchmark fixtures for measuring `/deep-revie
 | `workflow` | GitHub Actions workflow diff | CI agent dispatches in addition to always-on agents |
 | `mixed-typescript` | Playwright utility plus MCP TypeScript diff | TypeScript and unit-test agents dispatch in addition to always-on agents |
 | `large-diff` | Docs, Python script, Playwright test, and workflow diff | Every specialist dispatches |
+| `high-lines` | Synthetic 3,000+ line docs, Python, TypeScript, Playwright test, and workflow diff | Every specialist dispatches; stresses high-line-count review behavior |
 
 The `.diff` files in `fixtures/` are stable scope inputs. For controlled benchmark runs, apply one fixture in a disposable worktree so `/deep-review-pro` reviews it through normal local-diff mode, then reset the worktree before applying the next fixture. Do not pass the fixture text as a freeform `/deep-review-pro` argument; freeform mode is reserved for reviewer bias over the current local diff.
+
+`high-lines.diff` is generated on demand to avoid committing a repetitive 3,000+ line payload:
+
+```bash
+python3 scripts/generate-deep-review-high-lines-fixture.py \
+  --out docs/deep-review-pro-benchmark/fixtures/high-lines.diff
+```
 
 ## Capturing Runs
 

--- a/docs/deep-review-pro-benchmark/README.md
+++ b/docs/deep-review-pro-benchmark/README.md
@@ -1,0 +1,112 @@
+# deep-review-pro Token Benchmark
+
+This directory contains repeatable benchmark fixtures for measuring `/deep-review-pro` token usage before and after prompt or dispatch optimizations.
+
+## Fixtures
+
+`fixtures.json` records the expected dispatch shape for each representative scope:
+
+| Fixture | Scope | Expected shape |
+| --- | --- | --- |
+| `docs-only` | Documentation-only diff | Always-on agents dispatch; TypeScript, Python, CI, QA, and unit-test agents skip |
+| `playwright-test` | Playwright spec diff | TypeScript and QA agents dispatch in addition to always-on agents |
+| `workflow` | GitHub Actions workflow diff | CI agent dispatches in addition to always-on agents |
+| `mixed-typescript` | Playwright utility plus MCP TypeScript diff | TypeScript and unit-test agents dispatch in addition to always-on agents |
+| `large-diff` | Docs, Python script, Playwright test, and workflow diff | Every specialist dispatches |
+
+The `.diff` files in `fixtures/` are stable scope inputs. For controlled benchmark runs, apply one fixture in a disposable worktree so `/deep-review-pro` reviews it through normal local-diff mode, then reset the worktree before applying the next fixture. Do not pass the fixture text as a freeform `/deep-review-pro` argument; freeform mode is reserved for reviewer bias over the current local diff.
+
+## Capturing Runs
+
+Create one directory for the baseline run and one for the optimized run. Each run directory should contain a subdirectory per fixture:
+
+```text
+benchmark-runs/
+  before/
+    docs-only/
+      orchestrator-before.json
+      orchestrator-after.json
+      agents/
+        deep-review-security.txt
+        deep-review-project-checklist.txt
+        ...
+  after/
+    docs-only/
+      orchestrator-before.json
+      orchestrator-after.json
+      agents/
+        deep-review-security.txt
+        deep-review-project-checklist.txt
+        ...
+```
+
+For each fixture:
+
+1. Snapshot the current Claude JSONL usage counters to `orchestrator-before.json`.
+2. Run `/deep-review-pro` against the fixture scope.
+3. Snapshot the same counters to `orchestrator-after.json`.
+4. Save each dispatched agent result, including its trailing `<usage>` postscript, as `agents/<agent>.txt`.
+5. Do not create files for skipped agents; skipped counts come from `fixtures.json`.
+
+The preferred orchestrator snapshot files use Claude's raw counter names:
+
+```json
+{
+  "input_tokens": 1200,
+  "output_tokens": 400,
+  "cache_read_input_tokens": 10000,
+  "cache_creation_input_tokens": 300
+}
+```
+
+Create each snapshot from the active Claude JSONL log with:
+
+```bash
+jq -s '
+  map(select(.message.usage) | .message.usage)
+  | {
+      input_tokens: (if all(has("input_tokens")) then map(.input_tokens) | add else null end),
+      output_tokens: (if all(has("output_tokens")) then map(.output_tokens) | add else null end),
+      cache_read_input_tokens: (if all(has("cache_read_input_tokens")) then map(.cache_read_input_tokens) | add else null end),
+      cache_creation_input_tokens: (if all(has("cache_creation_input_tokens")) then map(.cache_creation_input_tokens) | add else null end)
+    }
+' "$SESSION_LOG" > orchestrator-before.json
+```
+
+Run the same command after `/deep-review-pro` and write `orchestrator-after.json`.
+
+When both snapshot files are present, the harness subtracts `before` from `after` and records only the controlled invocation's delta. For older captured runs, a single `orchestrator.jsonl` or `session.jsonl` file is still supported, but that fallback is cumulative for the saved log and should only be used for an isolated fresh Claude session.
+
+The harness intentionally does not invoke Claude Code. It normalizes captured artifacts so optimization branches can compare the same fixture set without relying on live session state.
+
+## Generating Reports
+
+Run:
+
+```bash
+python3 scripts/benchmark-deep-review-pro.py \
+  --before benchmark-runs/before \
+  --after benchmark-runs/after \
+  --out-dir benchmark-runs/report
+```
+
+The command writes:
+
+- `deep-review-pro-benchmark.json` for machine-readable fixture, before, and after data.
+- `deep-review-pro-benchmark.csv` for spreadsheet-friendly deltas.
+- `deep-review-pro-benchmark.md` for the human-readable summary.
+
+## Field Accuracy
+
+Exact fields:
+
+- `dispatched_agents` and `skipped_agents` come from `fixtures.json`.
+- Sub-agent `total_tokens`, `tool_uses`, and `duration_ms` are exact when the saved agent output includes a numeric `<usage>` postscript.
+- Orchestrator `input`, `output`, `cache_read`, and `cache_creation` are exact when both counter snapshots are present and numeric, or when every JSONL `message.usage` record in the fallback log includes the corresponding Claude usage field.
+
+Best-effort or unavailable fields:
+
+- Orchestrator usage depends on Claude Code's undocumented JSONL location and schema. If a snapshot or fallback log is missing, unreadable, invalid, or lacks a field, the harness reports that field as `unavailable`.
+- Sub-agent usage depends on the undocumented `<usage>` postscript. If the postscript or one of its numeric fields is missing, the harness reports that field as `unavailable`.
+- `total_tokens` combines orchestrator input/output with sub-agent totals. If any contributing field is unavailable, the total is also unavailable instead of treating the missing value as zero.
+- `wall_clock_ms` is the sum of sub-agent `duration_ms` values. It does not include top-level orchestration time unless Claude exposes that time in future artifacts.

--- a/docs/deep-review-pro-benchmark/fixtures.json
+++ b/docs/deep-review-pro-benchmark/fixtures.json
@@ -1,0 +1,101 @@
+[
+  {
+    "name": "docs-only",
+    "scope_file": "fixtures/docs-only.diff",
+    "description": "Documentation-only change that should exercise only the always-on agents.",
+    "expected_dispatched": [
+      "deep-review-security",
+      "deep-review-project-checklist",
+      "deep-review-simplification",
+      "deep-review-code",
+      "deep-review-architecture",
+      "deep-review-docs"
+    ],
+    "expected_skipped": [
+      "deep-review-typescript",
+      "deep-review-python",
+      "deep-review-ci",
+      "deep-review-qa",
+      "deep-review-unit-test"
+    ]
+  },
+  {
+    "name": "playwright-test",
+    "scope_file": "fixtures/playwright-test.diff",
+    "description": "Playwright spec change that should dispatch TypeScript and QA specialists.",
+    "expected_dispatched": [
+      "deep-review-security",
+      "deep-review-project-checklist",
+      "deep-review-simplification",
+      "deep-review-code",
+      "deep-review-architecture",
+      "deep-review-docs",
+      "deep-review-typescript",
+      "deep-review-qa"
+    ],
+    "expected_skipped": [
+      "deep-review-python",
+      "deep-review-ci",
+      "deep-review-unit-test"
+    ]
+  },
+  {
+    "name": "workflow",
+    "scope_file": "fixtures/workflow.diff",
+    "description": "GitHub Actions workflow change that should dispatch the CI specialist.",
+    "expected_dispatched": [
+      "deep-review-security",
+      "deep-review-project-checklist",
+      "deep-review-simplification",
+      "deep-review-code",
+      "deep-review-architecture",
+      "deep-review-docs",
+      "deep-review-ci"
+    ],
+    "expected_skipped": [
+      "deep-review-typescript",
+      "deep-review-python",
+      "deep-review-qa",
+      "deep-review-unit-test"
+    ]
+  },
+  {
+    "name": "mixed-typescript",
+    "scope_file": "fixtures/mixed-typescript.diff",
+    "description": "Mixed TypeScript utility and MCP server change that should dispatch TypeScript and unit-test specialists.",
+    "expected_dispatched": [
+      "deep-review-security",
+      "deep-review-project-checklist",
+      "deep-review-simplification",
+      "deep-review-code",
+      "deep-review-architecture",
+      "deep-review-docs",
+      "deep-review-typescript",
+      "deep-review-unit-test"
+    ],
+    "expected_skipped": [
+      "deep-review-python",
+      "deep-review-ci",
+      "deep-review-qa"
+    ]
+  },
+  {
+    "name": "large-diff",
+    "scope_file": "fixtures/large-diff.diff",
+    "description": "Broad multi-area diff that should dispatch every specialist.",
+    "expected_dispatched": [
+      "deep-review-security",
+      "deep-review-project-checklist",
+      "deep-review-simplification",
+      "deep-review-code",
+      "deep-review-architecture",
+      "deep-review-docs",
+      "deep-review-typescript",
+      "deep-review-python",
+      "deep-review-ci",
+      "deep-review-qa",
+      "deep-review-unit-test"
+    ],
+    "expected_skipped": []
+  }
+]

--- a/docs/deep-review-pro-benchmark/fixtures.json
+++ b/docs/deep-review-pro-benchmark/fixtures.json
@@ -97,5 +97,25 @@
       "deep-review-unit-test"
     ],
     "expected_skipped": []
+  },
+  {
+    "name": "high-lines",
+    "scope_file": "fixtures/high-lines.diff",
+    "generator": "scripts/generate-deep-review-high-lines-fixture.py",
+    "description": "Synthetic 3,000+ line broad diff that should dispatch every specialist and stress high-line-count review behavior.",
+    "expected_dispatched": [
+      "deep-review-security",
+      "deep-review-project-checklist",
+      "deep-review-simplification",
+      "deep-review-code",
+      "deep-review-architecture",
+      "deep-review-docs",
+      "deep-review-typescript",
+      "deep-review-python",
+      "deep-review-ci",
+      "deep-review-qa",
+      "deep-review-unit-test"
+    ],
+    "expected_skipped": []
   }
 ]

--- a/docs/deep-review-pro-benchmark/fixtures/docs-only.diff
+++ b/docs/deep-review-pro-benchmark/fixtures/docs-only.diff
@@ -1,0 +1,7 @@
+diff --git a/docs/AI_ASSISTANTS.md b/docs/AI_ASSISTANTS.md
+--- a/docs/AI_ASSISTANTS.md
++++ b/docs/AI_ASSISTANTS.md
+@@ -1,2 +1,3 @@
+ # AI Assistants
+ This file owns project-specific AI assistant workflows.
++Document benchmark fixture behavior.

--- a/docs/deep-review-pro-benchmark/fixtures/large-diff.diff
+++ b/docs/deep-review-pro-benchmark/fixtures/large-diff.diff
@@ -1,0 +1,24 @@
+diff --git a/docs/AI_ASSISTANTS.md b/docs/AI_ASSISTANTS.md
+--- a/docs/AI_ASSISTANTS.md
++++ b/docs/AI_ASSISTANTS.md
+@@ -1,3 +1,4 @@
+ # AI Assistants
++Large benchmark fixture documentation change.
+diff --git a/scripts/self-healing.py b/scripts/self-healing.py
+--- a/scripts/self-healing.py
++++ b/scripts/self-healing.py
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env python3
++FIXTURE_FLAG = True
+diff --git a/playwright/typescript/tests/home.spec.ts b/playwright/typescript/tests/home.spec.ts
+--- a/playwright/typescript/tests/home.spec.ts
++++ b/playwright/typescript/tests/home.spec.ts
+@@ -1,3 +1,4 @@
+ import { test, expect } from '@fixtures/base.fixture';
++test.describe('large fixture', () => {});
+diff --git a/.github/workflows/playwright-run.yml b/.github/workflows/playwright-run.yml
+--- a/.github/workflows/playwright-run.yml
++++ b/.github/workflows/playwright-run.yml
+@@ -1,4 +1,5 @@
+ name: Playwright
++run-name: large benchmark fixture

--- a/docs/deep-review-pro-benchmark/fixtures/mixed-typescript.diff
+++ b/docs/deep-review-pro-benchmark/fixtures/mixed-typescript.diff
@@ -1,0 +1,16 @@
+diff --git a/playwright/typescript/utils/string.util.ts b/playwright/typescript/utils/string.util.ts
+--- a/playwright/typescript/utils/string.util.ts
++++ b/playwright/typescript/utils/string.util.ts
+@@ -1,3 +1,4 @@
+ export function trimValue(value: string): string {
++  const normalized = value;
+   return value.trim();
+ }
+diff --git a/mcp/coverage-matrix/index.ts b/mcp/coverage-matrix/index.ts
+--- a/mcp/coverage-matrix/index.ts
++++ b/mcp/coverage-matrix/index.ts
+@@ -1,3 +1,4 @@
+ export function main(): void {
++  const fixture = true;
+   return;
+ }

--- a/docs/deep-review-pro-benchmark/fixtures/playwright-test.diff
+++ b/docs/deep-review-pro-benchmark/fixtures/playwright-test.diff
@@ -1,0 +1,7 @@
+diff --git a/playwright/typescript/tests/home.spec.ts b/playwright/typescript/tests/home.spec.ts
+--- a/playwright/typescript/tests/home.spec.ts
++++ b/playwright/typescript/tests/home.spec.ts
+@@ -1,2 +1,3 @@
+ import { test, expect } from '@fixtures/base.fixture';
++test.describe('benchmark fixture', () => {});
+ test('home page loads', async ({ page }) => {

--- a/docs/deep-review-pro-benchmark/fixtures/workflow.diff
+++ b/docs/deep-review-pro-benchmark/fixtures/workflow.diff
@@ -1,0 +1,8 @@
+diff --git a/.github/workflows/playwright-run.yml b/.github/workflows/playwright-run.yml
+--- a/.github/workflows/playwright-run.yml
++++ b/.github/workflows/playwright-run.yml
+@@ -1,3 +1,4 @@
+ name: Playwright
++run-name: benchmark fixture
+ on:
+   workflow_dispatch:

--- a/scripts/benchmark-deep-review-pro.py
+++ b/scripts/benchmark-deep-review-pro.py
@@ -233,7 +233,14 @@ def load_fixtures(path=DEFAULT_FIXTURES):
         if not scope_path.is_relative_to(root):
             raise ValueError(f"{path}: scope_file {fixture['scope_file']} resolves outside {root}")
         if not scope_path.exists():
-            raise ValueError(f"{path}: scope_file {fixture['scope_file']} does not exist")
+            generator = fixture.get("generator")
+            if not generator:
+                raise ValueError(f"{path}: scope_file {fixture['scope_file']} does not exist")
+            generator_path = (REPO_ROOT / generator).resolve()
+            if not generator_path.is_relative_to(REPO_ROOT):
+                raise ValueError(f"{path}: generator {generator} resolves outside {REPO_ROOT}")
+            if not generator_path.exists():
+                raise ValueError(f"{path}: generator {generator} does not exist")
     return fixtures
 
 

--- a/scripts/benchmark-deep-review-pro.py
+++ b/scripts/benchmark-deep-review-pro.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Normalize /deep-review-pro token benchmark artifacts.
+
+The script does not invoke Claude Code. It consumes captured artifacts from
+controlled /deep-review-pro runs and writes comparable JSON, CSV, and Markdown
+reports for before/after optimization checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+DEFAULT_FIXTURES = REPO_ROOT / "docs" / "deep-review-pro-benchmark" / "fixtures.json"
+METRIC_FIELDS = (
+    "total_tokens",
+    "dispatched_agents",
+    "skipped_agents",
+    "tool_uses",
+    "wall_clock_ms",
+    "cache_read",
+    "cache_creation",
+)
+ORCHESTRATOR_FIELDS = {
+    "input": "input_tokens",
+    "output": "output_tokens",
+    "cache_read": "cache_read_input_tokens",
+    "cache_creation": "cache_creation_input_tokens",
+}
+AGENT_USAGE_FIELDS = ("total_tokens", "tool_uses", "duration_ms")
+SAFE_FIXTURE_NAME = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+SAFE_AGENT_NAME = re.compile(r"^deep-review-[a-z0-9-]+$")
+
+
+def exact(value):
+    return {"value": value, "availability": "exact"}
+
+
+def unavailable(reason):
+    return {"value": None, "availability": "unavailable", "reason": reason}
+
+
+def metric_value(metric):
+    return metric.get("value") if metric.get("availability") == "exact" else None
+
+
+def render_metric(metric):
+    value = metric_value(metric)
+    return str(value) if value is not None else "unavailable"
+
+
+def render_metric_detail(metric):
+    value = metric_value(metric)
+    if value is not None:
+        return str(value)
+    reason = metric.get("reason")
+    return f"unavailable ({reason})" if reason else "unavailable"
+
+
+def total_metric(run, fixture_name, field):
+    return run["fixtures"][fixture_name]["totals"].get(
+        field,
+        unavailable(f"{field} missing from benchmark input"),
+    )
+
+
+def run_total_metric(run, field):
+    return run["totals"].get(field, unavailable(f"total {field} missing from benchmark input"))
+
+
+def sum_metrics(metrics, field_name):
+    total = 0
+    reasons = []
+    for metric in metrics:
+        value = metric_value(metric)
+        if value is None:
+            reasons.append(metric.get("reason", f"{field_name} unavailable"))
+        else:
+            total += value
+    if reasons:
+        return unavailable("; ".join(reasons))
+    return exact(total)
+
+
+def parse_orchestrator_jsonl(path):
+    records = []
+    try:
+        with path.open() as handle:
+            for line_number, line in enumerate(handle, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    reason = f"{path}:{line_number} is not valid JSON: {exc.msg}"
+                    return {field: unavailable(reason) for field in ORCHESTRATOR_FIELDS}
+                usage = record.get("message", {}).get("usage")
+                if usage is not None:
+                    records.append(usage)
+    except FileNotFoundError:
+        reason = f"{path} missing"
+        return {field: unavailable(reason) for field in ORCHESTRATOR_FIELDS}
+    except OSError as exc:
+        reason = f"{path} unreadable: {exc}"
+        return {field: unavailable(reason) for field in ORCHESTRATOR_FIELDS}
+
+    if not records:
+        reason = f"{path} has no message.usage records"
+        return {field: unavailable(reason) for field in ORCHESTRATOR_FIELDS}
+
+    result = {}
+    for output_field, jsonl_field in ORCHESTRATOR_FIELDS.items():
+        missing_count = sum(1 for usage in records if jsonl_field not in usage)
+        if missing_count:
+            result[output_field] = unavailable(
+                f"{jsonl_field} missing from {missing_count} of {len(records)} usage records"
+            )
+            continue
+        values = []
+        for usage in records:
+            try:
+                values.append(int(usage[jsonl_field]))
+            except (TypeError, ValueError):
+                result[output_field] = unavailable(f"{jsonl_field} is not numeric in {path}")
+                break
+        else:
+            result[output_field] = exact(sum(values))
+    return result
+
+
+def parse_orchestrator_counter_json(path):
+    try:
+        with path.open() as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        reason = f"{path} missing"
+        return {field: unavailable(reason) for field in ORCHESTRATOR_FIELDS}
+    except (OSError, json.JSONDecodeError) as exc:
+        reason = f"{path} unreadable or invalid JSON: {exc}"
+        return {field: unavailable(reason) for field in ORCHESTRATOR_FIELDS}
+
+    result = {}
+    for output_field, counter_field in ORCHESTRATOR_FIELDS.items():
+        if counter_field not in payload:
+            result[output_field] = unavailable(f"{counter_field} missing from {path}")
+            continue
+        try:
+            result[output_field] = exact(int(payload[counter_field]))
+        except (TypeError, ValueError):
+            result[output_field] = unavailable(f"{counter_field} is not numeric in {path}")
+    return result
+
+
+def subtract_orchestrator_counters(before, after):
+    result = {}
+    for field in ORCHESTRATOR_FIELDS:
+        before_value = metric_value(before[field])
+        after_value = metric_value(after[field])
+        if before_value is None or after_value is None:
+            result[field] = unavailable(
+                f"cannot compute {field} delta: "
+                f"before={render_metric_detail(before[field])}, "
+                f"after={render_metric_detail(after[field])}"
+            )
+        else:
+            result[field] = exact(after_value - before_value)
+    return result
+
+
+def parse_orchestrator_usage(fixture_dir):
+    before_snapshot = fixture_dir / "orchestrator-before.json"
+    after_snapshot = fixture_dir / "orchestrator-after.json"
+    if before_snapshot.exists() or after_snapshot.exists():
+        return subtract_orchestrator_counters(
+            parse_orchestrator_counter_json(before_snapshot),
+            parse_orchestrator_counter_json(after_snapshot),
+        )
+    return parse_orchestrator_jsonl(find_orchestrator_log(fixture_dir))
+
+
+def parse_agent_usage(text):
+    matches = re.findall(r"<usage>\s*(.*?)\s*</usage>", text, re.DOTALL)
+    if not matches:
+        return {field: unavailable("missing <usage> postscript") for field in AGENT_USAGE_FIELDS}
+
+    raw_usage = matches[-1].strip()
+    try:
+        usage = json.loads(raw_usage)
+    except json.JSONDecodeError:
+        usage = {}
+        for line in raw_usage.splitlines():
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            usage[key.strip()] = value.strip()
+
+    result = {}
+    for field in AGENT_USAGE_FIELDS:
+        if field not in usage:
+            result[field] = unavailable(f"{field} missing from <usage> postscript")
+            continue
+        try:
+            result[field] = exact(int(usage[field]))
+        except (TypeError, ValueError):
+            result[field] = unavailable(f"{field} in <usage> is not numeric")
+    return result
+
+
+def load_fixtures(path=DEFAULT_FIXTURES):
+    with path.open() as handle:
+        fixtures = json.load(handle)
+
+    root = path.parent.resolve()
+    names = set()
+    for fixture in fixtures:
+        for required in ("name", "scope_file", "description", "expected_dispatched", "expected_skipped"):
+            if required not in fixture:
+                raise ValueError(f"{path}: fixture missing {required}")
+        if not SAFE_FIXTURE_NAME.fullmatch(fixture["name"]):
+            raise ValueError(f"{path}: invalid fixture name {fixture['name']}")
+        if fixture["name"] in names:
+            raise ValueError(f"{path}: duplicate fixture name {fixture['name']}")
+        names.add(fixture["name"])
+        for agent in [*fixture["expected_dispatched"], *fixture["expected_skipped"]]:
+            if not SAFE_AGENT_NAME.fullmatch(agent):
+                raise ValueError(f"{path}: invalid agent name {agent}")
+        scope_path = (root / fixture["scope_file"]).resolve()
+        if not scope_path.is_relative_to(root):
+            raise ValueError(f"{path}: scope_file {fixture['scope_file']} resolves outside {root}")
+        if not scope_path.exists():
+            raise ValueError(f"{path}: scope_file {fixture['scope_file']} does not exist")
+    return fixtures
+
+
+def find_orchestrator_log(fixture_dir):
+    for name in ("orchestrator.jsonl", "session.jsonl"):
+        candidate = fixture_dir / name
+        if candidate.exists():
+            return candidate
+    return fixture_dir / "orchestrator.jsonl"
+
+
+def collect_fixture_run(run_dir, fixture):
+    fixture_dir = run_dir / fixture["name"]
+    orchestrator = parse_orchestrator_usage(fixture_dir)
+    agents = {}
+    for agent in fixture["expected_dispatched"]:
+        agent_path = fixture_dir / "agents" / f"{agent}.txt"
+        try:
+            agent_text = agent_path.read_text()
+        except FileNotFoundError:
+            agent_text = ""
+        agents[agent] = parse_agent_usage(agent_text)
+
+    agent_token_metrics = [usage["total_tokens"] for usage in agents.values()]
+    tool_metrics = [usage["tool_uses"] for usage in agents.values()]
+    wall_metrics = [usage["duration_ms"] for usage in agents.values()]
+    input_tokens = orchestrator["input"]
+    output_tokens = orchestrator["output"]
+
+    token_metrics = [input_tokens, output_tokens, *agent_token_metrics]
+    totals = {
+        "total_tokens": sum_metrics(token_metrics, "total_tokens"),
+        "dispatched_agents": exact(len(fixture["expected_dispatched"])),
+        "skipped_agents": exact(len(fixture["expected_skipped"])),
+        "tool_uses": sum_metrics(tool_metrics, "tool_uses"),
+        "wall_clock_ms": sum_metrics(wall_metrics, "wall_clock_ms"),
+        "cache_read": orchestrator["cache_read"],
+        "cache_creation": orchestrator["cache_creation"],
+    }
+    return {
+        "description": fixture["description"],
+        "scope_file": fixture["scope_file"],
+        "expected_dispatch": {
+            "dispatched": fixture["expected_dispatched"],
+            "skipped": fixture["expected_skipped"],
+        },
+        "orchestrator": orchestrator,
+        "agents": agents,
+        "totals": totals,
+    }
+
+
+def collect_run(run_dir, fixtures):
+    fixture_results = {}
+    for fixture in fixtures:
+        fixture_results[fixture["name"]] = collect_fixture_run(run_dir, fixture)
+
+    totals = {}
+    for field in METRIC_FIELDS:
+        totals[field] = sum_metrics([result["totals"][field] for result in fixture_results.values()], field)
+    return {"run_dir": str(run_dir), "fixtures": fixture_results, "totals": totals}
+
+
+def delta(before_metric, after_metric):
+    before_value = metric_value(before_metric)
+    after_value = metric_value(after_metric)
+    if before_value is None or after_value is None:
+        return "unavailable"
+    return str(after_value - before_value)
+
+
+def comparison_rows(before, after):
+    rows = []
+    fixture_names = sorted(set(before["fixtures"]) | set(after["fixtures"]))
+    for name in fixture_names:
+        for field in METRIC_FIELDS:
+            before_metric = total_metric(before, name, field)
+            after_metric = total_metric(after, name, field)
+            rows.append(
+                {
+                    "fixture": name,
+                    "metric": field,
+                    "before": render_metric(before_metric),
+                    "after": render_metric(after_metric),
+                    "delta": delta(before_metric, after_metric),
+                    "has_unavailable": (
+                        metric_value(before_metric) is None
+                        or metric_value(after_metric) is None
+                    ),
+                }
+            )
+    for field in METRIC_FIELDS:
+        before_total = run_total_metric(before, field)
+        after_total = run_total_metric(after, field)
+        rows.append(
+            {
+                "fixture": "TOTAL",
+                "metric": field,
+                "before": render_metric(before_total),
+                "after": render_metric(after_total),
+                "delta": delta(before_total, after_total),
+                "has_unavailable": (
+                    metric_value(before_total) is None
+                    or metric_value(after_total) is None
+                ),
+            }
+        )
+    return rows
+
+
+def build_comparison_report(before, after):
+    lines = [
+        "# deep-review-pro Token Benchmark",
+        "",
+        "| Fixture | Metric | Before | After | Delta |",
+        "| --- | --- | ---: | ---: | ---: |",
+    ]
+    rows = comparison_rows(before, after)
+    for row in rows:
+        lines.append(
+            f"| {row['fixture']} | {row['metric']} | {row['before']} | {row['after']} | {row['delta']} |"
+        )
+
+    unavailable_notes = [
+        f"{row['fixture'].lower() if row['fixture'] == 'TOTAL' else row['fixture']} {row['metric']} unavailable"
+        for row in rows
+        if row["has_unavailable"]
+    ]
+
+    if unavailable_notes:
+        lines.extend(["", "## Unavailable Fields", ""])
+        lines.extend(f"- {note}" for note in sorted(set(unavailable_notes)))
+    return "\n".join(lines) + "\n"
+
+
+def write_csv(path, before, after):
+    rows = comparison_rows(before, after)
+    fieldnames = ["fixture", "metric", "before", "after", "delta"]
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows({name: row[name] for name in fieldnames} for row in rows)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixtures", type=Path, default=DEFAULT_FIXTURES)
+    parser.add_argument(
+        "--before",
+        type=Path,
+        required=True,
+        help="Directory containing before-run captured artifacts.",
+    )
+    parser.add_argument(
+        "--after",
+        type=Path,
+        required=True,
+        help="Directory containing after-run captured artifacts.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Directory for benchmark JSON, CSV, and Markdown output.",
+    )
+    args = parser.parse_args(argv)
+
+    fixtures = load_fixtures(args.fixtures)
+    before = collect_run(args.before, fixtures)
+    after = collect_run(args.after, fixtures)
+    output = {"fixtures": fixtures, "before": before, "after": after}
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "deep-review-pro-benchmark.json").write_text(json.dumps(output, indent=2) + "\n")
+    write_csv(args.out_dir / "deep-review-pro-benchmark.csv", before, after)
+    (args.out_dir / "deep-review-pro-benchmark.md").write_text(build_comparison_report(before, after))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"benchmark-deep-review-pro failed: {exc}", file=sys.stderr)
+        raise

--- a/scripts/generate-deep-review-high-lines-fixture.py
+++ b/scripts/generate-deep-review-high-lines-fixture.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Generate the high-line-count deep-review-pro benchmark fixture."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+DEFAULT_DOC_LINES = 3025
+DEFAULT_OUT = Path("docs/deep-review-pro-benchmark/fixtures/high-lines.diff")
+
+
+def append_new_file_diff(lines: list[str], path: str, body: list[str]) -> None:
+    lines.extend(
+        [
+            f"diff --git a/{path} b/{path}",
+            "new file mode 100644",
+            "index 0000000..1111111",
+            "--- /dev/null",
+            f"+++ b/{path}",
+            f"@@ -0,0 +1,{len(body)} @@",
+        ]
+    )
+    lines.extend(f"+{line}" for line in body)
+
+
+def build_high_lines_fixture(doc_line_count: int = DEFAULT_DOC_LINES) -> str:
+    doc_body = [
+        "# High Lines Benchmark Fixture",
+        "",
+        "This synthetic file exists only inside the benchmark fixture diff.",
+        "It gives `/deep-review-pro` a stable high-line-count scope without changing production documentation.",
+        "",
+    ]
+    for index in range(1, doc_line_count + 1):
+        doc_body.append(
+            "Synthetic benchmark line "
+            f"{index:04d}: stable large-diff payload for token and dispatch measurement."
+        )
+
+    lines: list[str] = []
+    append_new_file_diff(
+        lines,
+        "docs/deep-review-pro-benchmark/synthetic/high-lines.md",
+        doc_body,
+    )
+    append_new_file_diff(
+        lines,
+        "scripts/deep_review_high_lines_fixture.py",
+        [
+            '"""Synthetic benchmark helper used only by the high-lines fixture diff."""',
+            "",
+            "from __future__ import annotations",
+            "",
+            "",
+            "def summarize_fixture_lines(lines: list[str]) -> dict[str, int]:",
+            '    """Return simple line metrics for benchmark fixture input."""',
+            "    non_empty = [line for line in lines if line.strip()]",
+            "    return {",
+            '        "total": len(lines),',
+            '        "non_empty": len(non_empty),',
+            '        "empty": len(lines) - len(non_empty),',
+            "    }",
+            "",
+            "",
+            "def fixture_name() -> str:",
+            '    """Return the stable fixture identifier."""',
+            '    return "high-lines"',
+        ],
+    )
+    append_new_file_diff(
+        lines,
+        "playwright/typescript/tests/deep-review-high-lines.spec.ts",
+        [
+            "import { expect, test } from '@fixtures/base.fixture';",
+            "import { HIGH_LINES_FIXTURE_NAME, isHighLinesFixture } from '@utils/deep-review-high-lines';",
+            "",
+            "test.describe('high-lines benchmark fixture', { tag: '@regression' }, () => {",
+            "  test('recognizes the high-lines fixture name', async () => {",
+            "    expect(isHighLinesFixture(HIGH_LINES_FIXTURE_NAME)).toBe(true);",
+            "  });",
+            "});",
+        ],
+    )
+    append_new_file_diff(
+        lines,
+        "playwright/typescript/utils/deep-review-high-lines.ts",
+        [
+            "export const HIGH_LINES_FIXTURE_NAME = 'high-lines' as const;",
+            "",
+            "export function isHighLinesFixture(name: string): boolean {",
+            "  return name === HIGH_LINES_FIXTURE_NAME;",
+            "}",
+        ],
+    )
+    append_new_file_diff(
+        lines,
+        ".github/workflows/deep-review-high-lines.yml",
+        [
+            "name: Deep Review High Lines Fixture",
+            "",
+            "on:",
+            "  workflow_dispatch:",
+            "",
+            "jobs:",
+            "  noop:",
+            "    runs-on: ubuntu-latest",
+            "    steps:",
+            "      - name: Print fixture name",
+            "        run: echo high-lines",
+        ],
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help="Path where the generated high-lines diff should be written.",
+    )
+    parser.add_argument(
+        "--doc-lines",
+        type=int,
+        default=DEFAULT_DOC_LINES,
+        help="Number of synthetic documentation payload lines to generate.",
+    )
+    args = parser.parse_args(argv)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(build_high_lines_fixture(args.doc_lines))
+    print(args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_benchmark_deep_review_pro.py
+++ b/scripts/test_benchmark_deep_review_pro.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.util
 import csv
+import io
 import json
 import sys
 import tempfile
@@ -22,6 +23,14 @@ _spec = importlib.util.spec_from_file_location(
 benchmark = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(benchmark)
 sys.modules["benchmark_deep_review_pro"] = benchmark
+
+_generator_spec = importlib.util.spec_from_file_location(
+    "generate_deep_review_high_lines_fixture",
+    Path(__file__).parent / "generate-deep-review-high-lines-fixture.py",
+)
+high_lines_generator = importlib.util.module_from_spec(_generator_spec)
+_generator_spec.loader.exec_module(high_lines_generator)
+sys.modules["generate_deep_review_high_lines_fixture"] = high_lines_generator
 
 
 def write_json(path: Path, value):
@@ -246,6 +255,115 @@ summary: 0 high / 1 medium / 0 low
 
 
 class FixtureTests(unittest.TestCase):
+    def test_default_high_lines_fixture_exercises_full_roster_with_large_diff(self):
+        fixtures = benchmark.load_fixtures()
+        high_lines = next(fixture for fixture in fixtures if fixture["name"] == "high-lines")
+        diff_text = high_lines_generator.build_high_lines_fixture()
+        added_lines = sum(
+            1 for line in diff_text.splitlines() if line.startswith("+") and not line.startswith("+++")
+        )
+
+        self.assertGreaterEqual(added_lines, 3000)
+        self.assertEqual(high_lines["generator"], "scripts/generate-deep-review-high-lines-fixture.py")
+        self.assertEqual(high_lines["expected_skipped"], [])
+        self.assertEqual(
+            set(high_lines["expected_dispatched"]),
+            {
+                "deep-review-security",
+                "deep-review-project-checklist",
+                "deep-review-simplification",
+                "deep-review-code",
+                "deep-review-architecture",
+                "deep-review-docs",
+                "deep-review-typescript",
+                "deep-review-python",
+                "deep-review-ci",
+                "deep-review-qa",
+                "deep-review-unit-test",
+            },
+        )
+
+    def test_high_lines_generator_writes_requested_output_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "high-lines.diff"
+
+            with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                exit_code = high_lines_generator.main(
+                    ["--out", str(out_path), "--doc-lines", "3"]
+                )
+
+            generated = out_path.read_text()
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn(str(out_path), stdout.getvalue())
+        self.assertIn("Synthetic benchmark line 0003", generated)
+        self.assertIn("+++ b/playwright/typescript/tests/deep-review-high-lines.spec.ts", generated)
+        self.assertIn("+++ b/.github/workflows/deep-review-high-lines.yml", generated)
+
+    def test_fixture_with_missing_scope_file_can_reference_repo_generator(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "generated",
+                        "scope_file": "fixtures/generated.diff",
+                        "generator": "scripts/generate-deep-review-high-lines-fixture.py",
+                        "description": "Generated fixture.",
+                        "expected_dispatched": ["deep-review-docs"],
+                        "expected_skipped": [],
+                    }
+                ],
+            )
+
+            fixtures = benchmark.load_fixtures(fixtures_path)
+
+        self.assertEqual(fixtures[0]["name"], "generated")
+
+    def test_rejects_generated_fixture_with_generator_outside_repo(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "generated",
+                        "scope_file": "fixtures/generated.diff",
+                        "generator": "/tmp/outside-generator.py",
+                        "description": "Generated fixture.",
+                        "expected_dispatched": ["deep-review-docs"],
+                        "expected_skipped": [],
+                    }
+                ],
+            )
+
+            with self.assertRaisesRegex(ValueError, "generator .* resolves outside"):
+                benchmark.load_fixtures(fixtures_path)
+
+    def test_rejects_generated_fixture_with_missing_generator(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "generated",
+                        "scope_file": "fixtures/generated.diff",
+                        "generator": "scripts/missing-generator.py",
+                        "description": "Generated fixture.",
+                        "expected_dispatched": ["deep-review-docs"],
+                        "expected_skipped": [],
+                    }
+                ],
+            )
+
+            with self.assertRaisesRegex(ValueError, "generator .* does not exist"):
+                benchmark.load_fixtures(fixtures_path)
+
     def test_fixture_metadata_records_expected_dispatch_shape(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/scripts/test_benchmark_deep_review_pro.py
+++ b/scripts/test_benchmark_deep_review_pro.py
@@ -1,0 +1,696 @@
+"""Unit tests for scripts/benchmark-deep-review-pro.py.
+
+Usage:
+    python3 scripts/test_benchmark_deep_review_pro.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import csv
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_spec = importlib.util.spec_from_file_location(
+    "benchmark_deep_review_pro",
+    Path(__file__).parent / "benchmark-deep-review-pro.py",
+)
+benchmark = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(benchmark)
+sys.modules["benchmark_deep_review_pro"] = benchmark
+
+
+def write_json(path: Path, value):
+    path.write_text(json.dumps(value, indent=2) + "\n")
+
+
+def write_run_fixture(run_dir: Path, fixture_name: str, agents, *, input_tokens=10):
+    fixture_dir = run_dir / fixture_name
+    (fixture_dir / "agents").mkdir(parents=True)
+    (fixture_dir / "orchestrator.jsonl").write_text(
+        json.dumps(
+            {
+                "message": {
+                    "usage": {
+                        "input_tokens": input_tokens,
+                        "output_tokens": 5,
+                        "cache_read_input_tokens": 2,
+                        "cache_creation_input_tokens": 1,
+                    }
+                }
+            }
+        )
+        + "\n"
+    )
+    for agent in agents:
+        (fixture_dir / "agents" / f"{agent}.txt").write_text(
+            "<usage>\n"
+            '{"total_tokens": 20, "tool_uses": 3, "duration_ms": 40}'
+            "\n</usage>\n"
+        )
+
+
+class OrchestratorUsageTests(unittest.TestCase):
+    def test_sums_exact_jsonl_usage_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "session.jsonl"
+            log.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "message": {
+                                    "usage": {
+                                        "input_tokens": 10,
+                                        "output_tokens": 5,
+                                        "cache_read_input_tokens": 2,
+                                        "cache_creation_input_tokens": 1,
+                                    }
+                                }
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "message": {
+                                    "usage": {
+                                        "input_tokens": 3,
+                                        "output_tokens": 7,
+                                        "cache_read_input_tokens": 11,
+                                        "cache_creation_input_tokens": 13,
+                                    }
+                                }
+                            }
+                        ),
+                    ]
+                )
+                + "\n"
+            )
+
+            result = benchmark.parse_orchestrator_jsonl(log)
+
+        self.assertEqual(result["input"], {"value": 13, "availability": "exact"})
+        self.assertEqual(result["output"], {"value": 12, "availability": "exact"})
+        self.assertEqual(result["cache_read"], {"value": 13, "availability": "exact"})
+        self.assertEqual(result["cache_creation"], {"value": 14, "availability": "exact"})
+
+    def test_missing_jsonl_field_is_unavailable_not_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "session.jsonl"
+            log.write_text(
+                json.dumps(
+                    {
+                        "message": {
+                            "usage": {
+                                "input_tokens": 10,
+                                "output_tokens": 5,
+                            }
+                        }
+                    }
+                )
+                + "\n"
+            )
+
+            result = benchmark.parse_orchestrator_jsonl(log)
+
+        self.assertEqual(result["input"], {"value": 10, "availability": "exact"})
+        self.assertEqual(result["cache_read"]["value"], None)
+        self.assertEqual(result["cache_read"]["availability"], "unavailable")
+        self.assertIn("cache_read_input_tokens", result["cache_read"]["reason"])
+
+    def test_missing_jsonl_file_marks_every_orchestrator_field_unavailable(self):
+        result = benchmark.parse_orchestrator_jsonl(Path("/tmp/does-not-exist.jsonl"))
+
+        for field in ("input", "output", "cache_read", "cache_creation"):
+            self.assertEqual(result[field]["value"], None)
+            self.assertEqual(result[field]["availability"], "unavailable")
+
+    def test_unreadable_jsonl_path_marks_every_orchestrator_field_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = benchmark.parse_orchestrator_jsonl(Path(tmp))
+
+        for field in ("input", "output", "cache_read", "cache_creation"):
+            self.assertEqual(result[field]["value"], None)
+            self.assertEqual(result[field]["availability"], "unavailable")
+            self.assertIn("unreadable", result[field]["reason"])
+
+    def test_invalid_jsonl_and_nonnumeric_fields_are_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            invalid = Path(tmp) / "invalid.jsonl"
+            invalid.write_text("{not json}\n")
+            invalid_result = benchmark.parse_orchestrator_jsonl(invalid)
+
+            nonnumeric = Path(tmp) / "nonnumeric.jsonl"
+            nonnumeric.write_text(
+                json.dumps(
+                    {
+                        "message": {
+                            "usage": {
+                                "input_tokens": "ten",
+                                "output_tokens": 5,
+                                "cache_read_input_tokens": 2,
+                                "cache_creation_input_tokens": 1,
+                            }
+                        }
+                    }
+                )
+                + "\n"
+            )
+            nonnumeric_result = benchmark.parse_orchestrator_jsonl(nonnumeric)
+
+        self.assertEqual(invalid_result["input"]["availability"], "unavailable")
+        self.assertIn("not valid JSON", invalid_result["input"]["reason"])
+        self.assertEqual(nonnumeric_result["input"]["availability"], "unavailable")
+        self.assertIn("not numeric", nonnumeric_result["input"]["reason"])
+
+    def test_jsonl_without_usage_records_is_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "session.jsonl"
+            log.write_text(json.dumps({"message": {}}) + "\n")
+
+            result = benchmark.parse_orchestrator_jsonl(log)
+
+        self.assertEqual(result["input"]["availability"], "unavailable")
+        self.assertIn("no message.usage", result["input"]["reason"])
+
+
+class AgentUsageTests(unittest.TestCase):
+    def test_parses_json_usage_postscript(self):
+        text = """findings: none
+summary: 0 high / 0 medium / 0 low
+<usage>
+{"total_tokens": 123, "tool_uses": 4, "duration_ms": 5678}
+</usage>
+"""
+
+        result = benchmark.parse_agent_usage(text)
+
+        self.assertEqual(result["total_tokens"], {"value": 123, "availability": "exact"})
+        self.assertEqual(result["tool_uses"], {"value": 4, "availability": "exact"})
+        self.assertEqual(result["duration_ms"], {"value": 5678, "availability": "exact"})
+
+    def test_missing_postscript_is_unavailable_not_zero(self):
+        result = benchmark.parse_agent_usage("Failures: none.\nsummary: 1 pass / 0 fail / 3 N/A\n")
+
+        for field in ("total_tokens", "tool_uses", "duration_ms"):
+            self.assertEqual(result[field]["value"], None)
+            self.assertEqual(result[field]["availability"], "unavailable")
+            self.assertIn("<usage>", result[field]["reason"])
+
+    def test_parses_key_value_usage_postscript_and_marks_bad_values_unavailable(self):
+        text = """<usage>
+total_tokens: 12
+tool_uses: invalid
+ignored line
+duration_ms: 34
+</usage>
+"""
+
+        result = benchmark.parse_agent_usage(text)
+
+        self.assertEqual(result["total_tokens"], {"value": 12, "availability": "exact"})
+        self.assertEqual(result["duration_ms"], {"value": 34, "availability": "exact"})
+        self.assertEqual(result["tool_uses"]["availability"], "unavailable")
+        self.assertIn("not numeric", result["tool_uses"]["reason"])
+
+    def test_parses_trailing_usage_postscript_when_findings_contain_usage_text(self):
+        text = """MEDIUM | docs | finding mentions
+<usage>{"total_tokens": 1, "tool_uses": 1, "duration_ms": 1}</usage>
+summary: 0 high / 1 medium / 0 low
+<usage>
+{"total_tokens": 123, "tool_uses": 4, "duration_ms": 5678}
+</usage>
+"""
+
+        result = benchmark.parse_agent_usage(text)
+
+        self.assertEqual(result["total_tokens"], {"value": 123, "availability": "exact"})
+        self.assertEqual(result["tool_uses"], {"value": 4, "availability": "exact"})
+        self.assertEqual(result["duration_ms"], {"value": 5678, "availability": "exact"})
+
+    def test_partial_usage_postscript_marks_missing_fields_unavailable(self):
+        text = """<usage>
+{"total_tokens": 123, "tool_uses": 4}
+</usage>
+"""
+
+        result = benchmark.parse_agent_usage(text)
+
+        self.assertEqual(result["total_tokens"], {"value": 123, "availability": "exact"})
+        self.assertEqual(result["tool_uses"], {"value": 4, "availability": "exact"})
+        self.assertEqual(result["duration_ms"]["availability"], "unavailable")
+        self.assertIn("duration_ms missing", result["duration_ms"]["reason"])
+
+
+class FixtureTests(unittest.TestCase):
+    def test_fixture_metadata_records_expected_dispatch_shape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            scope_file = root / "docs-only.diff"
+            scope_file.write_text("+++ b/docs/AI_ASSISTANTS.md\n")
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "docs-only",
+                        "scope_file": "docs-only.diff",
+                        "description": "Documentation-only change.",
+                        "expected_dispatched": [
+                            "deep-review-security",
+                            "deep-review-docs",
+                        ],
+                        "expected_skipped": [
+                            "deep-review-typescript",
+                        ],
+                    }
+                ],
+            )
+
+            fixtures = benchmark.load_fixtures(fixtures_path)
+
+        self.assertEqual(fixtures[0]["name"], "docs-only")
+        self.assertIn("deep-review-docs", fixtures[0]["expected_dispatched"])
+        self.assertIn("deep-review-typescript", fixtures[0]["expected_skipped"])
+
+    def test_rejects_agent_names_with_path_separators(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            (root / "scope.diff").write_text("+++ b/docs/AI_ASSISTANTS.md\n")
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "bad-agent",
+                        "scope_file": "scope.diff",
+                        "description": "Bad fixture.",
+                        "expected_dispatched": ["../outside"],
+                        "expected_skipped": [],
+                    }
+                ],
+            )
+
+            with self.assertRaisesRegex(ValueError, "invalid agent name"):
+                benchmark.load_fixtures(fixtures_path)
+
+    def test_rejects_scope_files_outside_fixture_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "bad-scope",
+                        "scope_file": "../outside.diff",
+                        "description": "Bad fixture.",
+                        "expected_dispatched": ["deep-review-docs"],
+                        "expected_skipped": [],
+                    }
+                ],
+            )
+
+            with self.assertRaisesRegex(ValueError, "scope_file"):
+                benchmark.load_fixtures(fixtures_path)
+
+    def test_rejects_duplicate_and_invalid_fixture_names(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            (root / "scope.diff").write_text("+++ b/docs/AI_ASSISTANTS.md\n")
+            fixture = {
+                "name": "duplicate",
+                "scope_file": "scope.diff",
+                "description": "Duplicate fixture.",
+                "expected_dispatched": ["deep-review-docs"],
+                "expected_skipped": [],
+            }
+            write_json(fixtures_path, [fixture, fixture])
+
+            with self.assertRaisesRegex(ValueError, "duplicate fixture name"):
+                benchmark.load_fixtures(fixtures_path)
+
+            fixture["name"] = "../bad"
+            write_json(fixtures_path, [fixture])
+            with self.assertRaisesRegex(ValueError, "invalid fixture name"):
+                benchmark.load_fixtures(fixtures_path)
+
+    def test_rejects_missing_scope_file_inside_fixture_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "missing-scope",
+                        "scope_file": "missing.diff",
+                        "description": "Missing scope fixture.",
+                        "expected_dispatched": ["deep-review-docs"],
+                        "expected_skipped": [],
+                    }
+                ],
+            )
+
+            with self.assertRaisesRegex(ValueError, "does not exist"):
+                benchmark.load_fixtures(fixtures_path)
+
+    def test_rejects_fixture_missing_required_metadata_field(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            (root / "scope.diff").write_text("+++ b/docs/AI_ASSISTANTS.md\n")
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "missing-description",
+                        "scope_file": "scope.diff",
+                        "expected_dispatched": ["deep-review-docs"],
+                        "expected_skipped": [],
+                    }
+                ],
+            )
+
+            with self.assertRaisesRegex(ValueError, "fixture missing description"):
+                benchmark.load_fixtures(fixtures_path)
+
+
+class RunCollectionTests(unittest.TestCase):
+    def test_collect_run_handles_empty_fixture_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = benchmark.collect_run(Path(tmp), [])
+
+        self.assertEqual(result["fixtures"], {})
+        for field in benchmark.METRIC_FIELDS:
+            self.assertEqual(result["totals"][field], {"value": 0, "availability": "exact"})
+
+    def test_collect_run_main_and_csv_outputs_include_all_metrics(self):
+        agents = ["deep-review-security", "deep-review-docs"]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            (root / "scope.diff").write_text("+++ b/docs/AI_ASSISTANTS.md\n")
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "docs-only",
+                        "scope_file": "scope.diff",
+                        "description": "Docs fixture.",
+                        "expected_dispatched": agents,
+                        "expected_skipped": ["deep-review-typescript"],
+                    }
+                ],
+            )
+            write_run_fixture(root / "before", "docs-only", agents, input_tokens=10)
+            write_run_fixture(root / "after", "docs-only", agents, input_tokens=7)
+
+            fixtures = benchmark.load_fixtures(fixtures_path)
+            before = benchmark.collect_run(root / "before", fixtures)
+            self.assertEqual(before["fixtures"]["docs-only"]["totals"]["total_tokens"]["value"], 55)
+            self.assertEqual(before["totals"]["dispatched_agents"]["value"], 2)
+
+            csv_path = root / "comparison.csv"
+            benchmark.write_csv(csv_path, before, before)
+            with csv_path.open() as handle:
+                rows = list(csv.DictReader(handle))
+            self.assertEqual(rows[0]["metric"], "total_tokens")
+            self.assertEqual(rows[0]["before"], "55")
+            self.assertEqual(rows[1]["metric"], "dispatched_agents")
+            self.assertEqual(rows[1]["before"], "2")
+
+            out_dir = root / "out"
+            benchmark.main(
+                [
+                    "--fixtures",
+                    str(fixtures_path),
+                    "--before",
+                    str(root / "before"),
+                    "--after",
+                    str(root / "after"),
+                    "--out-dir",
+                    str(out_dir),
+                ]
+            )
+
+            self.assertTrue((out_dir / "deep-review-pro-benchmark.json").exists())
+            self.assertTrue((out_dir / "deep-review-pro-benchmark.csv").exists())
+            markdown = (out_dir / "deep-review-pro-benchmark.md").read_text()
+            self.assertIn("| docs-only | total_tokens | 55 | 52 | -3 |", markdown)
+
+    def test_collect_run_aggregates_multiple_fixtures(self):
+        agents = ["deep-review-security"]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures = [
+                {
+                    "name": "docs-only",
+                    "scope_file": "scope-a.diff",
+                    "description": "Docs fixture.",
+                    "expected_dispatched": agents,
+                    "expected_skipped": [],
+                },
+                {
+                    "name": "workflow",
+                    "scope_file": "scope-b.diff",
+                    "description": "Workflow fixture.",
+                    "expected_dispatched": agents,
+                    "expected_skipped": ["deep-review-ci"],
+                },
+            ]
+            write_run_fixture(root / "run", "docs-only", agents, input_tokens=10)
+            write_run_fixture(root / "run", "workflow", agents, input_tokens=20)
+
+            result = benchmark.collect_run(root / "run", fixtures)
+
+        self.assertEqual(result["totals"]["total_tokens"], {"value": 80, "availability": "exact"})
+        self.assertEqual(result["totals"]["dispatched_agents"], {"value": 2, "availability": "exact"})
+        self.assertEqual(result["totals"]["skipped_agents"], {"value": 1, "availability": "exact"})
+
+    def test_collect_run_prefers_orchestrator_counter_snapshot_delta(self):
+        agents = ["deep-review-security"]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = {
+                "name": "docs-only",
+                "scope_file": "scope.diff",
+                "description": "Docs fixture.",
+                "expected_dispatched": agents,
+                "expected_skipped": [],
+            }
+            fixture_dir = root / "run" / "docs-only"
+            (fixture_dir / "agents").mkdir(parents=True)
+            (fixture_dir / "orchestrator.jsonl").write_text(
+                json.dumps(
+                    {
+                        "message": {
+                            "usage": {
+                                "input_tokens": 999,
+                                "output_tokens": 999,
+                                "cache_read_input_tokens": 999,
+                                "cache_creation_input_tokens": 999,
+                            }
+                        }
+                    }
+                )
+                + "\n"
+            )
+            write_json(
+                fixture_dir / "orchestrator-before.json",
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_input_tokens": 20,
+                    "cache_creation_input_tokens": 10,
+                },
+            )
+            write_json(
+                fixture_dir / "orchestrator-after.json",
+                {
+                    "input_tokens": 130,
+                    "output_tokens": 70,
+                    "cache_read_input_tokens": 25,
+                    "cache_creation_input_tokens": 12,
+                },
+            )
+            (fixture_dir / "agents" / "deep-review-security.txt").write_text(
+                '<usage>{"total_tokens": 10, "tool_uses": 1, "duration_ms": 2}</usage>'
+            )
+
+            result = benchmark.collect_fixture_run(root / "run", fixture)
+
+        self.assertEqual(result["orchestrator"]["input"], {"value": 30, "availability": "exact"})
+        self.assertEqual(result["orchestrator"]["output"], {"value": 20, "availability": "exact"})
+        self.assertEqual(result["orchestrator"]["cache_read"], {"value": 5, "availability": "exact"})
+        self.assertEqual(result["orchestrator"]["cache_creation"], {"value": 2, "availability": "exact"})
+
+    def test_snapshot_errors_are_reported_as_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture_dir = root / "docs-only"
+            fixture_dir.mkdir()
+            (fixture_dir / "orchestrator-before.json").write_text("{not json}\n")
+            write_json(
+                fixture_dir / "orchestrator-after.json",
+                {
+                    "input_tokens": "bad",
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 2,
+                },
+            )
+
+            result = benchmark.parse_orchestrator_usage(fixture_dir)
+
+        self.assertEqual(result["input"]["availability"], "unavailable")
+        self.assertEqual(result["output"]["availability"], "unavailable")
+        self.assertEqual(result["cache_read"]["availability"], "unavailable")
+        self.assertIn("cannot compute", result["input"]["reason"])
+
+    def test_partial_snapshot_pair_reports_missing_counter_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture_dir = root / "docs-only"
+            fixture_dir.mkdir()
+            write_json(
+                fixture_dir / "orchestrator-before.json",
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 5,
+                    "cache_creation_input_tokens": 2,
+                },
+            )
+
+            result = benchmark.parse_orchestrator_usage(fixture_dir)
+
+        for field in ("input", "output", "cache_read", "cache_creation"):
+            self.assertEqual(result[field]["availability"], "unavailable")
+            self.assertIn("cannot compute", result[field]["reason"])
+            self.assertIn("orchestrator-after.json missing", result[field]["reason"])
+
+    def test_missing_agent_output_is_reported_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = {
+                "name": "docs-only",
+                "scope_file": "scope.diff",
+                "description": "Docs fixture.",
+                "expected_dispatched": ["deep-review-security"],
+                "expected_skipped": [],
+            }
+            fixture_dir = root / "run" / "docs-only"
+            (fixture_dir / "agents").mkdir(parents=True)
+            (fixture_dir / "orchestrator.jsonl").write_text(
+                json.dumps(
+                    {
+                        "message": {
+                            "usage": {
+                                "input_tokens": 1,
+                                "output_tokens": 2,
+                                "cache_read_input_tokens": 3,
+                                "cache_creation_input_tokens": 4,
+                            }
+                        }
+                    }
+                )
+                + "\n"
+            )
+
+            result = benchmark.collect_fixture_run(root / "run", fixture)
+
+        self.assertEqual(
+            result["agents"]["deep-review-security"]["total_tokens"]["availability"],
+            "unavailable",
+        )
+        self.assertIn(
+            "missing <usage>",
+            result["agents"]["deep-review-security"]["total_tokens"]["reason"],
+        )
+
+    def test_main_uses_sys_argv_when_argv_is_none(self):
+        agents = ["deep-review-security"]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixtures_path = root / "fixtures.json"
+            (root / "scope.diff").write_text("+++ b/docs/AI_ASSISTANTS.md\n")
+            write_json(
+                fixtures_path,
+                [
+                    {
+                        "name": "docs-only",
+                        "scope_file": "scope.diff",
+                        "description": "Docs fixture.",
+                        "expected_dispatched": agents,
+                        "expected_skipped": [],
+                    }
+                ],
+            )
+            write_run_fixture(root / "before", "docs-only", agents, input_tokens=10)
+            write_run_fixture(root / "after", "docs-only", agents, input_tokens=9)
+            out_dir = root / "out"
+
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "benchmark-deep-review-pro.py",
+                    "--fixtures",
+                    str(fixtures_path),
+                    "--before",
+                    str(root / "before"),
+                    "--after",
+                    str(root / "after"),
+                    "--out-dir",
+                    str(out_dir),
+                ],
+            ):
+                benchmark.main()
+
+            self.assertTrue((out_dir / "deep-review-pro-benchmark.md").exists())
+
+
+class ReportTests(unittest.TestCase):
+    def test_builds_before_after_report_with_numeric_and_unavailable_deltas(self):
+        before = {
+            "fixtures": {
+                "docs-only": {
+                    "totals": {
+                        "total_tokens": {"value": 100, "availability": "exact"},
+                        "tool_uses": {"value": 6, "availability": "exact"},
+                    }
+                }
+            },
+            "totals": {
+                "total_tokens": {"value": 100, "availability": "exact"},
+                "tool_uses": {"value": 6, "availability": "exact"},
+            },
+        }
+        after = {
+            "fixtures": {
+                "docs-only": {
+                    "totals": {
+                        "total_tokens": {"value": 80, "availability": "exact"},
+                        "tool_uses": {"value": None, "availability": "unavailable", "reason": "missing <usage>"},
+                    }
+                }
+            },
+            "totals": {
+                "total_tokens": {"value": 80, "availability": "exact"},
+                "tool_uses": {"value": None, "availability": "unavailable", "reason": "missing <usage>"},
+            },
+        }
+
+        report = benchmark.build_comparison_report(before, after)
+
+        self.assertIn("| docs-only | total_tokens | 100 | 80 | -20 |", report)
+        self.assertIn("| TOTAL | total_tokens | 100 | 80 | -20 |", report)
+        self.assertIn("tool_uses unavailable", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add stable `/deep-review-pro` benchmark fixtures for docs-only, Playwright test, workflow, mixed TypeScript, and large-diff scopes.
- Add `scripts/benchmark-deep-review-pro.py` to normalize captured Claude orchestrator snapshots and sub-agent `<usage>` postscripts into JSON, CSV, and Markdown before/after reports.
- Document the benchmark capture workflow, exact versus unavailable token fields, and link it from the AI assistant docs.

Closes #579
Contributes to #587

## Test plan

- [x] `python3 scripts/test_benchmark_deep_review_pro.py`
- [x] `python3 -m unittest discover scripts 'test_*.py'`
- [x] `python3 -m coverage run scripts/test_benchmark_deep_review_pro.py`
- [x] `python3 -m coverage report -m scripts/benchmark-deep-review-pro.py scripts/test_benchmark_deep_review_pro.py`
- [x] `python3 -m json.tool docs/deep-review-pro-benchmark/fixtures.json >/dev/null`
- [x] Snapshot-based CLI smoke test generated JSON, CSV, and Markdown artifacts in a temporary directory.
- [x] GitHub Actions CI completes on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable benchmark tool and fixtures to capture and compare token usage before/after optimizations, plus a generator for large "high-lines" fixtures.

* **Documentation**
  * Updated docs and index to include benchmark guidance, benchmarks entry, and instructions for running reports.

* **Tests**
  * Added end-to-end and unit tests validating fixture loading, metric extraction, error handling, and report generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->