### PR TITLE
#625 Publish indexed Playwright failure evidence

### DIFF
--- a/.github/actions/collect-failure-evidence/action.yml
+++ b/.github/actions/collect-failure-evidence/action.yml
@@ -1,0 +1,126 @@
+name: Collect Failure Evidence
+description: Build and optionally upload an indexed Playwright failure-evidence artifact.
+
+inputs:
+  artifact-name:
+    description: Artifact name to write into the index and upload.
+    required: true
+  project:
+    description: Playwright project name shown in the evidence index.
+    required: true
+  shard:
+    description: Shard label shown in the evidence index.
+    required: true
+  total-shards:
+    description: Total shard count shown in the evidence index.
+    required: true
+  working-directory:
+    description: Directory containing the Playwright TypeScript package.
+    required: false
+    default: playwright/typescript
+  upload-artifact:
+    description: Whether to upload the generated evidence artifact.
+    required: false
+    default: "true"
+  withhold-sensitive-details:
+    description: Whether to withhold raw results and error text from public evidence.
+    required: false
+    default: "false"
+  withhold-binary-attachments:
+    description: Whether to index binary attachments without copying their bodies.
+    required: false
+    default: "false"
+  redact-env-names:
+    description: Whitespace- or comma-separated environment variable names whose values should be redacted from text evidence.
+    required: false
+    default: ""
+  retention-days:
+    description: Artifact retention in days.
+    required: false
+    default: "30"
+
+runs:
+  using: composite
+  steps:
+    - name: Collect failure evidence
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        PROJECT: ${{ inputs.project }}
+        SHARD: ${{ inputs.shard }}
+        TOTAL_SHARDS: ${{ inputs.total-shards }}
+        WITHHOLD_SENSITIVE_DETAILS: ${{ inputs.withhold-sensitive-details }}
+        WITHHOLD_BINARY_ATTACHMENTS: ${{ inputs.withhold-binary-attachments }}
+        REDACT_ENV_NAMES: ${{ inputs.redact-env-names }}
+      run: |
+        withhold_args=()
+        if [ "$WITHHOLD_SENSITIVE_DETAILS" = "true" ]; then
+          withhold_args+=(--withhold-sensitive-details)
+        fi
+        if [ "$WITHHOLD_BINARY_ATTACHMENTS" = "true" ]; then
+          withhold_args+=(--withhold-binary-attachments)
+        fi
+        redact_args=()
+        if [ -n "$REDACT_ENV_NAMES" ]; then
+          redact_args+=(--redact-env-names "$REDACT_ENV_NAMES")
+        fi
+
+        if ! node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/collect-failure-evidence.ts \
+          --results test-results/results.json \
+          --source test-results \
+          --out failure-evidence \
+          --artifact-name "$ARTIFACT_NAME" \
+          --run-id "$GITHUB_RUN_ID" \
+          --project "$PROJECT" \
+          --shard "$SHARD" \
+          --total-shards "$TOTAL_SHARDS" \
+          "${withhold_args[@]}" \
+          "${redact_args[@]}"; then
+          rm -rf failure-evidence
+          mkdir -p failure-evidence
+          {
+            echo "# Playwright Failure Evidence"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Run | $GITHUB_RUN_ID |"
+            echo "| Artifact | $ARTIFACT_NAME |"
+            echo "| Download command | gh run download $GITHUB_RUN_ID --name $ARTIFACT_NAME |"
+            echo "| Project | $PROJECT |"
+            echo "| Shard | $SHARD/$TOTAL_SHARDS |"
+            echo "| Results | not produced |"
+            echo
+            echo "## Warnings"
+            echo
+            echo "- Failure evidence collection failed before an index could be generated."
+          } > failure-evidence/index.md
+        fi
+
+        summary_limit_bytes=900000
+        if [ -f failure-evidence/index.md ]; then
+          summary_bytes=$(wc -c < failure-evidence/index.md | tr -d ' ')
+          if [ "$summary_bytes" -le "$summary_limit_bytes" ]; then
+            cat failure-evidence/index.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+          else
+            head -c "$summary_limit_bytes" failure-evidence/index.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+            {
+              echo
+              echo
+              echo "> Failure evidence summary truncated at ${summary_limit_bytes} bytes. Download the ${ARTIFACT_NAME} artifact for the full index."
+            } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+          fi
+        fi
+
+    - name: Upload failure evidence
+      if: ${{ inputs.upload-artifact == 'true' && env.ACT != 'true' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          ${{ inputs.working-directory }}/failure-evidence/index.md
+          ${{ inputs.working-directory }}/failure-evidence/manifest.json
+          ${{ inputs.working-directory }}/failure-evidence/results.json
+          ${{ inputs.working-directory }}/failure-evidence/failures/
+        retention-days: ${{ inputs.retention-days }}
+        if-no-files-found: ignore

--- a/.github/workflows/playwright-run.yml
+++ b/.github/workflows/playwright-run.yml
@@ -177,7 +177,7 @@ jobs:
 
           trap cleanup_auth_regeneration_artifacts EXIT
           cleanup_auth_regeneration_artifacts
-          npx playwright test --project=setup --reporter=line --trace=off --output=.auth-regeneration-results
+          npx playwright test --project=setup --reporter=line --output=.auth-regeneration-results
         working-directory: playwright/typescript
         env:
           ENV: ${{ vars.ENV }}
@@ -258,6 +258,51 @@ jobs:
           name: blob-report-${{ inputs.id }}-${{ inputs.shard }}
           path: playwright/typescript/blob-report/
           retention-days: 30
+      - name: Collect failure evidence
+        if: ${{ failure() && steps.run-playwright-tests.outcome == 'failure' }}
+        working-directory: playwright/typescript
+        env:
+          ARTIFACT_NAME: failure-evidence-${{ inputs.id }}-${{ inputs.shard }}
+          PROJECT: ${{ inputs.project }}
+          SHARD: ${{ inputs.shard }}
+          TOTAL_SHARDS: ${{ inputs.total-shards }}
+        run: |
+          mkdir -p failure-evidence
+          if ! node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/collect-failure-evidence.ts \
+            --results test-results/results.json \
+            --source test-results \
+            --out failure-evidence \
+            --artifact-name "$ARTIFACT_NAME" \
+            --run-id "$GITHUB_RUN_ID" \
+            --project "$PROJECT" \
+            --shard "$SHARD" \
+            --total-shards "$TOTAL_SHARDS"; then
+            {
+              echo "# Playwright Failure Evidence"
+              echo
+              echo "| Field | Value |"
+              echo "| --- | --- |"
+              echo "| Run | $GITHUB_RUN_ID |"
+              echo "| Artifact | $ARTIFACT_NAME |"
+              echo "| Download command | gh run download $GITHUB_RUN_ID --name $ARTIFACT_NAME |"
+              echo "| Project | $PROJECT |"
+              echo "| Shard | $SHARD/$TOTAL_SHARDS |"
+              echo "| Results | not produced |"
+              echo
+              echo "## Warnings"
+              echo
+              echo "- Failure evidence collection failed before an index could be generated."
+            } > failure-evidence/index.md
+          fi
+
+          cat failure-evidence/index.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      - uses: actions/upload-artifact@v7
+        if: ${{ failure() && steps.run-playwright-tests.outcome == 'failure' && steps.detect-act.outputs.running != 'true' }}
+        with:
+          name: failure-evidence-${{ inputs.id }}-${{ inputs.shard }}
+          path: playwright/typescript/failure-evidence/
+          retention-days: 30
+          if-no-files-found: ignore
       - name: Collect self-healing data
         if: ${{ failure() && steps.run-playwright-tests.outcome == 'failure' }}
         working-directory: playwright/typescript

--- a/.github/workflows/playwright-run.yml
+++ b/.github/workflows/playwright-run.yml
@@ -1,10 +1,9 @@
 name: Playwright Run
 
 # Reusable workflow that encapsulates a single matrix entry's Playwright run:
-# checkout → install Node + browsers + xmllint → run tests → upload reports
-# and (on failure) self-healing artefacts. Callers pass the matrix entry as
-# discrete inputs so this workflow has no implicit knowledge of the caller's
-# matrix shape.
+# checkout → install Node + browsers + xmllint → run tests → upload sanitized failure evidence.
+# Callers pass the matrix entry as discrete inputs so this workflow has no implicit knowledge of
+# the caller's matrix shape.
 
 on:
   workflow_call:
@@ -239,92 +238,12 @@ jobs:
           # Fail loudly if snap-token ever drifts from the real filename rule (e.g. a project rename
           # that forgets to update the matrix JSON) — default `warn` would silently lose baselines.
           if-no-files-found: error
-      - name: Detect local act runner
-        id: detect-act
-        if: ${{ !cancelled() }}
-        run: |
-          if [ "${ACT}" = "true" ]; then
-            echo "running=true" >> "$GITHUB_OUTPUT"
-          fi
-      - uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() && steps.detect-act.outputs.running != 'true' && steps.run-playwright-tests.outcome != 'skipped' }}
-        with:
-          name: playwright-report-${{ inputs.id }}-${{ inputs.shard }}
-          path: playwright/typescript/playwright-report/
-          retention-days: 30
-      - uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() && steps.detect-act.outputs.running != 'true' && steps.run-playwright-tests.outcome != 'skipped' }}
-        with:
-          name: blob-report-${{ inputs.id }}-${{ inputs.shard }}
-          path: playwright/typescript/blob-report/
-          retention-days: 30
       - name: Collect failure evidence
         if: ${{ failure() && steps.run-playwright-tests.outcome == 'failure' }}
-        working-directory: playwright/typescript
-        env:
-          ARTIFACT_NAME: failure-evidence-${{ inputs.id }}-${{ inputs.shard }}
-          PROJECT: ${{ inputs.project }}
-          SHARD: ${{ inputs.shard }}
-          TOTAL_SHARDS: ${{ inputs.total-shards }}
-        run: |
-          mkdir -p failure-evidence
-          if ! node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/collect-failure-evidence.ts \
-            --results test-results/results.json \
-            --source test-results \
-            --out failure-evidence \
-            --artifact-name "$ARTIFACT_NAME" \
-            --run-id "$GITHUB_RUN_ID" \
-            --project "$PROJECT" \
-            --shard "$SHARD" \
-            --total-shards "$TOTAL_SHARDS"; then
-            {
-              echo "# Playwright Failure Evidence"
-              echo
-              echo "| Field | Value |"
-              echo "| --- | --- |"
-              echo "| Run | $GITHUB_RUN_ID |"
-              echo "| Artifact | $ARTIFACT_NAME |"
-              echo "| Download command | gh run download $GITHUB_RUN_ID --name $ARTIFACT_NAME |"
-              echo "| Project | $PROJECT |"
-              echo "| Shard | $SHARD/$TOTAL_SHARDS |"
-              echo "| Results | not produced |"
-              echo
-              echo "## Warnings"
-              echo
-              echo "- Failure evidence collection failed before an index could be generated."
-            } > failure-evidence/index.md
-          fi
-
-          cat failure-evidence/index.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-      - uses: actions/upload-artifact@v7
-        if: ${{ failure() && steps.run-playwright-tests.outcome == 'failure' && steps.detect-act.outputs.running != 'true' }}
+        uses: ./.github/actions/collect-failure-evidence
         with:
-          name: failure-evidence-${{ inputs.id }}-${{ inputs.shard }}
-          path: playwright/typescript/failure-evidence/
-          retention-days: 30
-          if-no-files-found: ignore
-      - name: Collect self-healing data
-        if: ${{ failure() && steps.run-playwright-tests.outcome == 'failure' }}
-        working-directory: playwright/typescript
-        run: |
-          mkdir -p self-healing-data
-          cp test-results/results.json self-healing-data/ 2>/dev/null || true
-          find test-results -maxdepth 2 -name 'selector-fix.md' -not -path '*/attachments/*' | while IFS= read -r f; do
-            dir="self-healing-data/$(dirname "$f")"
-            mkdir -p "$dir"
-            cp "$f" "$dir/"
-          done
-          for name in dom.xhtml error-context.md; do
-            find test-results -maxdepth 2 -name "$name" -not -path '*/attachments/*' | while IFS= read -r f; do
-              dir="self-healing-data/$(dirname "$f")"
-              mkdir -p "$dir"
-              cp "$f" "$dir/"
-            done
-          done
-      - uses: actions/upload-artifact@v7
-        if: ${{ failure() && steps.run-playwright-tests.outcome == 'failure' && steps.detect-act.outputs.running != 'true' }}
-        with:
-          name: self-healing-data-${{ inputs.id }}-${{ inputs.shard }}
-          path: playwright/typescript/self-healing-data/
-          retention-days: 7
-          if-no-files-found: ignore
+          artifact-name: failure-evidence-${{ inputs.id }}-${{ inputs.shard }}
+          project: ${{ inputs.project }}
+          shard: ${{ inputs.shard }}
+          total-shards: ${{ inputs.total-shards }}
+          withhold-sensitive-details: "true"

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -143,6 +143,7 @@ jobs:
         with:
           browser: chromium
       - name: Run auth.setup.ts
+        id: run-auth-setup
         run: npx playwright test --project=setup
         working-directory: playwright/typescript
         env:
@@ -153,6 +154,56 @@ jobs:
           ORWELLSTAT_PASSWORD_EMPTY: ${{ secrets.ORWELLSTAT_PASSWORD_EMPTY }}
           BASIC_AUTH_USER: ${{ (inputs.env || 'staging') == 'staging' && secrets.BASIC_AUTH_USER || '' }}
           BASIC_AUTH_PASSWORD: ${{ (inputs.env || 'staging') == 'staging' && secrets.BASIC_AUTH_PASSWORD || '' }}
+      - name: Detect local act runner
+        id: detect-act
+        if: ${{ !cancelled() }}
+        run: |
+          if [ "${ACT}" = "true" ]; then
+            echo "running=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Collect failure evidence
+        if: ${{ failure() && steps.run-auth-setup.outcome == 'failure' }}
+        working-directory: playwright/typescript
+        env:
+          ARTIFACT_NAME: failure-evidence-auth-setup-${{ matrix.id }}
+          PROJECT: ${{ matrix.id }}
+        run: |
+          mkdir -p failure-evidence
+          if ! node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/collect-failure-evidence.ts \
+            --results test-results/results.json \
+            --source test-results \
+            --out failure-evidence \
+            --artifact-name "$ARTIFACT_NAME" \
+            --run-id "$GITHUB_RUN_ID" \
+            --project "$PROJECT" \
+            --shard auth-setup \
+            --total-shards 1; then
+            {
+              echo "# Playwright Failure Evidence"
+              echo
+              echo "| Field | Value |"
+              echo "| --- | --- |"
+              echo "| Run | $GITHUB_RUN_ID |"
+              echo "| Artifact | $ARTIFACT_NAME |"
+              echo "| Download command | gh run download $GITHUB_RUN_ID --name $ARTIFACT_NAME |"
+              echo "| Project | $PROJECT |"
+              echo "| Shard | auth-setup/1 |"
+              echo "| Results | not produced |"
+              echo
+              echo "## Warnings"
+              echo
+              echo "- Failure evidence collection failed before an index could be generated."
+            } > failure-evidence/index.md
+          fi
+
+          cat failure-evidence/index.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      - uses: actions/upload-artifact@v7
+        if: ${{ failure() && steps.run-auth-setup.outcome == 'failure' && steps.detect-act.outputs.running != 'true' }}
+        with:
+          name: failure-evidence-auth-setup-${{ matrix.id }}
+          path: playwright/typescript/failure-evidence/
+          retention-days: 30
+          if-no-files-found: ignore
       - name: Upload storage states
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/playwright-typescript.yml
+++ b/.github/workflows/playwright-typescript.yml
@@ -69,8 +69,8 @@ jobs:
           # Visual-baseline runs collapse to total-shards=1 — sharding visual.spec.ts can leave a
           # shard with zero PNGs to upload for low-snapshot projects, tripping
           # `if-no-files-found: error` in playwright-run.yml. Regular runs fan out across 2 shards
-          # to halve per-leg wall-clock; the merge-reports job stitches blob reports back into
-          # a single HTML report covering the full spec set.
+          # to halve per-leg wall-clock; failed shards publish sanitized failure-evidence indexes
+          # instead of raw Playwright reports because the jobs run with account and drain-token secrets.
           if [ "$UPDATE_BASELINES" = "true" ]; then
             TOTAL_SHARDS=1
           else
@@ -135,10 +135,10 @@ jobs:
         run: npm ci
         working-directory: playwright/typescript
       - name: Set up Playwright Chromium
-        # `auth.setup.ts` has no `use` block in `playwright.config.ts` so it always runs in
-        # default Chromium — every auth-setup leg shares the same chromium cache regardless of
-        # `matrix.browser`. Test-leg caches (keyed on each leg's actual browser) are populated
-        # separately by `playwright-run.yml`.
+        # The setup project does not override browser/device, so it always runs in default
+        # Chromium; its `use` block only disables trace/screenshot/video capture for sensitive
+        # auth setup failures. Every auth-setup leg can share the chromium cache regardless of
+        # `matrix.browser`, while test-leg caches are populated separately by `playwright-run.yml`.
         uses: ./.github/actions/setup-playwright-browser
         with:
           browser: chromium
@@ -154,56 +154,15 @@ jobs:
           ORWELLSTAT_PASSWORD_EMPTY: ${{ secrets.ORWELLSTAT_PASSWORD_EMPTY }}
           BASIC_AUTH_USER: ${{ (inputs.env || 'staging') == 'staging' && secrets.BASIC_AUTH_USER || '' }}
           BASIC_AUTH_PASSWORD: ${{ (inputs.env || 'staging') == 'staging' && secrets.BASIC_AUTH_PASSWORD || '' }}
-      - name: Detect local act runner
-        id: detect-act
-        if: ${{ !cancelled() }}
-        run: |
-          if [ "${ACT}" = "true" ]; then
-            echo "running=true" >> "$GITHUB_OUTPUT"
-          fi
       - name: Collect failure evidence
         if: ${{ failure() && steps.run-auth-setup.outcome == 'failure' }}
-        working-directory: playwright/typescript
-        env:
-          ARTIFACT_NAME: failure-evidence-auth-setup-${{ matrix.id }}
-          PROJECT: ${{ matrix.id }}
-        run: |
-          mkdir -p failure-evidence
-          if ! node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/collect-failure-evidence.ts \
-            --results test-results/results.json \
-            --source test-results \
-            --out failure-evidence \
-            --artifact-name "$ARTIFACT_NAME" \
-            --run-id "$GITHUB_RUN_ID" \
-            --project "$PROJECT" \
-            --shard auth-setup \
-            --total-shards 1; then
-            {
-              echo "# Playwright Failure Evidence"
-              echo
-              echo "| Field | Value |"
-              echo "| --- | --- |"
-              echo "| Run | $GITHUB_RUN_ID |"
-              echo "| Artifact | $ARTIFACT_NAME |"
-              echo "| Download command | gh run download $GITHUB_RUN_ID --name $ARTIFACT_NAME |"
-              echo "| Project | $PROJECT |"
-              echo "| Shard | auth-setup/1 |"
-              echo "| Results | not produced |"
-              echo
-              echo "## Warnings"
-              echo
-              echo "- Failure evidence collection failed before an index could be generated."
-            } > failure-evidence/index.md
-          fi
-
-          cat failure-evidence/index.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-      - uses: actions/upload-artifact@v7
-        if: ${{ failure() && steps.run-auth-setup.outcome == 'failure' && steps.detect-act.outputs.running != 'true' }}
+        uses: ./.github/actions/collect-failure-evidence
         with:
-          name: failure-evidence-auth-setup-${{ matrix.id }}
-          path: playwright/typescript/failure-evidence/
-          retention-days: 30
-          if-no-files-found: ignore
+          artifact-name: failure-evidence-auth-setup-${{ matrix.id }}
+          project: ${{ matrix.id }}
+          shard: auth-setup
+          total-shards: "1"
+          withhold-sensitive-details: "true"
       - name: Upload storage states
         uses: actions/upload-artifact@v7
         with:
@@ -237,45 +196,6 @@ jobs:
       shard: ${{ matrix.shard }}
       total-shards: ${{ matrix.total }}
     secrets: inherit
-
-  merge-reports:
-    needs: [setup-matrix, test]
-    # Only run when the matrix actually fanned out (regular runs); visual-baseline runs collapse
-    # to total-shards=1 with no per-leg blob reports worth merging. `always()` keeps the merge
-    # alive when individual shards fail so the unified HTML report still surfaces the failures.
-    if: ${{ github.repository == 'hubertgajewski/orwellstat' && always() && needs.test.result != 'skipped' && needs.test.result != 'cancelled' && needs.setup-matrix.outputs.total-shards != '1' }}
-    timeout-minutes: 5
-    runs-on: ${{ inputs.runner || vars.RUNNER || 'ubuntu-latest' }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          check-latest: true
-          cache: "npm"
-          cache-dependency-path: playwright/typescript/package-lock.json
-      - name: Install dependencies
-        run: npm ci
-        working-directory: playwright/typescript
-      - name: Download blob reports
-        # `merge-multiple: true` flattens every shard's blob-report-* artifact into a single
-        # directory; the per-blob filenames are unique so they can co-exist without collision.
-        uses: actions/download-artifact@v8
-        with:
-          pattern: blob-report-*
-          path: playwright/typescript/all-blob-reports
-          merge-multiple: true
-      - name: Merge blob reports into a unified HTML report
-        run: npx playwright merge-reports --reporter=html ./all-blob-reports
-        working-directory: playwright/typescript
-      - name: Upload merged HTML report
-        uses: actions/upload-artifact@v7
-        with:
-          name: playwright-report-merged
-          path: playwright/typescript/playwright-report
-          retention-days: 30
 
   commit-baselines:
     needs: test

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -35,23 +35,24 @@ Use [CI_LOCAL.md](CI_LOCAL.md) for self-hosted runner setup, security model, and
 
 Root scripts support CI workflows, hooks, and generated reports:
 
-| Script                                     | Purpose                                                                                          |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| `scripts/generate-quality-metrics.py`      | Generates `QUALITY_METRICS.md` and appends `quality-metrics-history.json` data points            |
-| `scripts/self-healing.py`                  | Parses Playwright failure artifacts and posts selector-fix comments or creates draft PRs         |
-| `scripts/provision-worktree-env.sh`        | Symlinks or copies gitignored env files into per-issue worktrees                                 |
-| `scripts/setup-runners.sh`                 | Registers and starts the self-hosted runner pool as launchd services                             |
-| `scripts/remove-runners.sh`                | De-registers and stops the self-hosted runner pool                                               |
-| `scripts/runner-lib.sh`                    | Shared helpers for the self-hosted runner setup/removal scripts                                  |
-| `scripts/verify_commit_command_hook.py`    | Shared pinned-hook check that verifies direct `git push` commands and rejects wrapped push forms |
-| `scripts/test_generate_quality_metrics.py` | Unit tests for generated quality-metrics behavior                                                |
-| `scripts/test_self_healing.py`             | Unit tests for self-healing loop prevention, classification, redaction, and AI boundaries        |
-| `scripts/test_runner_scripts.py`           | Unit tests for self-hosted runner setup/removal scripts                                          |
-| `scripts/run_pinned_hook.sh`               | Shared pinned-hash launcher for Claude/Codex PreToolUse hook scripts                             |
-| `scripts/shell_c_option_utils.py`          | Shared `-c` / clustered short-option parsing helpers for hook scripts                            |
-| `scripts/verify_playwright_cli_hook.py`    | Pinned PreToolUse helper that blocks direct Playwright CLI invocations and directs agents to `playwright-report-mcp` |
-| `scripts/test_playwright_cli_hook.py`      | Unit tests for the Playwright CLI hook script                                                    |
-| `scripts/test_commit_hook_config.py`       | Unit tests for Claude/Codex publish-time and Playwright CLI PreToolUse hook configuration        |
+| Script                                                      | Purpose                                                                                                                |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `scripts/generate-quality-metrics.py`                       | Generates `QUALITY_METRICS.md` and appends `quality-metrics-history.json` data points                                  |
+| `scripts/self-healing.py`                                   | Parses Playwright failure artifacts and posts selector-fix comments or creates draft PRs                               |
+| `scripts/provision-worktree-env.sh`                         | Symlinks or copies gitignored env files into per-issue worktrees                                                       |
+| `scripts/setup-runners.sh`                                  | Registers and starts the self-hosted runner pool as launchd services                                                   |
+| `scripts/remove-runners.sh`                                 | De-registers and stops the self-hosted runner pool                                                                     |
+| `scripts/runner-lib.sh`                                     | Shared helpers for the self-hosted runner setup/removal scripts                                                        |
+| `scripts/verify_commit_command_hook.py`                     | Shared pinned-hook check that verifies direct `git push` commands and rejects wrapped push forms                       |
+| `scripts/test_generate_quality_metrics.py`                  | Unit tests for generated quality-metrics behavior                                                                      |
+| `scripts/test_self_healing.py`                              | Unit tests for self-healing loop prevention, classification, redaction, and AI boundaries                              |
+| `scripts/test_runner_scripts.py`                            | Unit tests for self-hosted runner setup/removal scripts                                                                |
+| `scripts/run_pinned_hook.sh`                                | Shared pinned-hash launcher for Claude/Codex PreToolUse hook scripts                                                   |
+| `scripts/shell_c_option_utils.py`                           | Shared `-c` / clustered short-option parsing helpers for hook scripts                                                  |
+| `scripts/verify_playwright_cli_hook.py`                     | Pinned PreToolUse helper that blocks direct Playwright CLI invocations and directs agents to `playwright-report-mcp`   |
+| `scripts/test_playwright_cli_hook.py`                       | Unit tests for the Playwright CLI hook script                                                                          |
+| `scripts/test_commit_hook_config.py`                        | Unit tests for Claude/Codex publish-time and Playwright CLI PreToolUse hook configuration                              |
+| `playwright/typescript/scripts/collect-failure-evidence.ts` | Builds an indexed failure-evidence artifact from Playwright `test-results/results.json` and failed-attempt attachments |
 
 ## Playwright Typescript Tests
 
@@ -72,6 +73,7 @@ Auth setup details:
 - `auth-setup` runs `npx playwright test --project=setup` once per browser project.
 - Each setup leg logs in both populated and empty accounts, so normal runs perform 10 logins total, independent of shard count.
 - Auth state artifacts are named `auth-state-<id>` and retained for 1 day. Each artifact contains `.auth/populated.json`, `.auth/empty.json`, and `.auth/metadata.json` with non-secret generation time and GitHub run identifiers.
+- Failed setup legs upload indexed diagnostics as `failure-evidence-auth-setup-<id>` and append the same `index.md` map to the job summary. Setup runs disable trace, screenshot, and video capture so credential-entry artifacts are not published.
 - Downstream test legs depend on auth setup, so a setup failure skips tests instead of letting them pass with stale state.
 
 Reusable test job:
@@ -81,7 +83,8 @@ Reusable test job:
 - Each leg normally installs only the browser it needs.
 - It validates downloaded auth-state files and metadata before running the shard. Missing metadata, invalid timestamps, or metadata older than 1 hour triggers a local setup-project rerun in that leg; this protects failed-job reruns from reusing expired storage-state artifacts. Local auth regeneration reuses the shared browser setup action to install Chromium only for non-Chromium shard legs because the setup project uses Playwright's default browser.
 - It runs `npx playwright test --project=<project> --shard=<shard>/<total-shards>`.
-- Per-leg artifacts use `-<id>-<shard>` suffixes for reports, blob reports, self-healing data, and visual baselines. Report/blob uploads only run after the shard test step is reached, and self-healing data is collected/uploaded only when that shard test step fails.
+- Per-leg artifacts use `-<id>-<shard>` suffixes for reports, blob reports, failure evidence, self-healing data, and visual baselines. Report/blob uploads only run after the shard test step is reached, and failure evidence plus self-healing data are collected/uploaded only when that shard test step fails.
+- Failure evidence artifacts are named `failure-evidence-auth-setup-<id>` for setup failures and `failure-evidence-<id>-<shard>` for shard failures, then retained for 30 days. Each artifact contains `index.md`, `manifest.json`, a copy of `results.json` when Playwright produced it, and failed-attempt attachments under stable paths such as `failures/F002-R0/screenshot.png`. The collector copies generated attachments from `test-results/` and visual expected-baseline attachments from `tests/**-snapshots/`; other outside paths stay blocked. The `index.md` summary assigns every failed attempt an error id, shows the artifact download command, repeats the artifact name beside every attachment path, strips terminal color codes from error messages, and avoids runner-local absolute paths. The workflow also appends `index.md` to the job summary so the first diagnostic map is visible without downloading the artifact.
 - Artifacts are retained for 30 days unless otherwise noted.
 
 Caching:
@@ -120,7 +123,7 @@ Purpose:
 - The dedicated config sets `retries: 0`.
 - Trace, screenshot, and video are disabled so the form-encoded POST body cannot be captured in published artifacts on a flake.
 - The spec guard only opens when `REAL_CREDENTIAL_RUN === 'true'`, keeping the test out of the standard matrix.
-- The workflow uploads only the HTML report; no trace, screenshot, video, blob, or self-healing artifacts are produced.
+- The workflow uploads only the HTML report; no trace, screenshot, video, blob, failure-evidence, or self-healing artifacts are produced.
 
 ## Lint And Type-Check Backstop
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -66,7 +66,7 @@ Run shape:
 - A `setup-matrix` job computes the matrix at runtime for full or browser-filtered dispatch runs.
 - An `auth-setup` job runs the setup project once per browser project before the test matrix fans out.
 - The `test` matrix calls reusable workflow `.github/workflows/playwright-run.yml`.
-- `merge-reports` runs with `always()` and publishes one merged Playwright HTML report from blob artifacts.
+- Failed shard diagnostics are published through sanitized `failure-evidence-*` indexes only; raw Playwright HTML/blob reports and self-healing data are not uploaded from the secret-bearing shard jobs.
 
 Auth setup details:
 
@@ -83,8 +83,8 @@ Reusable test job:
 - Each leg normally installs only the browser it needs.
 - It validates downloaded auth-state files and metadata before running the shard. Missing metadata, invalid timestamps, or metadata older than 1 hour triggers a local setup-project rerun in that leg; this protects failed-job reruns from reusing expired storage-state artifacts. Local auth regeneration reuses the shared browser setup action to install Chromium only for non-Chromium shard legs because the setup project uses Playwright's default browser.
 - It runs `npx playwright test --project=<project> --shard=<shard>/<total-shards>`.
-- Per-leg artifacts use `-<id>-<shard>` suffixes for reports, blob reports, failure evidence, self-healing data, and visual baselines. Report/blob uploads only run after the shard test step is reached, and failure evidence plus self-healing data are collected/uploaded only when that shard test step fails.
-- Failure evidence artifacts are named `failure-evidence-auth-setup-<id>` for setup failures and `failure-evidence-<id>-<shard>` for shard failures, then retained for 30 days. Each artifact contains `index.md`, `manifest.json`, a copy of `results.json` when Playwright produced it, and failed-attempt attachments under stable paths such as `failures/F002-R0/screenshot.png`. The collector copies generated attachments from `test-results/` and visual expected-baseline attachments from `tests/**-snapshots/`; other outside paths stay blocked. The `index.md` summary assigns every failed attempt an error id, shows the artifact download command, repeats the artifact name beside every attachment path, strips terminal color codes from error messages, and avoids runner-local absolute paths. The workflow also appends `index.md` to the job summary so the first diagnostic map is visible without downloading the artifact.
+- Per-leg artifacts use `-<id>-<shard>` suffixes for sanitized failure evidence and visual baselines. Raw Playwright HTML/blob reports and self-healing data are intentionally not uploaded from secret-bearing shard jobs.
+- Failure evidence artifacts are named `failure-evidence-auth-setup-<id>` for setup failures and `failure-evidence-<id>-<shard>` for shard failures, then retained for 30 days. `.github/actions/collect-failure-evidence` owns the shared collection, fallback-index, job-summary, and upload steps for both auth setup and test shards. The collector normally writes `index.md`, `manifest.json`, a redacted copy of `results.json` when Playwright produced it, and failed-attempt attachments under stable paths such as `failures/F002-R0/console.log`; if the collector itself crashes, the action uploads a fallback artifact with `index.md` only. Secret-bearing shard and auth setup runs explicitly set `withhold-sensitive-details`, so raw `results.json`, error text, and attachment bodies are not published when messages or DOM snapshots can contain account identifiers, drain tokens, or other sensitive values. Their indexes still list each attachment path with an `attachment body withheld` note, preserving the failure-to-attachment mapping without uploading the body. The collector copies generated attachments from `test-results/` and visual expected-baseline attachments from `tests/**-snapshots/`; other outside paths stay blocked. The `index.md` summary assigns every failed attempt an error id, shows the artifact download command, repeats the artifact name beside every attachment path, strips terminal color codes and generic sensitive patterns from displayed non-withheld evidence, surfaces Playwright top-level JSON errors for non-withheld shard runs, and avoids runner-local absolute paths. The workflow also appends `index.md` to the job summary so the first diagnostic map is visible without downloading the artifact.
 - Artifacts are retained for 30 days unless otherwise noted.
 
 Caching:
@@ -92,6 +92,7 @@ Caching:
 - Node uses `actions/setup-node@v6` with `node-version-file: .node-version` and `check-latest: true`.
 - npm dependencies are cached by `package-lock.json`.
 - `.github/actions/setup-playwright-browser` restores an isolated Playwright browser cache under `RUNNER_TEMP`.
+- `.github/actions/collect-failure-evidence` centralizes failure-evidence collection and upload behavior used by auth setup and shard jobs.
 - Browser cache keys include runner OS, runner architecture, browser, and `@playwright/test` version.
 - The browser setup always runs `install-deps`, then lets `playwright install` reuse restored browsers or download missing binaries.
 - Artifact upload is skipped under `act`.
@@ -165,7 +166,7 @@ The workflow uses a non-cancelling concurrency group keyed by target branch so p
 
 ## Automated Code Review
 
-`.github/workflows/claude-code-review.yml` runs on PR opened, synchronize, ready-for-review, and reopened events. It uses `anthropics/claude-code-action@v1` to submit a formal GitHub review with inline comments.
+`.github/workflows/claude-code-review.yml` runs on PR opened, synchronize, ready-for-review, and reopened events. It pins `anthropics/claude-code-action` to the reviewed v1.0.159 commit SHA so proxy/OpenRouter routing stays stable until a future action bump has verified internal Agent SDK model routing for 48 hours.
 
 The workflow uses two tiers:
 
@@ -244,12 +245,12 @@ The workflow runs `scripts/generate-quality-metrics.py` to regenerate [QUALITY_M
 
 ## Self-Healing Selector Fix
 
-`.github/workflows/self-healing.yml` triggers through `workflow_run` after "Playwright Typescript Tests" fails. It detects selector/locator failures and either comments on the PR or creates a draft PR.
+`.github/workflows/self-healing.yml` triggers through `workflow_run` after "Playwright Typescript Tests" fails, then runs only when a `self-healing-data-*` artifact exists. The secret-bearing Playwright shard workflow no longer uploads that raw artifact; failed shards publish sanitized `failure-evidence-*` indexes instead.
 
 Data sources:
 
-- Uses precomputed `selector-fix.md` attachments when `AI_DIAGNOSIS` is enabled.
-- Otherwise calls the configured AI provider directly with redacted error context and DOM snapshot.
+- Uses precomputed `selector-fix.md` attachments when a trusted producer uploads `self-healing-data-*` and `AI_DIAGNOSIS` is enabled.
+- Otherwise calls the configured AI provider directly with redacted error context and DOM snapshot from that trusted artifact.
 - Redaction is performed by `playwright/typescript/scripts/redact.ts`, which reuses `redactSensitive` from `utils/diagnosis.util.ts`.
 - Redaction subprocess failure aborts the run instead of sending unredacted content.
 

--- a/docs/PLAYWRIGHT.md
+++ b/docs/PLAYWRIGHT.md
@@ -75,15 +75,13 @@ VALIDATE_REMOTE=true npx playwright test tests/validation.spec.ts
 
 Use `VALIDATE_REMOTE=true` sparingly; it posts XHTML to `validator.w3.org/check` and sends CSS URIs to `jigsaw.w3.org/css-validator`.
 
-To inspect flaky tests across CI runs, download blob artifacts and merge them:
+To inspect CI failures, start with the sanitized failure-evidence artifacts:
 
 ```bash
-gh run list --workflow=playwright-typescript.yml --limit 10 --json databaseId \
-  --jq '.[].databaseId' | \
-  xargs -I{} sh -c 'gh run download {} --pattern "blob-report-*" --dir ./blobs/{} 2>/dev/null || true'
-
-npx playwright merge-reports --reporter=html ./blobs/*/blob-report-*
+gh run download <run-id> --pattern "failure-evidence-*"
 ```
+
+Secret-bearing CI shards do not upload raw Playwright HTML/blob reports, traces, screenshots, videos, DOM snapshots, or self-healing data. Their failure-evidence indexes preserve the error-to-attachment mapping and mark withheld bodies explicitly.
 
 ## Test Tags
 
@@ -153,27 +151,27 @@ Public page classes live under `pages/public/`; authenticated page classes live 
 
 ## Fixtures And Utilities
 
-| Path                                  | Purpose                                                                                                                                                  |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fixtures/base.fixture.ts`            | Extends Playwright `test`, captures console logs and `dom.xhtml` on failure, attaches AI diagnosis when enabled, and re-exports common Playwright types  |
-| `fixtures/api.fixture.ts`             | Adds `unauthenticatedRequest` and `authenticatedRequest` API fixtures                                                                                    |
-| `fixtures/storage-state.ts`           | Exports populated and empty storage-state paths                                                                                                          |
-| `utils/accessibility.util.ts`         | Axe WCAG checks                                                                                                                                          |
-| `utils/string.util.ts`                | Heading visibility helper                                                                                                                                |
-| `utils/svg-chart.util.ts`             | SVG chart loading, parsing, and chart/table comparison helpers                                                                                           |
-| `utils/svg-chart-table.util.ts`       | Fixture-free XHTML snapshot table extractor                                                                                                              |
-| `utils/svg-chart-percent.util.ts`     | Percentage normalization and chart/table tolerance helpers                                                                                               |
-| `utils/validation.util.ts`            | XHTML and CSS validators with local and remote modes                                                                                                     |
-| `utils/track-hit.util.ts`             | Tracking-hit seeding through live snippets and `/scripts/drain.php`                                                                                      |
-| `utils/env.util.ts`                   | `.env` loading and credential validation                                                                                                                 |
-| `utils/auth-state-metadata.util.ts`   | Non-secret `.auth/metadata.json` writer for CI auth-state freshness checks                                                                               |
-| `utils/diagnosis.util.ts`             | AI diagnosis, selector-fix attachment, and redaction rules                                                                                               |
-| `utils/css-validator.util.ts`         | Pure helpers around `csstree-validator`                                                                                                                  |
-| `scripts/collect-failure-evidence.ts` | Builds CI `failure-evidence-*` artifacts with an indexed `index.md`, `manifest.json`, `results.json`, and failed-attempt attachments grouped by error id |
-| `scripts/verify-coverage-matrix.ts`   | Cross-checks active tests against `coverage-matrix.json`                                                                                                 |
-| `scripts/redact.ts`                   | stdin/stdout redaction CLI used by self-healing                                                                                                          |
-| `test-data/scripts/snippet-*.txt`     | Canonical HTML5, HTML4, and XHTML tracking snippets with `{{ORWELLSTAT_BASE}}` placeholders                                                              |
-| `test-data/scripts/tracking-*`        | HTML/HTML4/XHTML shells used by tracking E2E tests after inserting the matching live snippet                                                             |
+| Path                                  | Purpose                                                                                                                                                                                                                                                                |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fixtures/base.fixture.ts`            | Extends Playwright `test`, captures console logs and `dom.xhtml` on failure, attaches AI diagnosis when enabled, and re-exports common Playwright types                                                                                                                |
+| `fixtures/api.fixture.ts`             | Adds `unauthenticatedRequest` and `authenticatedRequest` API fixtures                                                                                                                                                                                                  |
+| `fixtures/storage-state.ts`           | Exports populated and empty storage-state paths                                                                                                                                                                                                                        |
+| `utils/accessibility.util.ts`         | Axe WCAG checks                                                                                                                                                                                                                                                        |
+| `utils/string.util.ts`                | Heading visibility helper                                                                                                                                                                                                                                              |
+| `utils/svg-chart.util.ts`             | SVG chart loading, parsing, and chart/table comparison helpers                                                                                                                                                                                                         |
+| `utils/svg-chart-table.util.ts`       | Fixture-free XHTML snapshot table extractor                                                                                                                                                                                                                            |
+| `utils/svg-chart-percent.util.ts`     | Percentage normalization and chart/table tolerance helpers                                                                                                                                                                                                             |
+| `utils/validation.util.ts`            | XHTML and CSS validators with local and remote modes                                                                                                                                                                                                                   |
+| `utils/track-hit.util.ts`             | Tracking-hit seeding through live snippets and `/scripts/drain.php`                                                                                                                                                                                                    |
+| `utils/env.util.ts`                   | `.env` loading and credential validation                                                                                                                                                                                                                               |
+| `utils/auth-state-metadata.util.ts`   | Non-secret `.auth/metadata.json` writer for CI auth-state freshness checks                                                                                                                                                                                             |
+| `utils/diagnosis.util.ts`             | AI diagnosis, selector-fix attachment, and redaction rules                                                                                                                                                                                                             |
+| `utils/css-validator.util.ts`         | Pure helpers around `csstree-validator`                                                                                                                                                                                                                                |
+| `scripts/collect-failure-evidence.ts` | Builds CI `failure-evidence-*` artifacts with an indexed `index.md`, `manifest.json`, redacted `results.json`, Playwright top-level errors, and failed-attempt attachments grouped by error id; secret-bearing jobs can index attachments without copying their bodies |
+| `scripts/verify-coverage-matrix.ts`   | Cross-checks active tests against `coverage-matrix.json`                                                                                                                                                                                                               |
+| `scripts/redact.ts`                   | stdin/stdout redaction CLI used by self-healing                                                                                                                                                                                                                        |
+| `test-data/scripts/snippet-*.txt`     | Canonical HTML5, HTML4, and XHTML tracking snippets with `{{ORWELLSTAT_BASE}}` placeholders                                                                                                                                                                            |
+| `test-data/scripts/tracking-*`        | HTML/HTML4/XHTML shells used by tracking E2E tests after inserting the matching live snippet                                                                                                                                                                           |
 
 Unit tests for pure utilities run through `npm run test:unit`.
 
@@ -203,7 +201,7 @@ Defined in `tsconfig.json`:
 
 Important defaults:
 
-- Failure artifacts: screenshots, video, console log, `dom.xhtml`, and optional AI diagnosis. CI failed shards upload `failure-evidence-<id>-<shard>` artifacts that index those files with traces, error context, selector-fix notes, and `results.json` when Playwright produced them. Failed auth setup legs upload `failure-evidence-auth-setup-<id>` with trace, screenshot, and video capture disabled. The evidence index gives each failed attempt an error id and shows the artifact name plus the path inside that artifact for every attachment.
+- Failure artifacts: screenshots, video, console log, `dom.xhtml`, and optional AI diagnosis. CI failed shards upload `failure-evidence-<id>-<shard>` artifacts that index those files with traces, error context, selector-fix notes, and `results.json` metadata when Playwright produced it. Because shard and auth setup jobs run with account or drain-token secrets, they pass `withhold-sensitive-details`: raw `results.json`, error text, and attachment bodies are not uploaded, and each attachment row is kept in the index with an `attachment body withheld` note. The evidence index gives each failed attempt an error id, strips generic sensitive patterns from non-withheld evidence, and shows the artifact name plus the path inside that artifact for every attachment.
 - `trace: 'on-first-retry'`.
 - `baseURL` from `ENV` (`production` by default, `staging` when `ENV=staging`).
 - `httpCredentials` injected automatically when `BASIC_AUTH_USER` is set.

--- a/docs/PLAYWRIGHT.md
+++ b/docs/PLAYWRIGHT.md
@@ -107,7 +107,7 @@ playwright/typescript/
   coverage-matrix.json           # manual page/form coverage matrix
   fixtures/                      # custom Playwright fixtures and storage-state constants
   pages/                         # Page Object Model classes
-  scripts/                       # matrix verifier and redaction CLI
+  scripts/                       # matrix verifier, failure-evidence collector, and redaction CLI
   test-data/                     # tracking snippet fixtures
   tests/                         # Playwright spec files
   types/                         # local TypeScript interfaces
@@ -153,26 +153,27 @@ Public page classes live under `pages/public/`; authenticated page classes live 
 
 ## Fixtures And Utilities
 
-| Path                                | Purpose                                                                                                                                                 |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fixtures/base.fixture.ts`          | Extends Playwright `test`, captures console logs and `dom.xhtml` on failure, attaches AI diagnosis when enabled, and re-exports common Playwright types |
-| `fixtures/api.fixture.ts`           | Adds `unauthenticatedRequest` and `authenticatedRequest` API fixtures                                                                                   |
-| `fixtures/storage-state.ts`         | Exports populated and empty storage-state paths                                                                                                         |
-| `utils/accessibility.util.ts`       | Axe WCAG checks                                                                                                                                         |
-| `utils/string.util.ts`              | Heading visibility helper                                                                                                                               |
-| `utils/svg-chart.util.ts`           | SVG chart loading, parsing, and chart/table comparison helpers                                                                                          |
-| `utils/svg-chart-table.util.ts`     | Fixture-free XHTML snapshot table extractor                                                                                                             |
-| `utils/svg-chart-percent.util.ts`   | Percentage normalization and chart/table tolerance helpers                                                                                              |
-| `utils/validation.util.ts`          | XHTML and CSS validators with local and remote modes                                                                                                    |
-| `utils/track-hit.util.ts`           | Tracking-hit seeding through live snippets and `/scripts/drain.php`                                                                                     |
-| `utils/env.util.ts`                 | `.env` loading and credential validation                                                                                                                |
-| `utils/auth-state-metadata.util.ts` | Non-secret `.auth/metadata.json` writer for CI auth-state freshness checks                                                                              |
-| `utils/diagnosis.util.ts`           | AI diagnosis, selector-fix attachment, and redaction rules                                                                                              |
-| `utils/css-validator.util.ts`       | Pure helpers around `csstree-validator`                                                                                                                 |
-| `scripts/verify-coverage-matrix.ts` | Cross-checks active tests against `coverage-matrix.json`                                                                                                |
-| `scripts/redact.ts`                 | stdin/stdout redaction CLI used by self-healing                                                                                                         |
-| `test-data/scripts/snippet-*.txt`   | Canonical HTML5, HTML4, and XHTML tracking snippets with `{{ORWELLSTAT_BASE}}` placeholders                                                             |
-| `test-data/scripts/tracking-*`      | HTML/HTML4/XHTML shells used by tracking E2E tests after inserting the matching live snippet                                                            |
+| Path                                  | Purpose                                                                                                                                                  |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fixtures/base.fixture.ts`            | Extends Playwright `test`, captures console logs and `dom.xhtml` on failure, attaches AI diagnosis when enabled, and re-exports common Playwright types  |
+| `fixtures/api.fixture.ts`             | Adds `unauthenticatedRequest` and `authenticatedRequest` API fixtures                                                                                    |
+| `fixtures/storage-state.ts`           | Exports populated and empty storage-state paths                                                                                                          |
+| `utils/accessibility.util.ts`         | Axe WCAG checks                                                                                                                                          |
+| `utils/string.util.ts`                | Heading visibility helper                                                                                                                                |
+| `utils/svg-chart.util.ts`             | SVG chart loading, parsing, and chart/table comparison helpers                                                                                           |
+| `utils/svg-chart-table.util.ts`       | Fixture-free XHTML snapshot table extractor                                                                                                              |
+| `utils/svg-chart-percent.util.ts`     | Percentage normalization and chart/table tolerance helpers                                                                                               |
+| `utils/validation.util.ts`            | XHTML and CSS validators with local and remote modes                                                                                                     |
+| `utils/track-hit.util.ts`             | Tracking-hit seeding through live snippets and `/scripts/drain.php`                                                                                      |
+| `utils/env.util.ts`                   | `.env` loading and credential validation                                                                                                                 |
+| `utils/auth-state-metadata.util.ts`   | Non-secret `.auth/metadata.json` writer for CI auth-state freshness checks                                                                               |
+| `utils/diagnosis.util.ts`             | AI diagnosis, selector-fix attachment, and redaction rules                                                                                               |
+| `utils/css-validator.util.ts`         | Pure helpers around `csstree-validator`                                                                                                                  |
+| `scripts/collect-failure-evidence.ts` | Builds CI `failure-evidence-*` artifacts with an indexed `index.md`, `manifest.json`, `results.json`, and failed-attempt attachments grouped by error id |
+| `scripts/verify-coverage-matrix.ts`   | Cross-checks active tests against `coverage-matrix.json`                                                                                                 |
+| `scripts/redact.ts`                   | stdin/stdout redaction CLI used by self-healing                                                                                                          |
+| `test-data/scripts/snippet-*.txt`     | Canonical HTML5, HTML4, and XHTML tracking snippets with `{{ORWELLSTAT_BASE}}` placeholders                                                              |
+| `test-data/scripts/tracking-*`        | HTML/HTML4/XHTML shells used by tracking E2E tests after inserting the matching live snippet                                                             |
 
 Unit tests for pure utilities run through `npm run test:unit`.
 
@@ -202,7 +203,7 @@ Defined in `tsconfig.json`:
 
 Important defaults:
 
-- Failure artifacts: screenshots, video, console log, `dom.xhtml`, and optional AI diagnosis.
+- Failure artifacts: screenshots, video, console log, `dom.xhtml`, and optional AI diagnosis. CI failed shards upload `failure-evidence-<id>-<shard>` artifacts that index those files with traces, error context, selector-fix notes, and `results.json` when Playwright produced them. Failed auth setup legs upload `failure-evidence-auth-setup-<id>` with trace, screenshot, and video capture disabled. The evidence index gives each failed attempt an error id and shows the artifact name plus the path inside that artifact for every attachment.
 - `trace: 'on-first-retry'`.
 - `baseURL` from `ENV` (`production` by default, `staging` when `ENV=staging`).
 - `httpCredentials` injected automatically when `BASIC_AUTH_USER` is set.

--- a/docs/TEST_INVENTORY.md
+++ b/docs/TEST_INVENTORY.md
@@ -42,15 +42,16 @@ This file describes what each Playwright spec covers. For commands, tags, fixtur
 
 ## Unit Test Suites
 
-| Spec                                     | Scope                             | Coverage                                                                                                                                                                       |
-| ---------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `utils/svg-chart-table.util.test.ts`     | XHTML table extraction            | Parses captured XHTML as `application/xhtml+xml`, trims cells, respects row limits, and returns `[]` on parse error or missing table.                                          |
-| `utils/svg-chart-percent.util.test.ts`   | Chart/table percentage comparison | Covers bracket stripping, integer-hundredths gap math, tolerance boundaries, and empirical 4-hundredths gaps.                                                                  |
-| `utils/diagnosis.util.test.ts`           | AI-diagnosis redaction            | Exercises cookie, set-cookie, bearer, API key, query token, JWT, email, mixed, no-match, char-budget, XHTML-structure, multiline, order-sensitivity, and bypass-attempt cases. |
-| `utils/auth-state-metadata.util.test.ts` | Auth-state metadata               | Verifies `.auth/metadata.json` contains generation time, GitHub run identifiers, and account labels without writing credential values.                                         |
-| `utils/css-validator.util.test.ts`       | CSS validation formatting         | Verifies intentionally broken CSS reports per-line errors with line numbers and source URL.                                                                                    |
-| `scripts/verify-coverage-matrix.test.ts` | Coverage-matrix drift verifier    | Covers false-positive, false-negative, in-sync, matrix-edit regression, and parser edge cases.                                                                                 |
-| `scripts/redact.test.ts`                 | Redaction CLI                     | Runs the real stdin/stdout subprocess path for `scripts/redact.ts`.                                                                                                            |
+| Spec                                       | Scope                             | Coverage                                                                                                                                                                       |
+| ------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `utils/svg-chart-table.util.test.ts`       | XHTML table extraction            | Parses captured XHTML as `application/xhtml+xml`, trims cells, respects row limits, and returns `[]` on parse error or missing table.                                          |
+| `utils/svg-chart-percent.util.test.ts`     | Chart/table percentage comparison | Covers bracket stripping, integer-hundredths gap math, tolerance boundaries, and empirical 4-hundredths gaps.                                                                  |
+| `utils/diagnosis.util.test.ts`             | AI-diagnosis redaction            | Exercises cookie, set-cookie, bearer, API key, query token, JWT, email, mixed, no-match, char-budget, XHTML-structure, multiline, order-sensitivity, and bypass-attempt cases. |
+| `utils/auth-state-metadata.util.test.ts`   | Auth-state metadata               | Verifies `.auth/metadata.json` contains generation time, GitHub run identifiers, and account labels without writing credential values.                                         |
+| `utils/css-validator.util.test.ts`         | CSS validation formatting         | Verifies intentionally broken CSS reports per-line errors with line numbers and source URL.                                                                                    |
+| `scripts/verify-coverage-matrix.test.ts`   | Coverage-matrix drift verifier    | Covers false-positive, false-negative, in-sync, matrix-edit regression, and parser edge cases.                                                                                 |
+| `scripts/collect-failure-evidence.test.ts` | Failure-evidence collector        | Covers failed-attempt indexing, attachment copying and warnings, duplicate names, visual baselines, malformed reporter shapes, top-level errors, redaction, and run metadata.  |
+| `scripts/redact.test.ts`                   | Redaction CLI                     | Runs the real stdin/stdout subprocess path for `scripts/redact.ts`.                                                                                                            |
 
 ## Coverage Matrix
 

--- a/playwright/typescript/.gitignore
+++ b/playwright/typescript/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 /test-results/
+/failure-evidence/
 /playwright-report/
 /blob-report/
 /.cache/

--- a/playwright/typescript/playwright.config.ts
+++ b/playwright/typescript/playwright.config.ts
@@ -74,6 +74,11 @@ export default defineConfig({
       testDir: '.',
       // Serial so the two account logins do not race each other or trip login throttling.
       fullyParallel: false,
+      use: {
+        trace: 'off',
+        screenshot: 'off',
+        video: 'off',
+      },
     },
     {
       name: 'Chromium',

--- a/playwright/typescript/scripts/collect-failure-evidence.test.ts
+++ b/playwright/typescript/scripts/collect-failure-evidence.test.ts
@@ -1,13 +1,14 @@
 import { after, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { collectFailureEvidence } from './collect-failure-evidence.ts';
 
 const tempDirs: string[] = [];
+const CLI_TIMEOUT_MS = 30_000;
 
 after(async () => {
   await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
@@ -22,6 +23,25 @@ async function makeTempDir(): Promise<string> {
 async function writeFixture(path: string, contents: string): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, contents);
+}
+
+function assertRecord(value: unknown): asserts value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new assert.AssertionError({ message: 'Expected a plain object' });
+  }
+}
+
+function assertRecordArray(value: unknown): asserts value is Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    throw new assert.AssertionError({ message: 'Expected an array' });
+  }
+  for (const item of value) assertRecord(item);
+}
+
+function assertFsErrorCode(error: unknown, code: string): true {
+  assertRecord(error);
+  assert.equal(error.code, code);
+  return true;
 }
 
 test('collects failed retry attachments into a readable evidence index', async () => {
@@ -158,19 +178,22 @@ test('collects failed retry attachments into a readable evidence index', async (
   );
   assert.equal(await readFile(join(out, 'failures/F002-R1/trace.zip'), 'utf8'), 'trace');
 
-  const manifestJson = JSON.parse(
-    await readFile(join(out, 'manifest.json'), 'utf8')
-  ) as typeof manifest;
+  const manifestJson: unknown = JSON.parse(await readFile(join(out, 'manifest.json'), 'utf8'));
+  assertRecord(manifestJson);
   assert.equal(manifestJson.artifactName, 'failure-evidence-webkit-1');
   assert.equal(manifestJson.runId, '28742473811');
   assert.equal(manifestJson.project, 'Webkit');
   assert.equal(manifestJson.shard, '1');
   assert.equal(manifestJson.totalShards, '2');
   assert.equal(manifestJson.resultsPath, 'results.json');
+  assertRecordArray(manifestJson.failures);
   assert.equal(manifestJson.failures.length, 2);
-  assert.equal(manifestJson.failures[0].attemptId, 'F001-R0');
-  assert.equal(manifestJson.failures[0].error, 'Test timeout of 30000ms exceeded.');
-  assert.equal('sourcePath' in manifestJson.failures[0].attachments[0], false);
+  const firstFailure = manifestJson.failures[0];
+  assert.equal(firstFailure.attemptId, 'F001-R0');
+  assert.equal(firstFailure.duration, 35164);
+  assert.equal(firstFailure.error, 'Test timeout of 30000ms exceeded.');
+  assertRecordArray(firstFailure.attachments);
+  assert.equal('sourcePath' in firstFailure.attachments[0], false);
   assert.equal(
     await readFile(join(out, 'results.json'), 'utf8'),
     `${JSON.stringify(results, null, 2)}\n`
@@ -187,6 +210,7 @@ test('collects failed retry attachments into a readable evidence index', async (
   assert.match(index, /\| Results \| results\.json \|/);
   assert.match(index, /## Error F001-R0/);
   assert.match(index, /\| Test \| navigation\.spec\.ts:20 - \/zone\/hits\/ has correct title \|/);
+  assert.match(index, /\| Duration \| 35164ms \|/);
   assert.match(index, /\| Error message \| Test timeout of 30000ms exceeded\. \|/);
   assert.doesNotMatch(index, /\u001b|\[31m|\[39m/);
   assert.doesNotMatch(index, /\/test-results\/results\.json/);
@@ -197,6 +221,59 @@ test('collects failed retry attachments into a readable evidence index', async (
   assert.match(
     index,
     /\| F002-R1 \| trace\.zip \| failure-evidence-webkit-1 \| failures\/F002-R1\/trace\.zip \|/
+  );
+});
+
+test('starts from a fresh output directory before collecting evidence', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+
+  await writeFixture(join(source, 'results.json'), `${JSON.stringify({ suites: [] })}\n`);
+  await writeFixture(join(out, 'unexpected-secret.txt'), 'stale');
+  await writeFixture(join(out, 'failures', 'old.txt'), 'stale');
+
+  await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '1',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  await assert.rejects(readFile(join(out, 'unexpected-secret.txt'), 'utf8'), (error) =>
+    assertFsErrorCode(error, 'ENOENT')
+  );
+  await assert.rejects(readFile(join(out, 'failures', 'old.txt'), 'utf8'), (error) =>
+    assertFsErrorCode(error, 'ENOENT')
+  );
+});
+
+test('rejects a symlinked output directory', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const realOut = join(root, 'real-output');
+  const out = join(root, 'failure-evidence');
+
+  await writeFixture(join(source, 'results.json'), `${JSON.stringify({ suites: [] })}\n`);
+  await mkdir(realOut);
+  await symlink(realOut, out, 'dir');
+
+  await assert.rejects(
+    collectFailureEvidence({
+      resultsPath: join(source, 'results.json'),
+      sourceDir: source,
+      outDir: out,
+      project: 'Webkit',
+      shard: '1',
+      totalShards: '1',
+      artifactName: 'failure-evidence-webkit-1',
+      generatedAt: '2026-07-05T12:00:00.000Z',
+    }),
+    (error) => assertFsErrorCode(error, 'ELOOP')
   );
 });
 
@@ -242,6 +319,412 @@ test('writes a warning index when results.json is malformed', async () => {
   assert.deepEqual(manifest.failures, []);
   assert.match(manifest.warnings[0], /Could not parse results/);
   assert.match(await readFile(join(out, 'index.md'), 'utf8'), /Could not parse results/);
+});
+
+test('rejects unexpected filesystem errors while reading results.json', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const directoryResultPath = join(source, 'results.json');
+  await mkdir(directoryResultPath, { recursive: true });
+
+  await assert.rejects(
+    collectFailureEvidence({
+      resultsPath: directoryResultPath,
+      sourceDir: source,
+      outDir: out,
+      project: 'Webkit',
+      shard: '1',
+      totalShards: '2',
+      artifactName: 'failure-evidence-webkit-1',
+      generatedAt: '2026-07-05T12:00:00.000Z',
+    }),
+    (error: unknown) => assertFsErrorCode(error, 'EISDIR')
+  );
+});
+
+test('does not read a symlinked results file that resolves outside the source directory', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const outsideResults = join(root, 'outside-results.json');
+  const symlinkedResults = join(source, 'results.json');
+
+  await writeFixture(
+    outsideResults,
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'storage-state.spec.ts',
+              title: 'outside storage state',
+              tests: [],
+            },
+          ],
+        },
+      ],
+      cookies: [{ name: 'session', value: 'plain-secret-cookie' }],
+    })}\n`
+  );
+  await mkdir(source, { recursive: true });
+  await symlink(outsideResults, symlinkedResults);
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: symlinkedResults,
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.deepEqual(manifest.failures, []);
+  assert.deepEqual(manifest.warnings, ['Results file path is outside source directory.']);
+  assert.equal(manifest.resultsPath, null);
+  await assert.rejects(readFile(join(out, 'results.json'), 'utf8'));
+  assert.doesNotMatch(await readFile(join(out, 'index.md'), 'utf8'), /plain-secret-cookie/);
+});
+
+test('writes a warning index when results.json is valid but not an object', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  await writeFixture(join(source, 'results.json'), '[]\n');
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.deepEqual(manifest.failures, []);
+  assert.deepEqual(manifest.warnings, ['results.json did not contain a Playwright JSON object.']);
+  assert.equal(manifest.resultsPath, 'results.json');
+  assert.equal(await readFile(join(out, 'results.json'), 'utf8'), '[]\n');
+  assert.match(
+    await readFile(join(out, 'index.md'), 'utf8'),
+    /results\.json did not contain a Playwright JSON object\./
+  );
+});
+
+test('surfaces top-level Playwright errors when no failed attempts exist', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      errors: [{ message: 'Global setup failed before tests started' }],
+      suites: [],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.deepEqual(manifest.failures, []);
+  assert.match(manifest.warnings[0], /Global setup failed before tests started/);
+  const index = await readFile(join(out, 'index.md'), 'utf8');
+  assert.match(index, /Global setup failed before tests started/);
+  assert.match(index, /No results contained failed Playwright attempts/);
+});
+
+test('ignores malformed reporter array elements instead of crashing', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        null,
+        {
+          suites: [null],
+          specs: [
+            null,
+            {
+              file: 'shape.spec.ts',
+              title: 'valid failed attempt',
+              tests: [
+                null,
+                {
+                  projectName: 'Webkit',
+                  results: [null, { retry: 0, status: 'failed', attachments: [null] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.equal(manifest.failures.length, 1);
+  assert.equal(manifest.failures[0].title, 'valid failed attempt');
+  assert.equal(manifest.failures[0].duration, null);
+  assert.equal(manifest.failures[0].attachments.length, 0);
+  assert.match(await readFile(join(out, 'index.md'), 'utf8'), /\| Duration \| unknown \|/);
+});
+
+test('redacts sensitive patterns from copied results, manifest, and index', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      errors: [{ message: 'bearer abcdefghijkl' }],
+      suites: [
+        {
+          specs: [
+            {
+              file: 'auth.setup.ts',
+              title: 'login alice@example.com',
+              tests: [
+                {
+                  projectName: 'setup',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      error: { message: 'Expected alice@example.com to be visible' },
+                      attachments: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  const manifestJson = await readFile(join(out, 'manifest.json'), 'utf8');
+  const index = await readFile(join(out, 'index.md'), 'utf8');
+  const copiedResults = await readFile(join(out, 'results.json'), 'utf8');
+
+  assert.equal(manifest.failures[0].error, 'Expected a***@example.com to be visible');
+  for (const text of [manifestJson, index, copiedResults]) {
+    assert.doesNotMatch(text, /alice@example\.com|abcdefghijkl/);
+    assert.match(text, /a\*\*\*@example\.com|\[REDACTED\]/);
+  }
+});
+
+test('withholds auth setup results and error text without requiring secret env values', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const originalUser = process.env.ORWELLSTAT_USER;
+  const originalEmptyUser = process.env.ORWELLSTAT_USER_EMPTY;
+  delete process.env.ORWELLSTAT_USER;
+  delete process.env.ORWELLSTAT_USER_EMPTY;
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      errors: [{ message: 'Login failed for plain-secret-user' }],
+      suites: [
+        {
+          specs: [
+            {
+              file: 'auth.setup.ts',
+              title: 'authenticate populated account',
+              tests: [
+                {
+                  projectName: 'setup',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      error: { message: 'Expected plain-secret-user to be visible' },
+                      attachments: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  try {
+    const manifest = await collectFailureEvidence({
+      resultsPath: join(source, 'results.json'),
+      sourceDir: source,
+      outDir: out,
+      project: 'setup',
+      shard: 'auth-setup',
+      totalShards: '1',
+      artifactName: 'failure-evidence-auth-setup-webkit',
+      withholdSensitiveDetails: true,
+      generatedAt: '2026-07-05T12:00:00.000Z',
+    });
+
+    assert.equal(manifest.resultsPath, null);
+    assert.equal(manifest.failures[0].error, null);
+    assert.match(manifest.warnings[0], /withheld/);
+    await assert.rejects(readFile(join(out, 'results.json'), 'utf8'));
+
+    const manifestJson = await readFile(join(out, 'manifest.json'), 'utf8');
+    const index = await readFile(join(out, 'index.md'), 'utf8');
+    for (const text of [manifestJson, index]) {
+      assert.doesNotMatch(text, /plain-secret-user/);
+      assert.match(text, /withheld/);
+    }
+  } finally {
+    if (originalUser === undefined) delete process.env.ORWELLSTAT_USER;
+    else process.env.ORWELLSTAT_USER = originalUser;
+    if (originalEmptyUser === undefined) delete process.env.ORWELLSTAT_USER_EMPTY;
+    else process.env.ORWELLSTAT_USER_EMPTY = originalEmptyUser;
+  }
+});
+
+test('withholds sensitive details from any artifact when explicitly requested', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const attempt = join(source, 'withheld-attachment');
+  await writeFixture(join(attempt, 'console.log'), 'alice@example.com');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      errors: [{ message: 'Login failed for plain-secret-user' }],
+      suites: [
+        {
+          specs: [
+            {
+              file: 'plain-secret-user.spec.ts',
+              title: 'explicit sensitive mode for plain-secret-user',
+              tests: [
+                {
+                  projectName: 'plain-secret-user-project',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      duration: 3210,
+                      error: { message: 'Expected plain-secret-user to be visible' },
+                      attachments: [
+                        {
+                          name: 'plain-secret-user console logs',
+                          contentType: 'plain-secret-user/content',
+                          path: join(attempt, 'console.log'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'setup',
+    shard: 'auth-setup',
+    totalShards: '1',
+    artifactName: 'failure-evidence-webkit-1',
+    withholdSensitiveDetails: true,
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.equal(manifest.resultsPath, null);
+  const failure = manifest.failures[0];
+  assert.equal(failure.attemptId, 'F001-R0');
+  assert.equal(failure.specFile, 'withheld');
+  assert.equal(failure.line, null);
+  assert.equal(failure.title, 'Withheld failure F001-R0');
+  assert.equal(failure.projectName, 'withheld');
+  assert.equal(failure.duration, null);
+  assert.equal(failure.error, null);
+  assert.equal(failure.attachments[0].name, 'Attachment 1');
+  assert.equal(failure.attachments[0].contentType, null);
+  assert.equal(failure.attachments[0].outputPath, 'failures/F001-R0/attachment-01.txt');
+  assert.equal(failure.attachments[0].copied, false);
+  assert.equal(failure.attachments[0].warning, 'attachment body withheld');
+  await assert.rejects(readFile(join(out, 'results.json'), 'utf8'));
+  await assert.rejects(readFile(join(out, failure.attachments[0].outputPath), 'utf8'));
+
+  const manifestJson = await readFile(join(out, 'manifest.json'), 'utf8');
+  const index = await readFile(join(out, 'index.md'), 'utf8');
+  for (const text of [manifestJson, index]) {
+    assert.doesNotMatch(text, /plain-secret-user/);
+    assert.doesNotMatch(text, /explicit sensitive mode/);
+    assert.doesNotMatch(text, /console logs/);
+  }
+});
+
+test('uses a generic parse warning when sensitive details are withheld', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  await writeFixture(join(source, 'results.json'), '{"message":"plain-secret-user"');
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'setup',
+    shard: 'auth-setup',
+    totalShards: '1',
+    artifactName: 'failure-evidence-webkit-1',
+    withholdSensitiveDetails: true,
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.deepEqual(manifest.failures, []);
+  assert.equal(manifest.resultsPath, null);
+  assert.match(manifest.warnings[0], /withheld/);
+  assert.match(manifest.warnings[1], /Could not parse results\.json\./);
+  assert.doesNotMatch(manifest.warnings.join('\n'), /plain-secret-user|position|Unexpected/);
+  await assert.rejects(readFile(join(out, 'results.json'), 'utf8'));
+  assert.doesNotMatch(await readFile(join(out, 'index.md'), 'utf8'), /plain-secret-user/);
 });
 
 test('does not copy attachment paths outside the source directory', async () => {
@@ -301,6 +784,389 @@ test('does not copy attachment paths outside the source directory', async () => 
   assert.equal(attachment.warning, 'attachment path is outside source directory');
   assert.equal(attachment.outputPath, 'failures/F001-R0/console-logs.log');
   await assert.rejects(readFile(join(out, attachment.outputPath), 'utf8'));
+});
+
+test('does not copy symlinked attachments that resolve outside the source directory', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const attempt = join(source, 'symlink-attempt');
+  const outsideAttachment = join(root, 'outside.log');
+  const symlinkedAttachment = join(attempt, 'console.log');
+
+  await writeFixture(outsideAttachment, 'outside');
+  await mkdir(attempt, { recursive: true });
+  await symlink(outsideAttachment, symlinkedAttachment);
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'security.spec.ts',
+              line: 1,
+              title: 'symlinked outside attachment path',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'console logs',
+                          contentType: 'text/plain',
+                          path: symlinkedAttachment,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  const attachment = manifest.failures[0].attachments[0];
+  assert.equal(attachment.copied, false);
+  assert.equal(attachment.warning, 'attachment path is outside source directory');
+  assert.equal(attachment.outputPath, 'failures/F001-R0/console-logs.log');
+  await assert.rejects(readFile(join(out, attachment.outputPath), 'utf8'));
+});
+
+test('copies valid attachment paths that contain redaction-shaped segments', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const attempt = join(source, 'alice@example.com-attempt');
+  await writeFixture(join(attempt, 'console.log'), 'console');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'email-path.spec.ts',
+              title: 'email-shaped attachment path',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'console logs',
+                          contentType: 'text/plain',
+                          path: join(attempt, 'console.log'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  const attachment = manifest.failures[0].attachments[0];
+  assert.equal(attachment.copied, true);
+  assert.equal(attachment.warning, undefined);
+  assert.equal(await readFile(join(out, attachment.outputPath), 'utf8'), 'console');
+  assert.doesNotMatch(await readFile(join(out, 'manifest.json'), 'utf8'), /alice@example\.com/);
+  assert.doesNotMatch(await readFile(join(out, 'results.json'), 'utf8'), /alice@example\.com/);
+});
+
+test('redacts text attachment bodies before copying them', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const attempt = join(source, 'text-attachment-Webkit');
+  await writeFixture(join(attempt, 'console.log'), 'user alice@example.com bearer abcdefghijkl');
+  await writeFixture(join(attempt, 'structured'), '{"email":"alice@example.com"}');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'text-attachment.spec.ts',
+              title: 'text attachment body',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'console logs',
+                          contentType: 'text/plain',
+                          path: join(attempt, 'console.log'),
+                        },
+                        {
+                          name: 'structured',
+                          contentType: 'application/json',
+                          path: join(attempt, 'structured'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  const attachment = manifest.failures[0].attachments[0];
+  assert.equal(attachment.copied, true);
+  const copied = await readFile(join(out, attachment.outputPath), 'utf8');
+  assert.equal(copied, 'user a***@example.com bearer [REDACTED]');
+
+  const structured = manifest.failures[0].attachments[1];
+  assert.equal(structured.copied, true);
+  assert.equal(
+    await readFile(join(out, structured.outputPath), 'utf8'),
+    '{"email":"a***@example.com"}'
+  );
+});
+
+test('withholds binary attachment bodies while copying configured-secret-redacted text evidence', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const attempt = join(source, 'binary-withheld-Webkit');
+  const originalUser = process.env.ORWELLSTAT_USER;
+  process.env.ORWELLSTAT_USER = 'plain-secret-user';
+  await writeFixture(join(attempt, 'test-failed-1.png'), 'raw screenshot pixels');
+  await writeFixture(join(attempt, 'console.log'), 'user plain-secret-user');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'binary-withheld.spec.ts',
+              title: 'binary attachment body',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'screenshot',
+                          contentType: 'image/png',
+                          path: join('binary-cli-Webkit', 'test-failed-1.png'),
+                        },
+                        {
+                          name: 'console logs',
+                          contentType: 'text/plain',
+                          path: join(attempt, 'console.log'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  try {
+    const manifest = await collectFailureEvidence({
+      resultsPath: join(source, 'results.json'),
+      sourceDir: source,
+      outDir: out,
+      project: 'Webkit',
+      shard: '1',
+      totalShards: '2',
+      artifactName: 'failure-evidence-webkit-1',
+      withholdBinaryAttachments: true,
+      redactEnvNames: ['ORWELLSTAT_USER'],
+      generatedAt: '2026-07-05T12:00:00.000Z',
+    });
+
+    const [screenshot, consoleLog] = manifest.failures[0].attachments;
+    assert.equal(screenshot.copied, false);
+    assert.equal(screenshot.warning, 'binary attachment body withheld');
+    await assert.rejects(readFile(join(out, screenshot.outputPath), 'utf8'));
+    assert.equal(consoleLog.copied, true);
+    assert.equal(await readFile(join(out, consoleLog.outputPath), 'utf8'), 'user [REDACTED]');
+    assert.match(await readFile(join(out, 'index.md'), 'utf8'), /binary attachment body withheld/);
+    assert.doesNotMatch(await readFile(join(out, 'manifest.json'), 'utf8'), /plain-secret-user/);
+  } finally {
+    if (originalUser === undefined) delete process.env.ORWELLSTAT_USER;
+    else process.env.ORWELLSTAT_USER = originalUser;
+  }
+});
+
+test('reports missing attachment files inside the source directory', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const attempt = join(source, 'missing-file-Webkit');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'missing-file.spec.ts',
+              title: 'missing attachment file',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'console logs',
+                          contentType: 'text/plain',
+                          path: join(attempt, 'console.log'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  const attachment = manifest.failures[0].attachments[0];
+  assert.equal(attachment.copied, false);
+  assert.equal(attachment.warning, 'attachment file is missing');
+  assert.equal(attachment.outputPath, 'failures/F001-R0/console-logs.log');
+  await assert.rejects(readFile(join(out, attachment.outputPath), 'utf8'));
+  assert.match(await readFile(join(out, 'index.md'), 'utf8'), /attachment file is missing/);
+});
+
+test('rejects unexpected filesystem errors while copying attachments', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const attempt = join(source, 'directory-attachment-Webkit');
+  const directoryAttachment = join(attempt, 'console.log');
+  await mkdir(directoryAttachment, { recursive: true });
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'directory-attachment.spec.ts',
+              title: 'directory attachment file',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'console logs',
+                          contentType: 'text/plain',
+                          path: directoryAttachment,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  await assert.rejects(
+    collectFailureEvidence({
+      resultsPath: join(source, 'results.json'),
+      sourceDir: source,
+      outDir: out,
+      project: 'Webkit',
+      shard: '1',
+      totalShards: '2',
+      artifactName: 'failure-evidence-webkit-1',
+      generatedAt: '2026-07-05T12:00:00.000Z',
+    }),
+    (error: unknown) => assertFsErrorCode(error, 'EISDIR')
+  );
 });
 
 test('copies visual snapshot baseline attachments from the project snapshots directory', async () => {
@@ -687,7 +1553,7 @@ test('CLI uses default paths and rejects invalid arguments', async () => {
   const ok = spawnSync(
     process.execPath,
     ['--experimental-strip-types', '--disable-warning=ExperimentalWarning', script],
-    { cwd: root, encoding: 'utf8' }
+    { cwd: root, encoding: 'utf8', timeout: CLI_TIMEOUT_MS }
   );
   assert.equal(ok.status, 0, ok.stderr);
   assert.match(await readFile(join(root, 'failure-evidence', 'index.md'), 'utf8'), /No results/);
@@ -695,8 +1561,130 @@ test('CLI uses default paths and rejects invalid arguments', async () => {
   const missingValue = spawnSync(
     process.execPath,
     ['--experimental-strip-types', '--disable-warning=ExperimentalWarning', script, '--results'],
-    { cwd: root, encoding: 'utf8' }
+    { cwd: root, encoding: 'utf8', timeout: CLI_TIMEOUT_MS }
   );
   assert.notEqual(missingValue.status, 0);
   assert.match(missingValue.stderr, /Missing value|expects an argument|argument missing/);
+});
+
+test('CLI withholds binary attachments when requested', async () => {
+  const root = await makeTempDir();
+  const attempt = join(root, 'test-results', 'binary-cli-Webkit');
+  await writeFixture(join(attempt, 'test-failed-1.png'), 'raw screenshot pixels');
+  await writeFixture(join(attempt, 'console.log'), 'user plain-secret-user');
+  await writeFixture(
+    join(root, 'test-results', 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'binary-cli.spec.ts',
+              title: 'binary cli attachment',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'screenshot',
+                          contentType: 'image/png',
+                          path: join('binary-cli-Webkit', 'test-failed-1.png'),
+                        },
+                        {
+                          name: 'console logs',
+                          contentType: 'text/plain',
+                          path: join('binary-cli-Webkit', 'console.log'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+  const script = fileURLToPath(new URL('collect-failure-evidence.ts', import.meta.url));
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--experimental-strip-types',
+      '--disable-warning=ExperimentalWarning',
+      script,
+      '--withhold-binary-attachments',
+      '--redact-env-names',
+      'ORWELLSTAT_USER',
+    ],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, ORWELLSTAT_USER: 'plain-secret-user' },
+      timeout: CLI_TIMEOUT_MS,
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const index = await readFile(join(root, 'failure-evidence', 'index.md'), 'utf8');
+  assert.match(index, /binary attachment body withheld/);
+  assert.equal(
+    await readFile(join(root, 'failure-evidence', 'failures/F001-R0/console-logs.log'), 'utf8'),
+    'user [REDACTED]'
+  );
+  assert.doesNotMatch(
+    await readFile(join(root, 'failure-evidence', 'manifest.json'), 'utf8'),
+    /plain-secret-user/
+  );
+  await assert.rejects(readFile(join(root, 'failure-evidence', 'failures/F001-R0/screenshot.png')));
+});
+
+test('uses GITHUB_RUN_ID when run id is not passed and omits the download command when unset', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const outWithEnv = join(root, 'failure-evidence-env');
+  const outWithoutEnv = join(root, 'failure-evidence-no-env');
+  const originalRunId = process.env.GITHUB_RUN_ID;
+  await writeFixture(join(source, 'results.json'), '{"suites":[]}\n');
+
+  try {
+    process.env.GITHUB_RUN_ID = '999999';
+    const withEnv = await collectFailureEvidence({
+      resultsPath: join(source, 'results.json'),
+      sourceDir: source,
+      outDir: outWithEnv,
+      project: 'Webkit',
+      shard: '1',
+      totalShards: '2',
+      artifactName: 'failure-evidence-webkit-1',
+      generatedAt: '2026-07-05T12:00:00.000Z',
+    });
+    assert.equal(withEnv.runId, '999999');
+    assert.match(
+      await readFile(join(outWithEnv, 'index.md'), 'utf8'),
+      /gh run download 999999 --name failure-evidence-webkit-1/
+    );
+
+    delete process.env.GITHUB_RUN_ID;
+    const withoutEnv = await collectFailureEvidence({
+      resultsPath: join(source, 'results.json'),
+      sourceDir: source,
+      outDir: outWithoutEnv,
+      project: 'Webkit',
+      shard: '1',
+      totalShards: '2',
+      artifactName: 'failure-evidence-webkit-1',
+      generatedAt: '2026-07-05T12:00:00.000Z',
+    });
+    assert.equal(withoutEnv.runId, null);
+    assert.match(await readFile(join(outWithoutEnv, 'index.md'), 'utf8'), /not available/);
+  } finally {
+    if (originalRunId === undefined) delete process.env.GITHUB_RUN_ID;
+    else process.env.GITHUB_RUN_ID = originalRunId;
+  }
 });

--- a/playwright/typescript/scripts/collect-failure-evidence.test.ts
+++ b/playwright/typescript/scripts/collect-failure-evidence.test.ts
@@ -1,0 +1,702 @@
+import { after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { collectFailureEvidence } from './collect-failure-evidence.ts';
+
+const tempDirs: string[] = [];
+
+after(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'orwellstat-failure-evidence-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeFixture(path: string, contents: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents);
+}
+
+test('collects failed retry attachments into a readable evidence index', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const firstAttempt = join(source, 'navigation-zone-hits-Webkit');
+  const retryAttempt = join(source, 'navigation-zone-hits-Webkit-retry1');
+
+  await writeFixture(join(firstAttempt, 'test-failed-1.png'), 'png');
+  await writeFixture(join(firstAttempt, 'video.webm'), 'video');
+  await writeFixture(join(firstAttempt, 'console.log'), 'console');
+  await writeFixture(join(firstAttempt, 'error-context.md'), 'context');
+  await writeFixture(join(firstAttempt, 'selector-fix.md'), 'selector fix');
+  await writeFixture(join(firstAttempt, 'attachments', 'DOM-123.xhtml'), '<html></html>');
+  await writeFixture(join(firstAttempt, 'attachments', 'AI-diagnosis-123.md'), 'diagnosis');
+  await writeFixture(join(retryAttempt, 'trace.zip'), 'trace');
+
+  const results = {
+    suites: [
+      {
+        specs: [
+          {
+            file: 'navigation.spec.ts',
+            line: 20,
+            title: '/zone/hits/ has correct title',
+            tests: [
+              {
+                projectName: 'Webkit',
+                results: [
+                  {
+                    retry: 0,
+                    status: 'timedOut',
+                    duration: 35_164,
+                    error: { message: '\u001b[31mTest timeout of 30000ms exceeded.\u001b[39m' },
+                    attachments: [
+                      {
+                        name: 'screenshot',
+                        contentType: 'image/png',
+                        path: join(firstAttempt, 'test-failed-1.png'),
+                      },
+                      {
+                        name: 'DOM',
+                        contentType: 'text/html',
+                        path: join(firstAttempt, 'attachments', 'DOM-123.xhtml'),
+                      },
+                      {
+                        name: 'AI diagnosis',
+                        contentType: 'text/plain',
+                        path: join(firstAttempt, 'attachments', 'AI-diagnosis-123.md'),
+                      },
+                      {
+                        name: 'console logs',
+                        contentType: 'text/plain',
+                        path: join(firstAttempt, 'console.log'),
+                      },
+                      {
+                        name: 'video',
+                        contentType: 'video/webm',
+                        path: join(firstAttempt, 'video.webm'),
+                      },
+                      {
+                        name: 'error-context',
+                        contentType: 'text/markdown',
+                        path: join(firstAttempt, 'error-context.md'),
+                      },
+                      {
+                        name: 'Selector fix',
+                        contentType: 'text/plain',
+                        path: join(firstAttempt, 'selector-fix.md'),
+                      },
+                    ],
+                  },
+                  {
+                    retry: 1,
+                    status: 'failed',
+                    duration: 1200,
+                    errors: [{ message: 'Expected title to match' }],
+                    attachments: [
+                      {
+                        name: 'trace',
+                        contentType: 'application/zip',
+                        path: join(retryAttempt, 'trace.zip'),
+                      },
+                    ],
+                  },
+                  {
+                    retry: 2,
+                    status: 'passed',
+                    duration: 900,
+                    attachments: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  await writeFixture(join(source, 'results.json'), `${JSON.stringify(results, null, 2)}\n`);
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    runId: '28742473811',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.equal(manifest.failures.length, 2);
+  assert.equal(manifest.failures[0].title, '/zone/hits/ has correct title');
+  assert.equal(manifest.failures[0].retry, 0);
+  assert.equal(manifest.failures[0].attachments.length, 7);
+  assert.deepEqual(
+    manifest.failures[0].attachments.map((attachment) => attachment.outputPath),
+    [
+      'failures/F001-R0/screenshot.png',
+      'failures/F001-R0/DOM.xhtml',
+      'failures/F001-R0/AI-diagnosis.md',
+      'failures/F001-R0/console-logs.log',
+      'failures/F001-R0/video.webm',
+      'failures/F001-R0/error-context.md',
+      'failures/F001-R0/Selector-fix.md',
+    ]
+  );
+  assert.equal(
+    await readFile(join(out, manifest.failures[0].attachments[0].outputPath), 'utf8'),
+    'png'
+  );
+  assert.equal(await readFile(join(out, 'failures/F002-R1/trace.zip'), 'utf8'), 'trace');
+
+  const manifestJson = JSON.parse(
+    await readFile(join(out, 'manifest.json'), 'utf8')
+  ) as typeof manifest;
+  assert.equal(manifestJson.artifactName, 'failure-evidence-webkit-1');
+  assert.equal(manifestJson.runId, '28742473811');
+  assert.equal(manifestJson.project, 'Webkit');
+  assert.equal(manifestJson.shard, '1');
+  assert.equal(manifestJson.totalShards, '2');
+  assert.equal(manifestJson.resultsPath, 'results.json');
+  assert.equal(manifestJson.failures.length, 2);
+  assert.equal(manifestJson.failures[0].attemptId, 'F001-R0');
+  assert.equal(manifestJson.failures[0].error, 'Test timeout of 30000ms exceeded.');
+  assert.equal('sourcePath' in manifestJson.failures[0].attachments[0], false);
+  assert.equal(
+    await readFile(join(out, 'results.json'), 'utf8'),
+    `${JSON.stringify(results, null, 2)}\n`
+  );
+
+  const index = await readFile(join(out, 'index.md'), 'utf8');
+  assert.match(index, /# Playwright Failure Evidence/);
+  assert.match(index, /\| Run \| 28742473811 \|/);
+  assert.match(index, /\| Artifact \| failure-evidence-webkit-1 \|/);
+  assert.match(
+    index,
+    /\| Download command \| gh run download 28742473811 --name failure-evidence-webkit-1 \|/
+  );
+  assert.match(index, /\| Results \| results\.json \|/);
+  assert.match(index, /## Error F001-R0/);
+  assert.match(index, /\| Test \| navigation\.spec\.ts:20 - \/zone\/hits\/ has correct title \|/);
+  assert.match(index, /\| Error message \| Test timeout of 30000ms exceeded\. \|/);
+  assert.doesNotMatch(index, /\u001b|\[31m|\[39m/);
+  assert.doesNotMatch(index, /\/test-results\/results\.json/);
+  assert.match(
+    index,
+    /\| F001-R0 \| screenshot\.png \| failure-evidence-webkit-1 \| failures\/F001-R0\/screenshot\.png \|/
+  );
+  assert.match(
+    index,
+    /\| F002-R1 \| trace\.zip \| failure-evidence-webkit-1 \| failures\/F002-R1\/trace\.zip \|/
+  );
+});
+
+test('writes an empty index when results.json is missing', async () => {
+  const root = await makeTempDir();
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(root, 'test-results', 'results.json'),
+    sourceDir: join(root, 'test-results'),
+    outDir: join(root, 'failure-evidence'),
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    runId: null,
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.deepEqual(manifest.failures, []);
+  assert.equal(manifest.warnings.length, 1);
+  const index = await readFile(join(root, 'failure-evidence', 'index.md'), 'utf8');
+  assert.match(index, /No results/);
+  assert.match(index, /\| Download command \| not available \|/);
+  assert.match(index, /\| Results \| not produced \|/);
+});
+
+test('writes a warning index when results.json is malformed', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  await writeFixture(join(source, 'results.json'), '{not json');
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.deepEqual(manifest.failures, []);
+  assert.match(manifest.warnings[0], /Could not parse results/);
+  assert.match(await readFile(join(out, 'index.md'), 'utf8'), /Could not parse results/);
+});
+
+test('does not copy attachment paths outside the source directory', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const outsideAttachment = join(root, 'outside.log');
+  await writeFixture(outsideAttachment, 'outside');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'security.spec.ts',
+              line: 1,
+              title: 'outside attachment path',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'console logs',
+                          contentType: 'text/plain',
+                          path: outsideAttachment,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  const attachment = manifest.failures[0].attachments[0];
+  assert.equal(attachment.copied, false);
+  assert.equal(attachment.warning, 'attachment path is outside source directory');
+  assert.equal(attachment.outputPath, 'failures/F001-R0/console-logs.log');
+  await assert.rejects(readFile(join(out, attachment.outputPath), 'utf8'));
+});
+
+test('copies visual snapshot baseline attachments from the project snapshots directory', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const snapshots = join(root, 'tests', 'visual.spec.ts-snapshots');
+  const expectedImage = join(snapshots, 'about-page-Webkit-linux.png');
+  await writeFixture(expectedImage, 'expected baseline');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'visual.spec.ts',
+              line: 98,
+              title: 'about page visual regression',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'about-page-expected.png',
+                          contentType: 'image/png',
+                          path: expectedImage,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  const attachment = manifest.failures[0].attachments[0];
+  assert.equal(attachment.copied, true);
+  assert.equal(attachment.warning, undefined);
+  assert.equal(attachment.outputPath, 'failures/F001-R0/about-page-expected.png');
+  assert.equal(await readFile(join(out, attachment.outputPath), 'utf8'), 'expected baseline');
+  assert.match(
+    await readFile(join(out, 'index.md'), 'utf8'),
+    /\| F001-R0 \| about-page-expected\.png \| failure-evidence-webkit-1 \| failures\/F001-R0\/about-page-expected\.png \|  \|/
+  );
+});
+
+test('reports attachments with no path without copying a file', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'missing-path.spec.ts',
+              title: 'missing attachment path',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'console logs',
+                          contentType: 'text/plain',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  const attachment = manifest.failures[0].attachments[0];
+  assert.equal(attachment.copied, false);
+  assert.equal(attachment.warning, 'attachment has no path');
+  assert.equal(attachment.outputPath, 'failures/F001-R0/console-logs.txt');
+  const index = await readFile(join(out, 'index.md'), 'utf8');
+  assert.match(index, /attachment has no path/);
+});
+
+test('renders failed attempts with no attachments explicitly', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'empty-attachments.spec.ts',
+              title: 'no attachments',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [{ retry: 0, status: 'failed', attachments: [] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.match(
+    await readFile(join(out, 'index.md'), 'utf8'),
+    /No attachments were listed for Error F001-R0\./
+  );
+});
+
+test('keeps duplicate attachment names as separate files', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const attempt = join(source, 'duplicate-attachments-Webkit');
+  await writeFixture(join(attempt, 'first.png'), 'first');
+  await writeFixture(join(attempt, 'second.png'), 'second');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'duplicate.spec.ts',
+              title: 'duplicate attachment names',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'screenshot',
+                          contentType: 'image/png',
+                          path: join(attempt, 'first.png'),
+                        },
+                        {
+                          name: 'screenshot',
+                          contentType: 'image/png',
+                          path: join(attempt, 'second.png'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.deepEqual(
+    manifest.failures[0].attachments.map((attachment) => attachment.outputPath),
+    ['failures/F001-R0/screenshot.png', 'failures/F001-R0/screenshot-2.png']
+  );
+  assert.equal(
+    await readFile(join(out, manifest.failures[0].attachments[0].outputPath), 'utf8'),
+    'first'
+  );
+  assert.equal(
+    await readFile(join(out, manifest.failures[0].attachments[1].outputPath), 'utf8'),
+    'second'
+  );
+});
+
+test('keeps same-title failures in separate error directories', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const firstAttempt = join(source, 'first');
+  const secondAttempt = join(source, 'second');
+  await writeFixture(join(firstAttempt, 'screenshot.png'), 'first');
+  await writeFixture(join(secondAttempt, 'screenshot.png'), 'second');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'collision.spec.ts',
+              line: 10,
+              title: 'same visible title',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'screenshot',
+                          contentType: 'image/png',
+                          path: join(firstAttempt, 'screenshot.png'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              file: 'collision.spec.ts',
+              line: 20,
+              title: 'same visible title',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'screenshot',
+                          contentType: 'image/png',
+                          path: join(secondAttempt, 'screenshot.png'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  const manifest = await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  assert.deepEqual(
+    manifest.failures.map((failure) => failure.attemptId),
+    ['F001-R0', 'F002-R0']
+  );
+  assert.equal(await readFile(join(out, 'failures/F001-R0/screenshot.png'), 'utf8'), 'first');
+  assert.equal(await readFile(join(out, 'failures/F002-R0/screenshot.png'), 'utf8'), 'second');
+});
+
+test('sanitizes markdown-sensitive attachment names in the index', async () => {
+  const root = await makeTempDir();
+  const source = join(root, 'test-results');
+  const out = join(root, 'failure-evidence');
+  const attempt = join(source, 'markdown');
+  await writeFixture(join(attempt, 'raw.txt'), 'raw');
+  await writeFixture(
+    join(source, 'results.json'),
+    `${JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              file: 'markdown.spec.ts',
+              title: 'markdown attachment names',
+              tests: [
+                {
+                  projectName: 'Webkit',
+                  results: [
+                    {
+                      retry: 0,
+                      status: 'failed',
+                      attachments: [
+                        {
+                          name: 'bad | name\nwith control\u0000 and Łódź',
+                          contentType: 'text/plain',
+                          path: join(attempt, 'raw.txt'),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })}\n`
+  );
+
+  await collectFailureEvidence({
+    resultsPath: join(source, 'results.json'),
+    sourceDir: source,
+    outDir: out,
+    project: 'Webkit',
+    shard: '1',
+    totalShards: '2',
+    artifactName: 'failure-evidence-webkit-1',
+    generatedAt: '2026-07-05T12:00:00.000Z',
+  });
+
+  const index = await readFile(join(out, 'index.md'), 'utf8');
+  assert.match(index, /bad-name-with-control-and-d.txt/);
+  assert.doesNotMatch(index, /bad \| name/);
+  assert.doesNotMatch(index, /\u0000/);
+});
+
+test('CLI uses default paths and rejects invalid arguments', async () => {
+  const root = await makeTempDir();
+  await writeFixture(join(root, 'test-results', 'results.json'), '{"suites":[]}\n');
+  const script = fileURLToPath(new URL('collect-failure-evidence.ts', import.meta.url));
+
+  const ok = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', '--disable-warning=ExperimentalWarning', script],
+    { cwd: root, encoding: 'utf8' }
+  );
+  assert.equal(ok.status, 0, ok.stderr);
+  assert.match(await readFile(join(root, 'failure-evidence', 'index.md'), 'utf8'), /No results/);
+
+  const missingValue = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', '--disable-warning=ExperimentalWarning', script, '--results'],
+    { cwd: root, encoding: 'utf8' }
+  );
+  assert.notEqual(missingValue.status, 0);
+  assert.match(missingValue.stderr, /Missing value|expects an argument|argument missing/);
+});

--- a/playwright/typescript/scripts/collect-failure-evidence.ts
+++ b/playwright/typescript/scripts/collect-failure-evidence.ts
@@ -1,0 +1,574 @@
+import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, extname, isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs as parseNodeArgs } from 'node:util';
+
+type RawAttachment = {
+  name?: unknown;
+  contentType?: unknown;
+  path?: unknown;
+};
+
+type RawResult = {
+  retry?: unknown;
+  status?: unknown;
+  duration?: unknown;
+  error?: { message?: unknown };
+  errors?: { message?: unknown }[];
+  attachments?: RawAttachment[];
+};
+
+type RawTest = {
+  projectName?: unknown;
+  results?: RawResult[];
+};
+
+type RawSpec = {
+  file?: unknown;
+  line?: unknown;
+  title?: unknown;
+  tests?: RawTest[];
+};
+
+type RawSuite = {
+  suites?: RawSuite[];
+  specs?: RawSpec[];
+};
+
+type RawResults = {
+  suites?: RawSuite[];
+};
+
+export type EvidenceAttachment = {
+  name: string;
+  contentType: string | null;
+  outputPath: string;
+  copied: boolean;
+  warning?: string;
+};
+
+export type EvidenceFailure = {
+  attemptId: string;
+  specFile: string;
+  line: number | null;
+  title: string;
+  projectName: string;
+  retry: number;
+  status: string;
+  duration: number | null;
+  error: string | null;
+  attachments: EvidenceAttachment[];
+};
+
+export type EvidenceManifest = {
+  generatedAt: string;
+  artifactName: string;
+  runId: string | null;
+  project: string;
+  shard: string;
+  totalShards: string;
+  resultsPath: string | null;
+  failures: EvidenceFailure[];
+  warnings: string[];
+};
+
+export type CollectFailureEvidenceOptions = {
+  resultsPath: string;
+  sourceDir: string;
+  outDir: string;
+  project: string;
+  shard: string;
+  totalShards: string;
+  artifactName?: string;
+  runId?: string | null;
+  generatedAt?: string;
+};
+
+type InternalAttachment = EvidenceAttachment & {
+  sourcePath: string | null;
+};
+
+type InternalFailure = Omit<EvidenceFailure, 'attachments'> & {
+  attachments: InternalAttachment[];
+};
+
+type CopyAttachmentContext = {
+  projectRoot: string;
+  sourceRoot: string;
+  outRoot: string;
+  attachment: InternalAttachment;
+};
+
+const FAILED_STATUSES = ['failed', 'timedOut', 'interrupted'] as const;
+const FAILED_STATUS_SET = new Set<string>(FAILED_STATUSES);
+
+function asString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
+}
+
+function stripControls(value: string): string {
+  return stripAnsi(value).replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
+}
+
+function cleanText(value: string): string {
+  return stripControls(value).replace(/\r\n?/g, '\n').trim();
+}
+
+function markdownCell(value: string | number | null): string {
+  return cleanText(String(value ?? ''))
+    .replace(/\n+/g, '<br>')
+    .replace(/\|/g, '\\|');
+}
+
+function sanitizePathComponent(value: string, fallback: string): string {
+  const safe = cleanText(value)
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter(Boolean)
+    .join('-')
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return safe.length > 0 ? safe : fallback;
+}
+
+function extensionFor(contentType: string | null): string {
+  switch (contentType) {
+    case 'image/png':
+      return '.png';
+    case 'video/webm':
+      return '.webm';
+    case 'application/zip':
+      return '.zip';
+    case 'text/html':
+      return '.html';
+    case 'text/markdown':
+      return '.md';
+    case 'text/plain':
+      return '.txt';
+    default:
+      return '.txt';
+  }
+}
+
+function attachmentFileName(attachment: InternalAttachment): string {
+  const name = sanitizePathComponent(attachment.name, 'attachment');
+  const sourcePath = attachment.sourcePath ?? '';
+  const sourceExt = extname(sourcePath);
+  const ext = sourceExt.length > 0 ? sourceExt : extensionFor(attachment.contentType);
+  return ext.length > 0 && name.toLowerCase().endsWith(ext.toLowerCase()) ? name : `${name}${ext}`;
+}
+
+function uniqueFileName(fileName: string, usedFileNames: Set<string>): string {
+  if (!usedFileNames.has(fileName)) {
+    usedFileNames.add(fileName);
+    return fileName;
+  }
+
+  const ext = extname(fileName);
+  const base = ext.length > 0 ? fileName.slice(0, -ext.length) : fileName;
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${base}-${suffix}${ext}`;
+    if (!usedFileNames.has(candidate)) {
+      usedFileNames.add(candidate);
+      return candidate;
+    }
+  }
+}
+
+function isInside(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel.length > 0 && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+function attachmentSourcePath(sourceRoot: string, attachment: InternalAttachment): string | null {
+  if (attachment.sourcePath === null || attachment.sourcePath.length === 0) return null;
+  return resolve(
+    isAbsolute(attachment.sourcePath)
+      ? attachment.sourcePath
+      : join(sourceRoot, attachment.sourcePath)
+  );
+}
+
+function isVisualSnapshotAttachment(
+  projectRoot: string,
+  sourcePath: string,
+  attachment: InternalAttachment
+): boolean {
+  if (attachment.contentType !== 'image/png') return false;
+
+  const testsRoot = join(projectRoot, 'tests');
+  const rel = relative(testsRoot, sourcePath);
+  if (rel.length === 0 || rel.startsWith('..') || isAbsolute(rel)) return false;
+
+  return rel.split(/[\\/]/).some((part) => part.endsWith('-snapshots'));
+}
+
+function isAllowedAttachmentSource(
+  projectRoot: string,
+  sourceRoot: string,
+  sourcePath: string,
+  attachment: InternalAttachment
+): boolean {
+  return (
+    isInside(sourceRoot, sourcePath) ||
+    isVisualSnapshotAttachment(projectRoot, sourcePath, attachment)
+  );
+}
+
+function errorMessage(result: RawResult): string | null {
+  if (typeof result.error?.message === 'string') return cleanText(result.error.message);
+  const firstError = Array.isArray(result.errors) ? result.errors[0] : undefined;
+  return typeof firstError?.message === 'string' ? cleanText(firstError.message) : null;
+}
+
+function attemptId(index: number, retry: number): string {
+  return `F${String(index + 1).padStart(3, '0')}-R${retry}`;
+}
+
+function publicFailure(failure: InternalFailure): EvidenceFailure {
+  return {
+    ...failure,
+    attachments: failure.attachments.map((attachment) => ({
+      name: attachment.name,
+      contentType: attachment.contentType,
+      outputPath: attachment.outputPath,
+      copied: attachment.copied,
+      ...(attachment.warning === undefined ? {} : { warning: attachment.warning }),
+    })),
+  };
+}
+
+function collectFailures(results: RawResults): InternalFailure[] {
+  const failures: InternalFailure[] = [];
+
+  function visitSuite(suite: RawSuite): void {
+    for (const nested of Array.isArray(suite.suites) ? suite.suites : []) {
+      visitSuite(nested);
+    }
+
+    for (const spec of Array.isArray(suite.specs) ? suite.specs : []) {
+      const specFile = cleanText(asString(spec.file, 'unknown.spec.ts'));
+      const title = cleanText(asString(spec.title, 'untitled test'));
+      const line = asNumber(spec.line);
+
+      for (const test of Array.isArray(spec.tests) ? spec.tests : []) {
+        const projectName = cleanText(asString(test.projectName, 'unknown-project'));
+        for (const result of Array.isArray(test.results) ? test.results : []) {
+          const status = cleanText(asString(result.status, 'unknown'));
+          if (!FAILED_STATUS_SET.has(status)) continue;
+
+          const retry = asNumber(result.retry) ?? 0;
+          failures.push({
+            attemptId: attemptId(failures.length, retry),
+            specFile,
+            line,
+            title,
+            projectName,
+            retry,
+            status,
+            duration: asNumber(result.duration),
+            error: errorMessage(result),
+            attachments: (Array.isArray(result.attachments) ? result.attachments : []).map(
+              (attachment) => ({
+                name: cleanText(asString(attachment.name, 'attachment')),
+                contentType:
+                  typeof attachment.contentType === 'string'
+                    ? cleanText(attachment.contentType)
+                    : null,
+                sourcePath: typeof attachment.path === 'string' ? attachment.path : null,
+                outputPath: '',
+                copied: false,
+              })
+            ),
+          });
+        }
+      }
+    }
+  }
+
+  for (const suite of Array.isArray(results.suites) ? results.suites : []) {
+    visitSuite(suite);
+  }
+
+  return failures;
+}
+
+async function copyAttachment({
+  projectRoot,
+  sourceRoot,
+  outRoot,
+  attachment,
+}: CopyAttachmentContext): Promise<void> {
+  const sourcePath = attachmentSourcePath(sourceRoot, attachment);
+  if (sourcePath === null) {
+    attachment.warning = 'attachment has no path';
+    return;
+  }
+  if (!isAllowedAttachmentSource(projectRoot, sourceRoot, sourcePath, attachment)) {
+    attachment.warning = 'attachment path is outside source directory';
+    return;
+  }
+
+  const destination = join(outRoot, attachment.outputPath);
+  await mkdir(dirname(destination), { recursive: true });
+  try {
+    await copyFile(sourcePath, destination);
+    attachment.copied = true;
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) {
+      attachment.warning = 'attachment file is missing';
+      return;
+    }
+    throw error;
+  }
+}
+
+async function cleanOutput(outDir: string): Promise<void> {
+  await mkdir(outDir, { recursive: true });
+  await Promise.all([
+    rm(join(outDir, 'failures'), { recursive: true, force: true }),
+    rm(join(outDir, 'index.md'), { force: true }),
+    rm(join(outDir, 'manifest.json'), { force: true }),
+    rm(join(outDir, 'results.json'), { force: true }),
+  ]);
+}
+
+function testLocation(failure: EvidenceFailure): string {
+  return failure.line === null ? failure.specFile : `${failure.specFile}:${failure.line}`;
+}
+
+function attachmentDisplayName(attachment: EvidenceAttachment): string {
+  return (
+    attachment.outputPath.split('/').pop() ?? sanitizePathComponent(attachment.name, 'attachment')
+  );
+}
+
+function artifactDownloadCommand(manifest: EvidenceManifest): string | null {
+  return manifest.runId === null
+    ? null
+    : `gh run download ${manifest.runId} --name ${manifest.artifactName}`;
+}
+
+function renderIndex(manifest: EvidenceManifest): string {
+  const lines = [
+    '# Playwright Failure Evidence',
+    '',
+    '| Field | Value |',
+    '| --- | --- |',
+    `| Run | ${markdownCell(manifest.runId ?? 'unknown')} |`,
+    `| Artifact | ${markdownCell(manifest.artifactName)} |`,
+    `| Download command | ${markdownCell(artifactDownloadCommand(manifest) ?? 'not available')} |`,
+    `| Project | ${markdownCell(manifest.project)} |`,
+    `| Shard | ${markdownCell(`${manifest.shard}/${manifest.totalShards}`)} |`,
+    `| Generated | ${markdownCell(manifest.generatedAt)} |`,
+    `| Results | ${markdownCell(manifest.resultsPath ?? 'not produced')} |`,
+    '',
+  ];
+
+  if (manifest.warnings.length > 0) {
+    lines.push('## Warnings', '');
+    for (const warning of manifest.warnings) lines.push(`- ${markdownCell(warning)}`);
+    lines.push('');
+  }
+
+  if (manifest.failures.length === 0) {
+    lines.push('No results contained failed Playwright attempts.');
+    return `${lines.join('\n')}\n`;
+  }
+
+  for (const failure of manifest.failures) {
+    const duration = failure.duration === null ? 'unknown' : `${failure.duration}ms`;
+    lines.push(`## Error ${markdownCell(failure.attemptId)}`, '');
+    lines.push('| Field | Value |');
+    lines.push('| --- | --- |');
+    lines.push(`| Test | ${markdownCell(`${testLocation(failure)} - ${failure.title}`)} |`);
+    lines.push(`| Project | ${markdownCell(failure.projectName)} |`);
+    lines.push(`| Status | ${markdownCell(failure.status)} |`);
+    lines.push(`| Retry | ${markdownCell(failure.retry)} |`);
+    lines.push(`| Duration | ${markdownCell(duration)} |`);
+    lines.push(`| Artifact to download | ${markdownCell(manifest.artifactName)} |`);
+    lines.push(`| Error message | ${markdownCell(failure.error ?? 'not reported')} |`);
+    lines.push('');
+
+    if (failure.attachments.length === 0) {
+      lines.push(`No attachments were listed for Error ${failure.attemptId}.`, '');
+      continue;
+    }
+
+    lines.push(`### Attachments for Error ${markdownCell(failure.attemptId)}`, '');
+    lines.push('| Error ID | Attachment | Download artifact | Path inside artifact | Note |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const attachment of failure.attachments) {
+      lines.push(
+        `| ${markdownCell(failure.attemptId)} | ${markdownCell(attachmentDisplayName(attachment))} | ${markdownCell(
+          manifest.artifactName
+        )} | ${markdownCell(attachment.outputPath)} | ${markdownCell(attachment.warning ?? '')} |`
+      );
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function defaultArtifactName(project: string, shard: string): string {
+  return `failure-evidence-${sanitizePathComponent(project.toLowerCase(), 'unknown-project')}-${sanitizePathComponent(
+    shard,
+    '1'
+  )}`;
+}
+
+function createEmptyManifest(options: CollectFailureEvidenceOptions): EvidenceManifest {
+  const artifactName = options.artifactName ?? defaultArtifactName(options.project, options.shard);
+  return {
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    artifactName,
+    runId: options.runId === undefined ? (process.env.GITHUB_RUN_ID ?? null) : options.runId,
+    project: options.project,
+    shard: options.shard,
+    totalShards: options.totalShards,
+    resultsPath: null,
+    failures: [],
+    warnings: [],
+  };
+}
+
+async function writeManifest(outRoot: string, manifest: EvidenceManifest): Promise<void> {
+  await writeFile(join(outRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeFile(join(outRoot, 'index.md'), renderIndex(manifest));
+}
+
+export async function collectFailureEvidence(
+  options: CollectFailureEvidenceOptions
+): Promise<EvidenceManifest> {
+  const sourceRoot = resolve(options.sourceDir);
+  const projectRoot = dirname(sourceRoot);
+  const outRoot = resolve(options.outDir);
+  const resultsPath = resolve(options.resultsPath);
+
+  await cleanOutput(outRoot);
+
+  const manifest = createEmptyManifest(options);
+
+  let raw: string;
+  try {
+    raw = await readFile(resultsPath, 'utf8');
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) {
+      manifest.warnings.push('No results file was produced.');
+      await writeManifest(outRoot, manifest);
+      return manifest;
+    }
+    throw error;
+  }
+
+  manifest.resultsPath = 'results.json';
+  await writeFile(join(outRoot, 'results.json'), raw);
+
+  let parsed: RawResults;
+  try {
+    parsed = JSON.parse(raw) as RawResults;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    manifest.warnings.push(`Could not parse results.json: ${cleanText(message)}`);
+    await writeManifest(outRoot, manifest);
+    return manifest;
+  }
+
+  const failures = collectFailures(parsed);
+  await Promise.all(
+    failures.map(async (failure) => {
+      const usedFileNames = new Set<string>();
+      for (const attachment of failure.attachments) {
+        attachment.outputPath = join(
+          'failures',
+          failure.attemptId,
+          uniqueFileName(attachmentFileName(attachment), usedFileNames)
+        );
+      }
+      await Promise.all(
+        failure.attachments.map((attachment) =>
+          copyAttachment({
+            projectRoot,
+            sourceRoot,
+            outRoot,
+            attachment,
+          })
+        )
+      );
+    })
+  );
+
+  manifest.failures = failures.map(publicFailure);
+  await writeManifest(outRoot, manifest);
+  return manifest;
+}
+
+function parseArgs(argv: string[]): CollectFailureEvidenceOptions {
+  const { values } = parseNodeArgs({
+    args: argv,
+    allowPositionals: false,
+    options: {
+      results: { type: 'string' },
+      source: { type: 'string' },
+      out: { type: 'string' },
+      project: { type: 'string' },
+      shard: { type: 'string' },
+      'total-shards': { type: 'string' },
+      'artifact-name': { type: 'string' },
+      'run-id': { type: 'string' },
+    },
+  });
+
+  const project = values.project ?? 'unknown-project';
+  const shard = values.shard ?? '1';
+
+  return {
+    resultsPath: values.results ?? 'test-results/results.json',
+    sourceDir: values.source ?? 'test-results',
+    outDir: values.out ?? 'failure-evidence',
+    project,
+    shard,
+    totalShards: values['total-shards'] ?? '1',
+    artifactName: values['artifact-name'] ?? defaultArtifactName(project, shard),
+    runId: values['run-id'] ?? process.env.GITHUB_RUN_ID ?? null,
+  };
+}
+
+async function main(): Promise<number> {
+  const options = parseArgs(process.argv.slice(2));
+  await collectFailureEvidence(options);
+  return 0;
+}
+
+const isMain =
+  typeof process !== 'undefined' &&
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err: unknown) => {
+      console.error(err instanceof Error ? err.message : err);
+      process.exit(1);
+    });
+}

--- a/playwright/typescript/scripts/collect-failure-evidence.ts
+++ b/playwright/typescript/scripts/collect-failure-evidence.ts
@@ -1,43 +1,13 @@
-import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { dirname, extname, isAbsolute, join, relative, resolve } from 'node:path';
+import { copyFile, lstat, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseArgs as parseNodeArgs } from 'node:util';
+import { parseArgs as parseNodeArgs, stripVTControlCharacters } from 'node:util';
+import { redactSensitive } from '../utils/diagnosis.util.ts';
 
-type RawAttachment = {
-  name?: unknown;
-  contentType?: unknown;
-  path?: unknown;
-};
-
-type RawResult = {
-  retry?: unknown;
-  status?: unknown;
-  duration?: unknown;
-  error?: { message?: unknown };
-  errors?: { message?: unknown }[];
-  attachments?: RawAttachment[];
-};
-
-type RawTest = {
-  projectName?: unknown;
-  results?: RawResult[];
-};
-
-type RawSpec = {
-  file?: unknown;
-  line?: unknown;
-  title?: unknown;
-  tests?: RawTest[];
-};
-
-type RawSuite = {
-  suites?: RawSuite[];
-  specs?: RawSpec[];
-};
-
-type RawResults = {
-  suites?: RawSuite[];
-};
+type JsonRecord = Record<string, unknown>;
+type RawResult = JsonRecord;
+type RawSuite = JsonRecord;
+type RawResults = JsonRecord;
 
 export type EvidenceAttachment = {
   name: string;
@@ -54,7 +24,7 @@ export type EvidenceFailure = {
   title: string;
   projectName: string;
   retry: number;
-  status: string;
+  status: FailedStatus;
   duration: number | null;
   error: string | null;
   attachments: EvidenceAttachment[];
@@ -82,6 +52,9 @@ export type CollectFailureEvidenceOptions = {
   artifactName?: string;
   runId?: string | null;
   generatedAt?: string;
+  withholdSensitiveDetails?: boolean;
+  withholdBinaryAttachments?: boolean;
+  redactEnvNames?: string[];
 };
 
 type InternalAttachment = EvidenceAttachment & {
@@ -97,10 +70,18 @@ type CopyAttachmentContext = {
   sourceRoot: string;
   outRoot: string;
   attachment: InternalAttachment;
+  withholdSensitiveDetails: boolean;
+  withholdBinaryAttachments: boolean;
+  redactor: EvidenceRedactor;
 };
 
+type EvidenceRedactor = (value: string) => string;
+
 const FAILED_STATUSES = ['failed', 'timedOut', 'interrupted'] as const;
+type FailedStatus = (typeof FAILED_STATUSES)[number];
+
 const FAILED_STATUS_SET = new Set<string>(FAILED_STATUSES);
+const MIN_CONFIGURED_SECRET_LENGTH = 3;
 
 function asString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.length > 0 ? value : fallback;
@@ -119,16 +100,72 @@ function hasErrorCode(error: unknown, code: string): boolean {
   );
 }
 
-function stripAnsi(value: string): string {
-  return value.replace(/\u001b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function recordArray(record: JsonRecord, key: string): JsonRecord[] {
+  const value = record[key];
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function isFailedStatus(value: string): value is FailedStatus {
+  return FAILED_STATUS_SET.has(value);
+}
+
+function redactConfiguredSecretValues(value: string, secretValues: readonly string[]): string {
+  let redacted = value;
+  for (const secretValue of secretValues) {
+    redacted = redacted.replaceAll(secretValue, '[REDACTED]');
+  }
+  return redacted;
+}
+
+function configuredSecretValues(envNames: readonly string[]): string[] {
+  return Array.from(
+    new Set(
+      envNames
+        .map((name) => process.env[name])
+        .filter(
+          (value): value is string =>
+            value !== undefined && value.length >= MIN_CONFIGURED_SECRET_LENGTH
+        )
+    )
+  ).sort((left, right) => right.length - left.length);
+}
+
+function createRedactor(envNames: readonly string[] = []): EvidenceRedactor {
+  const secretValues = configuredSecretValues(envNames);
+  return (value) => redactSensitive(redactConfiguredSecretValues(value, secretValues));
+}
+
+function redactEvidenceText(value: string, redactor: EvidenceRedactor): string {
+  return redactor(value);
+}
+
+function redactJsonValue(value: unknown, redactor: EvidenceRedactor): unknown {
+  if (typeof value === 'string') return redactEvidenceText(value, redactor);
+  if (Array.isArray(value)) return value.map((nested) => redactJsonValue(nested, redactor));
+  if (!isRecord(value)) return value;
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [key, redactJsonValue(nested, redactor)])
+  );
 }
 
 function stripControls(value: string): string {
-  return stripAnsi(value).replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
+  return stripVTControlCharacters(value).replace(
+    /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g,
+    ''
+  );
 }
 
 function cleanText(value: string): string {
   return stripControls(value).replace(/\r\n?/g, '\n').trim();
+}
+
+function cleanPublicText(value: string, redactor: EvidenceRedactor): string {
+  return cleanText(redactEvidenceText(value, redactor));
 }
 
 function markdownCell(value: string | number | null): string {
@@ -176,6 +213,10 @@ function attachmentFileName(attachment: InternalAttachment): string {
   return ext.length > 0 && name.toLowerCase().endsWith(ext.toLowerCase()) ? name : `${name}${ext}`;
 }
 
+function withheldAttachmentFileName(index: number, attachment: InternalAttachment): string {
+  return `attachment-${String(index + 1).padStart(2, '0')}${extensionFor(attachment.contentType)}`;
+}
+
 function uniqueFileName(fileName: string, usedFileNames: Set<string>): string {
   if (!usedFileNames.has(fileName)) {
     usedFileNames.add(fileName);
@@ -215,8 +256,8 @@ function isVisualSnapshotAttachment(
   if (attachment.contentType !== 'image/png') return false;
 
   const testsRoot = join(projectRoot, 'tests');
+  if (!isInside(testsRoot, sourcePath)) return false;
   const rel = relative(testsRoot, sourcePath);
-  if (rel.length === 0 || rel.startsWith('..') || isAbsolute(rel)) return false;
 
   return rel.split(/[\\/]/).some((part) => part.endsWith('-snapshots'));
 }
@@ -233,17 +274,59 @@ function isAllowedAttachmentSource(
   );
 }
 
-function errorMessage(result: RawResult): string | null {
-  if (typeof result.error?.message === 'string') return cleanText(result.error.message);
-  const firstError = Array.isArray(result.errors) ? result.errors[0] : undefined;
-  return typeof firstError?.message === 'string' ? cleanText(firstError.message) : null;
+function isTextAttachment(sourcePath: string, attachment: InternalAttachment): boolean {
+  const contentType = attachment.contentType?.toLowerCase().split(';', 1)[0].trim() ?? '';
+  if (
+    contentType.startsWith('text/') ||
+    ['application/json', 'application/xml', 'application/xhtml+xml'].includes(contentType) ||
+    contentType.endsWith('+json') ||
+    contentType.endsWith('+xml')
+  ) {
+    return true;
+  }
+  return ['.html', '.xhtml', '.xml', '.json', '.log', '.md', '.txt'].includes(
+    extname(sourcePath).toLowerCase()
+  );
+}
+
+function errorMessage(result: RawResult, redactor: EvidenceRedactor): string | null {
+  const error = isRecord(result.error) ? result.error : null;
+  if (typeof error?.message === 'string') return cleanPublicText(error.message, redactor);
+  const firstError = recordArray(result, 'errors')[0];
+  return typeof firstError?.message === 'string'
+    ? cleanPublicText(firstError.message, redactor)
+    : null;
 }
 
 function attemptId(index: number, retry: number): string {
   return `F${String(index + 1).padStart(3, '0')}-R${retry}`;
 }
 
-function publicFailure(failure: InternalFailure): EvidenceFailure {
+function publicFailure(
+  failure: InternalFailure,
+  options: { withholdSensitiveDetails: boolean }
+): EvidenceFailure {
+  if (options.withholdSensitiveDetails) {
+    return {
+      attemptId: failure.attemptId,
+      specFile: 'withheld',
+      line: null,
+      title: `Withheld failure ${failure.attemptId}`,
+      projectName: 'withheld',
+      retry: failure.retry,
+      status: failure.status,
+      duration: null,
+      error: null,
+      attachments: failure.attachments.map((attachment, index) => ({
+        name: `Attachment ${index + 1}`,
+        contentType: null,
+        outputPath: attachment.outputPath,
+        copied: false,
+        ...(attachment.warning === undefined ? {} : { warning: attachment.warning }),
+      })),
+    };
+  }
+
   return {
     ...failure,
     attachments: failure.attachments.map((attachment) => ({
@@ -256,24 +339,30 @@ function publicFailure(failure: InternalFailure): EvidenceFailure {
   };
 }
 
-function collectFailures(results: RawResults): InternalFailure[] {
+function collectFailures(
+  results: RawResults,
+  options: { includeErrorMessages: boolean; redactor: EvidenceRedactor }
+): InternalFailure[] {
   const failures: InternalFailure[] = [];
 
   function visitSuite(suite: RawSuite): void {
-    for (const nested of Array.isArray(suite.suites) ? suite.suites : []) {
+    for (const nested of recordArray(suite, 'suites')) {
       visitSuite(nested);
     }
 
-    for (const spec of Array.isArray(suite.specs) ? suite.specs : []) {
-      const specFile = cleanText(asString(spec.file, 'unknown.spec.ts'));
-      const title = cleanText(asString(spec.title, 'untitled test'));
+    for (const spec of recordArray(suite, 'specs')) {
+      const specFile = cleanPublicText(asString(spec.file, 'unknown.spec.ts'), options.redactor);
+      const title = cleanPublicText(asString(spec.title, 'untitled test'), options.redactor);
       const line = asNumber(spec.line);
 
-      for (const test of Array.isArray(spec.tests) ? spec.tests : []) {
-        const projectName = cleanText(asString(test.projectName, 'unknown-project'));
-        for (const result of Array.isArray(test.results) ? test.results : []) {
-          const status = cleanText(asString(result.status, 'unknown'));
-          if (!FAILED_STATUS_SET.has(status)) continue;
+      for (const test of recordArray(spec, 'tests')) {
+        const projectName = cleanPublicText(
+          asString(test.projectName, 'unknown-project'),
+          options.redactor
+        );
+        for (const result of recordArray(test, 'results')) {
+          const status = cleanPublicText(asString(result.status, 'unknown'), options.redactor);
+          if (!isFailedStatus(status)) continue;
 
           const retry = asNumber(result.retry) ?? 0;
           failures.push({
@@ -285,30 +374,38 @@ function collectFailures(results: RawResults): InternalFailure[] {
             retry,
             status,
             duration: asNumber(result.duration),
-            error: errorMessage(result),
-            attachments: (Array.isArray(result.attachments) ? result.attachments : []).map(
-              (attachment) => ({
-                name: cleanText(asString(attachment.name, 'attachment')),
-                contentType:
-                  typeof attachment.contentType === 'string'
-                    ? cleanText(attachment.contentType)
-                    : null,
-                sourcePath: typeof attachment.path === 'string' ? attachment.path : null,
-                outputPath: '',
-                copied: false,
-              })
-            ),
+            error: options.includeErrorMessages ? errorMessage(result, options.redactor) : null,
+            attachments: recordArray(result, 'attachments').map((attachment) => ({
+              name: cleanPublicText(asString(attachment.name, 'attachment'), options.redactor),
+              contentType:
+                typeof attachment.contentType === 'string'
+                  ? cleanText(attachment.contentType)
+                  : null,
+              sourcePath: typeof attachment.path === 'string' ? attachment.path : null,
+              outputPath: '',
+              copied: false,
+            })),
           });
         }
       }
     }
   }
 
-  for (const suite of Array.isArray(results.suites) ? results.suites : []) {
+  for (const suite of recordArray(results, 'suites')) {
     visitSuite(suite);
   }
 
   return failures;
+}
+
+function topLevelErrorWarnings(results: RawResults, redactor: EvidenceRedactor): string[] {
+  return recordArray(results, 'errors').map(
+    (error) =>
+      `Playwright reported top-level error: ${cleanPublicText(
+        asString(error.message, 'unknown error'),
+        redactor
+      )}`
+  );
 }
 
 async function copyAttachment({
@@ -316,21 +413,51 @@ async function copyAttachment({
   sourceRoot,
   outRoot,
   attachment,
+  withholdSensitiveDetails,
+  withholdBinaryAttachments,
+  redactor,
 }: CopyAttachmentContext): Promise<void> {
   const sourcePath = attachmentSourcePath(sourceRoot, attachment);
   if (sourcePath === null) {
     attachment.warning = 'attachment has no path';
     return;
   }
-  if (!isAllowedAttachmentSource(projectRoot, sourceRoot, sourcePath, attachment)) {
+
+  if (withholdSensitiveDetails) {
+    attachment.warning = 'attachment body withheld';
+    return;
+  }
+  if (withholdBinaryAttachments && !isTextAttachment(sourcePath, attachment)) {
+    attachment.warning = 'binary attachment body withheld';
+    return;
+  }
+
+  let canonicalSourcePath: string;
+  try {
+    canonicalSourcePath = await realpath(sourcePath);
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) {
+      attachment.warning = 'attachment file is missing';
+      return;
+    }
+    throw error;
+  }
+
+  if (!isAllowedAttachmentSource(projectRoot, sourceRoot, canonicalSourcePath, attachment)) {
     attachment.warning = 'attachment path is outside source directory';
     return;
   }
 
   const destination = join(outRoot, attachment.outputPath);
-  await mkdir(dirname(destination), { recursive: true });
   try {
-    await copyFile(sourcePath, destination);
+    if (isTextAttachment(canonicalSourcePath, attachment)) {
+      await writeFile(
+        destination,
+        redactEvidenceText(await readFile(canonicalSourcePath, 'utf8'), redactor)
+      );
+    } else {
+      await copyFile(canonicalSourcePath, destination);
+    }
     attachment.copied = true;
   } catch (error) {
     if (hasErrorCode(error, 'ENOENT')) {
@@ -342,13 +469,19 @@ async function copyAttachment({
 }
 
 async function cleanOutput(outDir: string): Promise<void> {
+  try {
+    const outStat = await lstat(outDir);
+    if (outStat.isSymbolicLink()) {
+      throw Object.assign(new Error(`Output directory must not be a symlink: ${outDir}`), {
+        code: 'ELOOP',
+      });
+    }
+  } catch (error) {
+    if (!hasErrorCode(error, 'ENOENT')) throw error;
+  }
+
+  await rm(outDir, { recursive: true, force: true });
   await mkdir(outDir, { recursive: true });
-  await Promise.all([
-    rm(join(outDir, 'failures'), { recursive: true, force: true }),
-    rm(join(outDir, 'index.md'), { force: true }),
-    rm(join(outDir, 'manifest.json'), { force: true }),
-    rm(join(outDir, 'results.json'), { force: true }),
-  ]);
 }
 
 function testLocation(failure: EvidenceFailure): string {
@@ -356,9 +489,7 @@ function testLocation(failure: EvidenceFailure): string {
 }
 
 function attachmentDisplayName(attachment: EvidenceAttachment): string {
-  return (
-    attachment.outputPath.split('/').pop() ?? sanitizePathComponent(attachment.name, 'attachment')
-  );
+  return basename(attachment.outputPath) || sanitizePathComponent(attachment.name, 'attachment');
 }
 
 function artifactDownloadCommand(manifest: EvidenceManifest): string | null {
@@ -436,6 +567,10 @@ function defaultArtifactName(project: string, shard: string): string {
   )}`;
 }
 
+function authSetupWithheldWarning(): string {
+  return 'Raw Playwright results and error messages were withheld to avoid exposing sensitive account values.';
+}
+
 function createEmptyManifest(options: CollectFailureEvidenceOptions): EvidenceManifest {
   const artifactName = options.artifactName ?? defaultArtifactName(options.project, options.shard);
   return {
@@ -452,8 +587,19 @@ function createEmptyManifest(options: CollectFailureEvidenceOptions): EvidenceMa
 }
 
 async function writeManifest(outRoot: string, manifest: EvidenceManifest): Promise<void> {
-  await writeFile(join(outRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
-  await writeFile(join(outRoot, 'index.md'), renderIndex(manifest));
+  await Promise.all([
+    writeFile(join(outRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`),
+    writeFile(join(outRoot, 'index.md'), renderIndex(manifest)),
+  ]);
+}
+
+async function writeMissingResultsManifest(
+  outRoot: string,
+  manifest: EvidenceManifest
+): Promise<EvidenceManifest> {
+  manifest.warnings.push('No results file was produced.');
+  await writeManifest(outRoot, manifest);
+  return manifest;
 }
 
 export async function collectFailureEvidence(
@@ -463,61 +609,128 @@ export async function collectFailureEvidence(
   const projectRoot = dirname(sourceRoot);
   const outRoot = resolve(options.outDir);
   const resultsPath = resolve(options.resultsPath);
+  const redactor = createRedactor(options.redactEnvNames);
 
   await cleanOutput(outRoot);
 
   const manifest = createEmptyManifest(options);
 
   let raw: string;
+  let canonicalProjectRoot: string;
+  let canonicalSourceRoot: string;
+  let canonicalResultsPath: string;
   try {
-    raw = await readFile(resultsPath, 'utf8');
+    [canonicalProjectRoot, canonicalSourceRoot, canonicalResultsPath] = await Promise.all([
+      realpath(projectRoot),
+      realpath(sourceRoot),
+      realpath(resultsPath),
+    ]);
   } catch (error) {
     if (hasErrorCode(error, 'ENOENT')) {
-      manifest.warnings.push('No results file was produced.');
-      await writeManifest(outRoot, manifest);
-      return manifest;
+      return writeMissingResultsManifest(outRoot, manifest);
     }
     throw error;
   }
 
-  manifest.resultsPath = 'results.json';
-  await writeFile(join(outRoot, 'results.json'), raw);
-
-  let parsed: RawResults;
-  try {
-    parsed = JSON.parse(raw) as RawResults;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    manifest.warnings.push(`Could not parse results.json: ${cleanText(message)}`);
+  if (!isInside(canonicalSourceRoot, canonicalResultsPath)) {
+    manifest.warnings.push('Results file path is outside source directory.');
     await writeManifest(outRoot, manifest);
     return manifest;
   }
 
-  const failures = collectFailures(parsed);
+  try {
+    raw = await readFile(canonicalResultsPath, 'utf8');
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) {
+      return writeMissingResultsManifest(outRoot, manifest);
+    }
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    if (options.withholdSensitiveDetails === true) {
+      manifest.warnings.push(authSetupWithheldWarning());
+      manifest.warnings.push('Could not parse results.json.');
+    } else {
+      manifest.resultsPath = 'results.json';
+      await writeFile(join(outRoot, 'results.json'), redactEvidenceText(raw, redactor));
+      const message = error instanceof Error ? error.message : String(error);
+      manifest.warnings.push(`Could not parse results.json: ${cleanPublicText(message, redactor)}`);
+    }
+    await writeManifest(outRoot, manifest);
+    return manifest;
+  }
+
+  const withholdSensitiveDetails = options.withholdSensitiveDetails === true;
+  const withholdBinaryAttachments = options.withholdBinaryAttachments === true;
+  if (withholdSensitiveDetails) {
+    manifest.warnings.push(authSetupWithheldWarning());
+  } else {
+    const redactedResults = redactJsonValue(parsed, redactor);
+    manifest.resultsPath = 'results.json';
+    await writeFile(join(outRoot, 'results.json'), `${JSON.stringify(redactedResults, null, 2)}\n`);
+  }
+
+  if (!isRecord(parsed)) {
+    manifest.warnings.push('results.json did not contain a Playwright JSON object.');
+    await writeManifest(outRoot, manifest);
+    return manifest;
+  }
+
+  if (withholdSensitiveDetails) {
+    if (recordArray(parsed, 'errors').length > 0) {
+      manifest.warnings.push(
+        'Playwright reported top-level errors, but their messages were withheld.'
+      );
+    }
+  } else {
+    manifest.warnings.push(...topLevelErrorWarnings(parsed, redactor));
+  }
+
+  const failures = collectFailures(parsed, {
+    includeErrorMessages: !withholdSensitiveDetails,
+    redactor,
+  });
   await Promise.all(
     failures.map(async (failure) => {
       const usedFileNames = new Set<string>();
-      for (const attachment of failure.attachments) {
+      for (const [index, attachment] of failure.attachments.entries()) {
         attachment.outputPath = join(
           'failures',
           failure.attemptId,
-          uniqueFileName(attachmentFileName(attachment), usedFileNames)
+          uniqueFileName(
+            withholdSensitiveDetails
+              ? withheldAttachmentFileName(index, attachment)
+              : attachmentFileName(attachment),
+            usedFileNames
+          )
         );
+      }
+      if (!withholdSensitiveDetails && failure.attachments.length > 0) {
+        await mkdir(join(outRoot, 'failures', failure.attemptId), { recursive: true });
       }
       await Promise.all(
         failure.attachments.map((attachment) =>
           copyAttachment({
-            projectRoot,
-            sourceRoot,
+            projectRoot: canonicalProjectRoot,
+            sourceRoot: canonicalSourceRoot,
             outRoot,
             attachment,
+            withholdSensitiveDetails,
+            withholdBinaryAttachments,
+            redactor,
           })
         )
       );
     })
   );
 
-  manifest.failures = failures.map(publicFailure);
+  manifest.failures = failures.map((failure) =>
+    publicFailure(failure, { withholdSensitiveDetails })
+  );
   await writeManifest(outRoot, manifest);
   return manifest;
 }
@@ -535,6 +748,9 @@ function parseArgs(argv: string[]): CollectFailureEvidenceOptions {
       'total-shards': { type: 'string' },
       'artifact-name': { type: 'string' },
       'run-id': { type: 'string' },
+      'withhold-sensitive-details': { type: 'boolean' },
+      'withhold-binary-attachments': { type: 'boolean' },
+      'redact-env-names': { type: 'string' },
     },
   });
 
@@ -548,9 +764,21 @@ function parseArgs(argv: string[]): CollectFailureEvidenceOptions {
     project,
     shard,
     totalShards: values['total-shards'] ?? '1',
-    artifactName: values['artifact-name'] ?? defaultArtifactName(project, shard),
+    artifactName: values['artifact-name'],
     runId: values['run-id'] ?? process.env.GITHUB_RUN_ID ?? null,
+    withholdSensitiveDetails: values['withhold-sensitive-details'] ?? false,
+    withholdBinaryAttachments: values['withhold-binary-attachments'] ?? false,
+    redactEnvNames: splitList(values['redact-env-names']),
   };
+}
+
+function splitList(value: string | undefined): string[] {
+  return value === undefined
+    ? []
+    : value
+        .split(/[\s,]+/)
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0);
 }
 
 async function main(): Promise<number> {

--- a/playwright/typescript/tsconfig.json
+++ b/playwright/typescript/tsconfig.json
@@ -18,6 +18,7 @@
   },
   "include": [
     "*.ts",
+    "scripts/**/*.ts",
     "tests/**/*.ts",
     "pages/**/*.ts",
     "types/**/*.ts",


### PR DESCRIPTION
## Summary

- Add a shared Playwright failure-evidence action that builds an indexed diagnostic artifact for failed auth setup and shard jobs.
- Make `index.md` the user-facing map: every failed attempt gets an error id like `F002-R0`, every attachment row repeats the artifact name and path inside that artifact, and the header shows the exact `gh run download <run> --name <artifact>` command.
- Harden evidence publishing for secret-bearing CI jobs: auth setup and shard jobs withhold raw `results.json`, error text, and attachment bodies while preserving the failure-to-attachment mapping in the index.
- Keep non-withheld collection safe and readable by redacting sensitive text, stripping terminal control codes, rejecting symlink/path escapes, allowing visual snapshot baselines, and capping the job-summary append.

Closes #625

## Review follow-up

- CodeRabbit collision concern: fixed by using unique attempt directories (`failures/F001-R0/...`) instead of directories derived from spec/title/project/retry; added same-title and duplicate-attachment tests.
- CodeRabbit summary-size concern: fixed in the shared action by truncating `GITHUB_STEP_SUMMARY` at 900000 bytes and pointing to the uploaded artifact for the full index.
- CodeRabbit test-process concern: CLI subprocess tests now use a fixed `spawnSync` timeout.
- Deep-review/user concerns: public manifest/index no longer expose runner-local source paths, ANSI/control characters are stripped from displayed errors, malformed/missing results produce warning indexes, and secret-bearing evidence avoids publishing credential-bearing raw files.

## Test plan

- [x] `npm run test:unit`
- [x] `npm run tsc`
- [x] `npm run format:check`
- [x] `node --test --experimental-strip-types --disable-warning=ExperimentalWarning scripts/collect-failure-evidence.test.ts`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/playwright-run.yml"); YAML.load_file(".github/workflows/playwright-typescript.yml"); YAML.load_file(".github/actions/collect-failure-evidence/action.yml"); puts "workflow yaml parse ok"'`
- [x] `git diff --check HEAD^..HEAD`
- [x] Staged diff secret/pathname scans found no denied filenames or hardcoded secret-shaped additions.
- [x] Visual expected-baseline regression: collector copies `tests/**-snapshots/*.png` attachments and still blocks arbitrary outside paths.
- [x] CodeRabbit inline comments with implemented fixes were replied to in-thread.
- [ ] Latest GitHub Actions run completes; Playwright shard failures already reproduced on `main` are non-blocking for this issue.

## Notes

`act -n` was attempted from a temp workflow copy to avoid the repo `.actrc` reading `.env`. The sandboxed run could not bind/listen, and the host-level dry run reported no Docker connection plus an `act` matrix-expression limitation, so local workflow execution could not be used as merge evidence.

The failed `auth-setup (mobile-chrome)` job from run `28742152377` was produced before this auth-setup artifact upload was added, so its Playwright attachment paths exist only in the runner log and are not downloadable from that completed run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Playwright CI “failure-evidence” bundles with an indexed summary and collected, sanitized failure attachments (including per-shard naming/retention).
  * Added a new automation action to generate and upload failure-evidence artifacts and append the index to the job summary.
* **Documentation**
  * Updated CI/Playwright docs to reflect failure-evidence conventions and when raw reports/self-healing data are withheld or omitted.
* **Bug Fixes**
  * Improved evidence generation for missing/malformed results, safe attachment copying, and consistent redaction/sanitization.
* **Tests**
  * Added comprehensive CLI test coverage for evidence output, redaction modes, and error handling.
* **Chores**
  * Disabled trace/screenshots/videos for Playwright `setup` tests; adjusted auth-state regeneration command and removed the merged HTML report step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->