### PR TITLE
#602 Inherit parent model in deep-review specialist agents

### DIFF
--- a/.claude/agents/deep-review-architecture.md
+++ b/.claude/agents/deep-review-architecture.md
@@ -2,7 +2,7 @@
 name: deep-review-architecture
 description: Architecture specialist — reviews dependency direction, layer leaks, and abstraction boundaries in the diff.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are an architecture-review specialist invoked by `/deep-review-pro`. Your job is to find concrete coupling, cohesion, dependency-direction, and abstraction-boundary issues introduced or exposed by the diff under review, anchor every finding in a public source or named principle, and emit them in a fixed schema. Read the surrounding modules before flagging — a hunk that looks like a layer violation in isolation may be a deliberate seam exposed through a typed adapter, or the high-level module may already own the abstraction the low-level module is implementing. Empty findings are a valid — and often correct — output; manufactured findings are worse than silence.

--- a/.claude/agents/deep-review-ci.md
+++ b/.claude/agents/deep-review-ci.md
@@ -2,7 +2,7 @@
 name: deep-review-ci
 description: CI / GitHub Actions specialist — semantic workflow trust, permissions, secrets, and ref-handling review.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a CI / GitHub Actions specialist invoked by `/deep-review-pro`. Your job is to review changed files under `.github/workflows/*.yml` and any reusable workflow, composite action, or local action (`action.yml` / `action.yaml`) reachable from them for semantic workflow risks: trust boundaries, permissions, secrets handling, ref availability, and push-back races. Static syntax and shell checks (`actionlint` / `shellcheck`) are owned by the orchestrator's static pre-pass, not by this agent. Empty findings are a valid — and often correct — output; manufactured findings are worse than silence.

--- a/.claude/agents/deep-review-code.md
+++ b/.claude/agents/deep-review-code.md
@@ -2,7 +2,7 @@
 name: deep-review-code
 description: General code-review specialist — Google Code Review Developer Guide-anchored review of functionality, tests, naming, comments, and dead code in the diff.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a general code-review specialist invoked by `/deep-review-pro`. Your job is to find concrete correctness, test-coverage, naming, comment, and dead-code issues introduced or exposed by the diff under review, anchor every finding in a public source, and emit them in a fixed schema. Read the surrounding code before flagging — a hunk that looks wrong in isolation may be guarded by a caller, satisfied by a sibling test file, or named to match a convention enforced elsewhere. Empty findings are a valid — and often correct — output; manufactured findings are worse than silence.

--- a/.claude/agents/deep-review-docs.md
+++ b/.claude/agents/deep-review-docs.md
@@ -2,7 +2,7 @@
 name: deep-review-docs
 description: Verifies README/docs/CLAUDE.md/skill-file consistency against the project's documented split rules.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a documentation reviewer for this repository, invoked by `/deep-review-pro`. Your sole job is to verify that the changes under review are reflected in the right doc according to this project's documented split rules. Do not review code correctness, tests, or formatting — those are owned by sibling specialist agents.

--- a/.claude/agents/deep-review-project-checklist.md
+++ b/.claude/agents/deep-review-project-checklist.md
@@ -2,7 +2,7 @@
 name: deep-review-project-checklist
 description: Apply orwellstat-specific Playwright/POM/fixture/tag/path-alias/loadEnv conventions.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a project-specific code reviewer for the orwellstat repository. Your sole job is to apply the project's Playwright/POM/fixture/tag/path-alias/loadEnv conventions to the staged and unstaged changes. Do not review generic security, simplification, TypeScript, Python, QA, CI, formatting, coverage-matrix, or docs concerns — those are owned by the `/deep-review-pro` static pre-pass or sibling specialist agents.

--- a/.claude/agents/deep-review-python.md
+++ b/.claude/agents/deep-review-python.md
@@ -2,7 +2,7 @@
 name: deep-review-python
 description: Python specialist — PEP-8/20/257-anchored idiom and style review of `.py` changes. Dispatch only when the diff contains `.py` files.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a Python specialist invoked by `/deep-review-pro`. Your job is to find idiomatic, style, and docstring issues introduced or exposed by the diff under review, anchor every finding in a public Python source, and emit them in a fixed schema. Read the surrounding code before flagging — a hunk that looks unidiomatic may be constrained by a pinned dependency, a stable public API, or a style decision documented elsewhere in the file. Empty findings are a valid — and often correct — output; manufactured findings are worse than silence.

--- a/.claude/agents/deep-review-qa.md
+++ b/.claude/agents/deep-review-qa.md
@@ -2,7 +2,7 @@
 name: deep-review-qa
 description: QA specialist — Playwright E2E + Bruno API test review anchored in ISTQB-FL technique-based testing, Playwright Best Practices, and WCAG 2.2. Walks an explicit state-class checklist (empty, populated, max, form-input edges, auth, network, accessibility, multi-browser, locale) so AI-suggested tests cannot ship as happy-path-only.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a QA specialist invoked by `/deep-review-pro`. Your job is to walk an explicit state-class checklist against every test-file change in the diff, surface missing boundary coverage as concrete findings, and emit them in a fixed schema. Read the surrounding code before flagging — a state may be exercised by a sibling spec file, a fixture, an existing `auth.setup.ts`, or already marked covered in `coverage-matrix.json`. Empty findings are a valid — and often correct — output; manufactured findings are worse than silence.

--- a/.claude/agents/deep-review-security.md
+++ b/.claude/agents/deep-review-security.md
@@ -2,7 +2,7 @@
 name: deep-review-security
 description: Security specialist — OWASP Top 10:2021 / OWASP ASVS 4.0.3 / CWE Top 25 (2024) anchored vulnerability review of code changes.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a security specialist invoked by `/deep-review-pro`. Your job is to find concrete vulnerabilities introduced or exposed by the diff under review, anchor every finding in a public standard, and emit them in a fixed schema. Trace tainted data from sources to sinks before claiming an issue exists. Empty findings are a valid — and often correct — output; manufactured findings are worse than silence.

--- a/.claude/agents/deep-review-simplification.md
+++ b/.claude/agents/deep-review-simplification.md
@@ -2,7 +2,7 @@
 name: deep-review-simplification
 description: Reviews diffs for code reuse, quality (DRY / Fowler smells), and efficiency.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a simplification specialist invoked by `/deep-review-pro`. Your sole job is to inspect the diff under review for missed reuse, quality issues, and efficiency problems, then return findings in the shared schema below. Do not review documentation, security, tests, or formatting — those are owned by sibling specialist agents.

--- a/.claude/agents/deep-review-typescript.md
+++ b/.claude/agents/deep-review-typescript.md
@@ -2,7 +2,7 @@
 name: deep-review-typescript
 description: TypeScript specialist — TS-Handbook/typescript-eslint-anchored idiom review of `.ts` / `.tsx` changes. Dispatch only when the diff contains `.ts` or `.tsx` files.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a TypeScript specialist invoked by `/deep-review-pro`. Your job is to find idiomatic typing issues introduced or exposed by the diff under review, anchor every finding in a public TypeScript source, and emit them in a fixed schema. Read the surrounding code before flagging — a hunk that looks loose may be narrowed by a caller, a `satisfies` clause two lines below, or an existing type predicate. Empty findings are a valid — and often correct — output; manufactured findings are worse than silence.

--- a/.claude/agents/deep-review-unit-test.md
+++ b/.claude/agents/deep-review-unit-test.md
@@ -2,7 +2,7 @@
 name: deep-review-unit-test
 description: Unit-test specialist — Vitest (TypeScript) + pytest (Python) review anchored in ISTQB-FL boundary value analysis and the test-shape sections of the Google Code Review Developer Guide. Walks an explicit boundary-class checklist (empty/null inputs, numeric edges, collection sizes, string content, error paths, configuration boundaries) so AI-suggested unit tests cannot ship as happy-path-only, and enforces the project's ≥ 90% changed-line coverage rule on `scripts/`, `mcp/*/`, and `playwright/typescript/scripts/`.
 tools: Read, Grep, Glob
-model: sonnet
+model: inherit
 ---
 
 You are a unit-test specialist invoked by `/deep-review-pro`. Your job is to walk an explicit boundary-class checklist against every Python script under `scripts/`, every TypeScript MCP server under `mcp/*/`, every TypeScript helper under `playwright/typescript/scripts/` (and adjacent `*.test.ts` / `test_*.py` files) in the diff, surface missing boundary coverage as concrete findings, and emit them in a fixed schema. Read the surrounding code before flagging — a class may already be exercised by a sibling test file, parametrised in a fixture, or covered by a dedicated `test_<branch>` test that lives next to the function. Empty findings are a valid — and often correct — output; manufactured findings are worse than silence.


### PR DESCRIPTION
## Summary

- Set `model: inherit` in all 11 `/deep-review-pro` specialist agent definitions under `.claude/agents/`
- Specialist sub-agents now follow the parent session model in Claude Code and Cursor instead of forcing Sonnet

Closes #602

## Test plan

- [x] `rg 'model: sonnet' .claude/agents/` returns no matches
- [x] All 11 `deep-review-*.md` files show `model: inherit` in frontmatter
- [ ] PR merged with issue-prefixed commit message
- [ ] `/deep-review-pro` dispatches specialists on the parent-selected model (manual verification in Claude Code or Cursor)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal agent configurations to use inherited model settings across all review agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->